### PR TITLE
[OSDEV-728] API. Sector values are missing from GET /facilities response. 

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -3,13 +3,11 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). The format is based on the `RELEASE-NOTES-TEMPLATE.md` file.
 
-Use the format below to document information about the new release.
-
 ## Release 1.10.0
 
 ## Introduction
 * Product name: Open Supply Hub
-* Release date: *Provide release date*
+* Release date: March 23, 2024
 
 ### Database changes
 #### Migrations:
@@ -28,10 +26,11 @@ Use the format below to document information about the new release.
 * [OSDEV-716](https://opensupplyhub.atlassian.net/browse/OSDEV-716) Search. Lost refresh icon. The refresh icon has been made visible.
 
 ### What's new
-* *Describe what's new here. The changes that can impact user experience should be listed in this section.*
+* [OSDEV-728](https://opensupplyhub.atlassian.net/browse/OSDEV-728) - Include `sector` data in the response of the `api/facilities/` API endpoint for the GET request, similar to what is provided in the `api/facilities/{id}` API endpoint.
 
 ### Release instructions:
 * *Provide release instructions here.*
+
 
 ## Release 1.9.0
 

--- a/src/django/api/serializers/facility/facility_index_details_serializer.py
+++ b/src/django/api/serializers/facility/facility_index_details_serializer.py
@@ -18,15 +18,9 @@ from .facility_index_serializer import FacilityIndexSerializer
 from .utils import (
     format_numeric,
     can_user_see_detail,
-    get_embed_contributor_id,
-    is_created_at_main_date,
     should_show_pending_claim_info,
     get_contributor_name_from_facilityindexnew,
-    get_contributor_id_from_facilityindexnew,
-    regroup_items_for_sector_field,
-    regroup_claims_for_sector_field,
-    format_date,
-    depromote_unspecified_items,
+    format_date
 )
 
 
@@ -344,78 +338,3 @@ class FacilityIndexDetailsSerializer(FacilityIndexSerializer):
 
     def get_has_inexact_coordinates(self, facility):
         return False
-
-    def get_sector(self, facility):
-        user_can_see_detail = can_user_see_detail(self)
-
-        use_main_created_at = is_created_at_main_date(self)
-        date_field_to_sort = (
-            'created_at' if use_main_created_at else 'updated_at'
-        )
-
-        items = regroup_items_for_sector_field(
-            facility.item_sectors, date_field_to_sort)
-
-        claims = regroup_claims_for_sector_field(
-            facility.claim_sectors, date_field_to_sort
-        )
-
-        contributor_id = get_embed_contributor_id(self)
-        if is_embed_mode_active(self) and contributor_id is not None:
-            contributor_id_int = int(contributor_id)
-            items = list(filter(
-                lambda item: item['contributor']['id'] == contributor_id_int,
-                items
-                ))
-            claims = list(filter(
-                lambda claim: claim['contributor']['id'] == contributor_id_int,
-                claims
-                ))
-
-        item_sectors = [
-            {
-                **({'created_at': format_date(i['created_at'])}
-                    if use_main_created_at else
-                    {}),
-                'updated_at': format_date(i['updated_at']),
-                'contributor_id': get_contributor_id_from_facilityindexnew(
-                    i['contributor'],
-                    (user_can_see_detail
-                     and i['source']['is_active']
-                     and i['source']['is_public']
-                     and i['has_active_complete_match'])),
-                'contributor_name': get_contributor_name_from_facilityindexnew(
-                    i['contributor'],
-                    (user_can_see_detail
-                     and i['source']['is_active']
-                     and i['source']['is_public']
-                     and i['has_active_complete_match'])),
-                'values': i['sector'],
-                'is_from_claim': False
-            }
-            for i in items
-        ]
-
-        claim_sectors = [
-            {
-                **({'created_at': format_date(c['created_at'])}
-                    if use_main_created_at else
-                    {}),
-                'updated_at': format_date(c['updated_at']),
-                'contributor_id': get_contributor_id_from_facilityindexnew(
-                    c['contributor'], user_can_see_detail),
-                'contributor_name': get_contributor_name_from_facilityindexnew(
-                    c['contributor'], user_can_see_detail),
-                'values': c['sector'],
-                'is_from_claim': True
-            }
-            for c in claims
-        ]
-
-        item_sectors = sorted(
-            item_sectors,
-            key=lambda i: i[date_field_to_sort],
-            reverse=True
-        )
-
-        return claim_sectors + depromote_unspecified_items(item_sectors)

--- a/src/django/api/serializers/facility/facility_index_details_serializer.py
+++ b/src/django/api/serializers/facility/facility_index_details_serializer.py
@@ -19,7 +19,7 @@ from .utils import (
     format_numeric,
     can_user_see_detail,
     should_show_pending_claim_info,
-    get_contributor_name_from_facilityindexnew,
+    get_contributor_name_from_facilityindex,
     format_date
 )
 
@@ -171,7 +171,7 @@ class FacilityIndexDetailsSerializer(FacilityIndexSerializer):
         if approved_claim_info:
             claim_info = approved_claim_info
             claim_info['contributor'] = \
-                get_contributor_name_from_facilityindexnew(
+                get_contributor_name_from_facilityindex(
                     claim_info['contributor'],
                     user_can_see_detail)
             return claim_info

--- a/src/django/api/serializers/facility/facility_index_extended_field_list_serializer.py
+++ b/src/django/api/serializers/facility/facility_index_extended_field_list_serializer.py
@@ -1,8 +1,8 @@
 from typing import Union
 
 from .utils import (
-    get_contributor_name_from_facilityindexnew,
-    get_contributor_id_from_facilityindexnew,
+    get_contributor_name_from_facilityindex,
+    get_contributor_id_from_facilityindex,
     format_date
 )
 
@@ -67,7 +67,7 @@ class FacilityIndexExtendedFieldListSerializer:
         embed_mode_active = self.context.get('embed_mode_active')
         if embed_mode_active:
             return None
-        return get_contributor_name_from_facilityindexnew(
+        return get_contributor_name_from_facilityindex(
             extended_field.get('contributor'),
             self._should_display_contributor(extended_field))
 
@@ -75,7 +75,7 @@ class FacilityIndexExtendedFieldListSerializer:
         embed_mode_active = self.context.get('embed_mode_active')
         if embed_mode_active:
             return None
-        return get_contributor_id_from_facilityindexnew(
+        return get_contributor_id_from_facilityindex(
             extended_field.get('contributor'),
             self._should_display_contributor(extended_field)
         )

--- a/src/django/api/serializers/facility/facility_index_serializer.py
+++ b/src/django/api/serializers/facility/facility_index_serializer.py
@@ -300,7 +300,7 @@ class FacilityIndexSerializer(GeoFeatureModelSerializer):
             grouped_data[field_name] = data
 
         return grouped_data
-    
+
     def get_sector(self, facility):
         user_can_see_detail = can_user_see_detail(self)
 

--- a/src/django/api/serializers/facility/facility_index_serializer.py
+++ b/src/django/api/serializers/facility/facility_index_serializer.py
@@ -299,9 +299,6 @@ class FacilityIndexSerializer(GeoFeatureModelSerializer):
 
             grouped_data[field_name] = data
 
-        sectors = self.get_sector(facility)
-        grouped_data["sector"] = sectors
-
         return grouped_data
     
     def get_sector(self, facility):

--- a/src/django/api/serializers/facility/utils.py
+++ b/src/django/api/serializers/facility/utils.py
@@ -450,3 +450,56 @@ def depromote_unspecified_items(items: list):
         k['values'][0] == 'Unspecified' and
         len(k['values']) == 1),
         reverse=False)
+
+def format_sectors(items,
+                   claims,
+                   date_field_to_sort,
+                   use_main_created_at,
+                   user_can_see_detail):
+    item_sectors = [
+        {
+            **({'created_at': format_date(i['created_at'])}
+                if use_main_created_at else
+                {}),
+            'updated_at': format_date(i['updated_at']),
+            'contributor_id': get_contributor_id_from_facilityindexnew(
+                i['contributor'],
+                (user_can_see_detail
+                    and i['source']['is_active']
+                    and i['source']['is_public']
+                    and i['has_active_complete_match'])),
+            'contributor_name': get_contributor_name_from_facilityindexnew(
+                i['contributor'],
+                (user_can_see_detail
+                    and i['source']['is_active']
+                    and i['source']['is_public']
+                    and i['has_active_complete_match'])),
+            'values': i['sector'],
+            'is_from_claim': False
+        }
+        for i in items
+    ]
+
+    claim_sectors = [
+        {
+            **({'created_at': format_date(c['created_at'])}
+                if use_main_created_at else
+                {}),
+            'updated_at': format_date(c['updated_at']),
+            'contributor_id': get_contributor_id_from_facilityindexnew(
+                c['contributor'], user_can_see_detail),
+            'contributor_name': get_contributor_name_from_facilityindexnew(
+                c['contributor'], user_can_see_detail),
+            'values': c['sector'],
+            'is_from_claim': True
+        }
+        for c in claims
+    ]
+
+    item_sectors = sorted(
+        item_sectors,
+        key=lambda i: i[date_field_to_sort],
+        reverse=True
+    )
+
+    return claim_sectors + depromote_unspecified_items(item_sectors)

--- a/src/django/api/serializers/facility/utils.py
+++ b/src/django/api/serializers/facility/utils.py
@@ -275,7 +275,7 @@ def get_facility_addresses(facility):
     return facility_list_item_matches
 
 
-def get_contributor_name_from_facilityindexnew(
+def get_contributor_name_from_facilityindex(
         contributor_data: dict,
         user_can_see_detail: bool) -> Union[None, str]:
     if contributor_data.get('id') is None:
@@ -286,7 +286,7 @@ def get_contributor_name_from_facilityindexnew(
     return name[0].lower() + name[1:]
 
 
-def get_contributor_id_from_facilityindexnew(
+def get_contributor_id_from_facilityindex(
         contributor: dict,
         user_can_see_detail: bool) -> Union[None, int]:
     if contributor.get('id') is not None and user_can_see_detail:
@@ -313,9 +313,9 @@ def create_name_field_from_facility_name(name: str,
     field_data = {
         'value': name,
         'field_name': ExtendedField.NAME,
-        'contributor_id': get_contributor_id_from_facilityindexnew(
+        'contributor_id': get_contributor_id_from_facilityindex(
             contributor, user_can_see_detail),
-        'contributor_name': get_contributor_name_from_facilityindexnew(
+        'contributor_name': get_contributor_name_from_facilityindex(
             contributor, user_can_see_detail),
         'updated_at': format_date(updated_at),
     }
@@ -339,9 +339,9 @@ def create_address_field_from_facility_address(address: str,
     field_data = {
         'value': address,
         'field_name': ExtendedField.ADDRESS,
-        'contributor_id': get_contributor_id_from_facilityindexnew(
+        'contributor_id': get_contributor_id_from_facilityindex(
             contributor, user_can_see_detail),
-        'contributor_name': get_contributor_name_from_facilityindexnew(
+        'contributor_name': get_contributor_name_from_facilityindex(
             contributor, user_can_see_detail),
         'updated_at': format_date(updated_at),
         'is_from_claim': is_from_claim,
@@ -457,50 +457,36 @@ def format_sectors(items,
                    date_field_to_sort,
                    use_main_created_at,
                    user_can_see_detail):
-    item_sectors = [
-        {
-            **({'created_at': format_date(i['created_at'])}
-                if use_main_created_at else
-                {}),
-            'updated_at': format_date(i['updated_at']),
-            'contributor_id': get_contributor_id_from_facilityindexnew(
-                i['contributor'],
-                (user_can_see_detail
-                    and i['source']['is_active']
-                    and i['source']['is_public']
-                    and i['has_active_complete_match'])),
-            'contributor_name': get_contributor_name_from_facilityindexnew(
-                i['contributor'],
-                (user_can_see_detail
-                    and i['source']['is_active']
-                    and i['source']['is_public']
-                    and i['has_active_complete_match'])),
-            'values': i['sector'],
-            'is_from_claim': False
+    def is_contributor_visible(entity, is_claim):
+        if is_claim:
+            return user_can_see_detail
+        return (user_can_see_detail and entity['source']['is_active']
+                and entity['source']['is_public']
+                and entity['has_active_complete_match'])
+
+    def format_sector_data(entity, is_claim):
+        formatted_data = {
+            'updated_at': format_date(entity['updated_at']),
+            'contributor_id': get_contributor_id_from_facilityindex(
+                entity['contributor'],
+                is_contributor_visible(entity, is_claim)),
+            'contributor_name': get_contributor_name_from_facilityindex(
+                entity['contributor'],
+                is_contributor_visible(entity, is_claim)),
+            'values': entity['sector'],
+            'is_from_claim': is_claim
         }
-        for i in items
-    ]
 
-    claim_sectors = [
-        {
-            **({'created_at': format_date(c['created_at'])}
-                if use_main_created_at else
-                {}),
-            'updated_at': format_date(c['updated_at']),
-            'contributor_id': get_contributor_id_from_facilityindexnew(
-                c['contributor'], user_can_see_detail),
-            'contributor_name': get_contributor_name_from_facilityindexnew(
-                c['contributor'], user_can_see_detail),
-            'values': c['sector'],
-            'is_from_claim': True
-        }
-        for c in claims
-    ]
+        if use_main_created_at:
+            formatted_data['created_at'] = format_date(entity['created_at'])
 
-    item_sectors = sorted(
-        item_sectors,
-        key=lambda i: i[date_field_to_sort],
-        reverse=True
-    )
+        return formatted_data
 
-    return claim_sectors + depromote_unspecified_items(item_sectors)
+    item_sectors = [format_sector_data(item, False) for item in items]
+    claim_sectors = [format_sector_data(claim, True) for claim in claims]
+
+    sorted_item_sectors = sorted(item_sectors,
+                                 key=lambda i: i[date_field_to_sort],
+                                 reverse=True)
+
+    return claim_sectors + depromote_unspecified_items(sorted_item_sectors)

--- a/src/django/api/serializers/facility/utils.py
+++ b/src/django/api/serializers/facility/utils.py
@@ -451,6 +451,7 @@ def depromote_unspecified_items(items: list):
         len(k['values']) == 1),
         reverse=False)
 
+
 def format_sectors(items,
                    claims,
                    date_field_to_sort,

--- a/src/django/api/tests/test_sector_api.py
+++ b/src/django/api/tests/test_sector_api.py
@@ -1,3 +1,5 @@
+import json
+
 from api.tests.facility_api_test_case_base import FacilityAPITestCaseBase
 
 from django.urls import reverse
@@ -10,25 +12,29 @@ class SectorAPITest(FacilityAPITestCaseBase):
         super(SectorAPITest, self).setUp()
         self.url = reverse("facility-list")
 
-    # TODO: Replace to Dedupe Hub if possible (issue between test database
-    #       & Dedupe Hub live database)
-    # @patch('api.geocoding.requests.get')
-    # def test_search(self, mock_get):
-    #     mock_get.return_value = Mock(ok=True, status_code=200)
-    #     mock_get.return_value.json.return_value = geocoding_data
-    #     self.join_group_and_login()
-    #     facility_response = self.client.post(self.url, json.dumps({
-    #         'country': "US",
-    #         'name': "Azavea",
-    #         'address': "990 Spring Garden St., Philadelphia PA 19123",
-    #         'sector': ['Apparel', 'Agriculture']
-    #     }), content_type='application/json')
-    #     facility_data = json.loads(facility_response.content)
-    #     facility_id = facility_data['os_id']
+    def test_search(self):
+        self.join_group_and_login()
 
-    #     response = self.client.get(
-    #         self.url + '?sectors=Agriculture'
-    #     )
-    #     data = json.loads(response.content)
-    #     self.assertEqual(data['count'], 1)
-    #     self.assertEqual(data['features'][0]['id'], facility_id)
+        response = self.client.get(
+            self.url + '?detail=true'
+        )
+        data = json.loads(response.content)
+
+        self.assertEqual(data['count'], 1)
+        self.assertEqual(data['features'][0]['id'], self.facility.id)
+        self.assertEqual(len(data['features'][0]['properties']['sector']), 1)
+        self.assertEqual(data['features'][0]['properties']
+                         ['sector'][0]['values'],
+                         ['Apparel'])
+
+    def test_search_without_detail(self):
+        self.join_group_and_login()
+
+        response = self.client.get(
+            self.url
+        )
+        data = json.loads(response.content)
+
+        self.assertEqual(data['count'], 1)
+        self.assertEqual(data['features'][0]['id'], self.facility.id)
+        self.assertNotIn('sector', data['features'][0]['properties'])

--- a/src/django/api/views/facility/facilities_view_set.py
+++ b/src/django/api/views/facility/facilities_view_set.py
@@ -155,7 +155,7 @@ class FacilitiesViewSet(ListModelMixin,
                     }
                 ]
             }
-        
+
         ### Sample Response - parameter 'detail' equal 'true'
             {
                 "type": "FeatureCollection",
@@ -192,13 +192,13 @@ class FacilitiesViewSet(ListModelMixin,
                                         "field_name": "field_name",
                                         "contributor_id": 1,
                                         "contributor_name": "contributor_name",
-                                        "updated_at": "0000-00-00T00:00:00.000000Z"
+                                        "updated_at": "0000-00-00T00:00:00"
                                     }
                                 ]
                             }
                             "sector": [
                                 {
-                                    "updated_at": "0000-00-00T00:00:00.000000Z",
+                                    "updated_at": "0000-00-00T00:00:00",
                                     "contributor_id": 1,
                                     "contributor_name": "contributor_name",
                                     "values": [
@@ -245,7 +245,10 @@ class FacilitiesViewSet(ListModelMixin,
 
             if not should_serialize_details:
                 exclude_fields.extend([
-                    'contributor_fields', 'extended_fields', 'contributors', 'sector'])
+                    'contributor_fields',
+                    'extended_fields',
+                    'contributors',
+                    'sector'])
             if not should_serialize_number_of_public_contributors:
                 exclude_fields.extend(['number_of_public_contributors'])
 

--- a/src/django/api/views/facility/facilities_view_set.py
+++ b/src/django/api/views/facility/facilities_view_set.py
@@ -189,7 +189,7 @@ class FacilitiesViewSet(ListModelMixin,
 
             if not should_serialize_details:
                 exclude_fields.extend([
-                    'contributor_fields', 'extended_fields', 'contributors'])
+                    'contributor_fields', 'extended_fields', 'contributors', 'sector'])
             if not should_serialize_number_of_public_contributors:
                 exclude_fields.extend(['number_of_public_contributors'])
 

--- a/src/django/api/views/facility/facilities_view_set.py
+++ b/src/django/api/views/facility/facilities_view_set.py
@@ -155,6 +155,62 @@ class FacilitiesViewSet(ListModelMixin,
                     }
                 ]
             }
+        
+        ### Sample Response - parameter 'detail' equal 'true'
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "id": "OS_ID_1",
+                        "type": "Feature",
+                        "geometry": {
+                            "type": "Point",
+                            "coordinates": [1, 1]
+                        },
+                        "properties": {
+                            "name": "facility_name_1",
+                            "address" "facility address_1",
+                            "country_code": "US",
+                            "country_name": "United States",
+                            "os_id": "OS_ID_1",
+                            "contributors": [
+                                {
+                                    "id": 1,
+                                    "name": "contributor_list_name",
+                                    "is_verified": false,
+                                    "contributor_name": "contributor_name",
+                                    "list_name": "list_name"
+                                }
+                            ],
+                            "has_approved_claim": false,
+                            "is_closed": null,
+                            "contributor_fields": [],
+                            "extended_fields": {
+                                "field_name": [
+                                    {
+                                        "value": "field_value",
+                                        "field_name": "field_name",
+                                        "contributor_id": 1,
+                                        "contributor_name": "contributor_name",
+                                        "updated_at": "0000-00-00T00:00:00.000000Z"
+                                    }
+                                ]
+                            }
+                            "sector": [
+                                {
+                                    "updated_at": "0000-00-00T00:00:00.000000Z",
+                                    "contributor_id": 1,
+                                    "contributor_name": "contributor_name",
+                                    "values": [
+                                        "sector_value"
+                                    ],
+                                    "is_from_claim": false
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
         """
         params = FacilityQueryParamsSerializer(data=request.query_params)
 


### PR DESCRIPTION
[OSDEV-728](https://opensupplyhub.atlassian.net/browse/OSDEV-728) API. Sector values are missing from GET /facilities response.

- Added 'sector' data response to endpoint **api/facilities/** similar as we got in **api/facilities/{id}**.
- Excluded _'sector'_ field if parameter _'detail'_ not set or equal _'true'_
- Updated docs for Swagger.