### PR TITLE
[OSDEV-915] Upgrade Kafka tool version to 3.5.2

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Architecture/Environment changes
 * [OSDEV-910](https://opensupplyhub.atlassian.net/browse/OSDEV-910) Add separated code quality pipelines for contricleaner, countries, django-api and frontend. After checking, it creates a code coverage report showing each particular app's code coverage. Add separated code quality jobs for code formatters.
+* [OSDEV-915](https://opensupplyhub.atlassian.net/browse/OSDEV-915) Upgrade Kafka tools to version 3.5.2
 
 ### Bugfix
 * [OSDEV-716](https://opensupplyhub.atlassian.net/browse/OSDEV-716) Search. Lost refresh icon. The refresh icon has been made visible.

--- a/src/kafka-tools/Dockerfile
+++ b/src/kafka-tools/Dockerfile
@@ -2,7 +2,7 @@ FROM amazonlinux:latest
 
 WORKDIR /opt/
 RUN yum install -y java-1.8.0 wget tar
-RUN wget https://dlcdn.apache.org/kafka/3.5.1/kafka_2.13-3.5.1.tgz
+RUN wget https://dlcdn.apache.org/kafka/3.5.2/kafka_2.13-3.5.2.tgz
 RUN tar -xzf kafka_2.13-3.5.1.tgz
 RUN ln /opt/kafka_2.13-3.5.1/bin/kafka-topics.sh /bin/kafka-topics
 WORKDIR /opt/kafka_2.13-3.5.1/


### PR DESCRIPTION
Kafka tool 3.5.1 isn't available anymore, so version is upgraded to 3.5.2.

[OSDEV-915](https://opensupplyhub.atlassian.net/browse/OSDEV-915)