### PR TITLE
Fix Django api limit tests that was sensitive to date

### DIFF
--- a/src/django/api/serializers/user_api_info_serializer.py
+++ b/src/django/api/serializers/user_api_info_serializer.py
@@ -1,6 +1,5 @@
 from django.utils import timezone
 from api.models import (RequestLog, ApiLimit)
-from api.limitation.date.date_limitation_context import DateLimitationContext
 from api.limitation.date.monthly_date_limitation import MonthlyDateLimitation
 from api.limitation.date.yearly_date_limitation import YearlyDateLimitation
 from django.core.exceptions import ObjectDoesNotExist
@@ -26,16 +25,14 @@ class UserApiInfoSerializer:
             apiLimit = None
             renewal_period = ''
 
-        context = DateLimitationContext()
-
         if renewal_period == '':
             return {}
         if renewal_period == 'MONTHLY':
-            context.set_strategy(MonthlyDateLimitation())
+            date_limitation = MonthlyDateLimitation()
         if renewal_period == 'YEARLY':
-            context.set_strategy(YearlyDateLimitation())
+            date_limitation = YearlyDateLimitation()
 
-        date_limitation = context.execute(date)
+        date_limitation.execute(date)
 
         return {
                 "start_date": date_limitation.get_start_date(),

--- a/src/django/api/tests/test_api_limit.py
+++ b/src/django/api/tests/test_api_limit.py
@@ -108,9 +108,9 @@ class ApiLimitTest(TestCase):
     def test_limit_warning_sent_once(self):
         for x in range(10):
             r_log_one = RequestLog.objects.create(user=self.user_one,
-                                                response_code=200)
+                                                  response_code=200)
             r_log_two = RequestLog.objects.create(user=self.user_two,
-                                                response_code=200)
+                                                  response_code=200)
 
             r_log_one.created_at = self.now
             r_log_one.save()
@@ -149,9 +149,9 @@ class ApiLimitTest(TestCase):
 
         for x in range(11):
             r_log_one = RequestLog.objects.create(user=self.user_one,
-                                                response_code=200)
+                                                  response_code=200)
             r_log_two = RequestLog.objects.create(user=self.user_two,
-                                                response_code=200)
+                                                  response_code=200)
 
             r_log_one.created_at = self.now
             r_log_one.save()


### PR DESCRIPTION
**Fix Django api limit tests that was sensitive to date**
- Fixed api limit tests for specific day 29-31
- Fixed calculation of current usage in the situation of contributor start paid subs between day 29-31