### PR TITLE
[OSDEV-918] ContriBot. New lists are not populating in Monday board and are not sent to slack

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -31,6 +31,7 @@ Move `countries` to a separate module so that it becomes possible to use both `d
 
 ### What's new
 * [OSDEV-728](https://opensupplyhub.atlassian.net/browse/OSDEV-728) - Include `sector` data in the response of the `api/facilities/` API endpoint for the GET request, similar to what is provided in the `api/facilities/{id}` API endpoint.
+* [OSDEV-918](https://opensupplyhub.atlassian.net/browse/OSDEV-918) - ContriBot. New lists are not populating in Monday board and are not sent to slack. Added validation to throw an error for users who upload a facility list with `|` in the description field.
 
 ### Release instructions:
 * *Provide release instructions here.*

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -28,10 +28,10 @@ Move `countries` to a separate module so that it becomes possible to use both `d
 
 ### Bugfix
 * [OSDEV-716](https://opensupplyhub.atlassian.net/browse/OSDEV-716) Search. Lost refresh icon. The refresh icon has been made visible.
+* [OSDEV-918](https://opensupplyhub.atlassian.net/browse/OSDEV-918) - ContriBot. New lists are not populating in Monday board and are not sent to slack. Added validation to throw an error for users who upload a facility list with `|` in the description field.
 
 ### What's new
 * [OSDEV-728](https://opensupplyhub.atlassian.net/browse/OSDEV-728) - Include `sector` data in the response of the `api/facilities/` API endpoint for the GET request, similar to what is provided in the `api/facilities/{id}` API endpoint.
-* [OSDEV-918](https://opensupplyhub.atlassian.net/browse/OSDEV-918) - ContriBot. New lists are not populating in Monday board and are not sent to slack. Added validation to throw an error for users who upload a facility list with `|` in the description field.
 
 ### Release instructions:
 * *Provide release instructions here.*

--- a/src/django/api/tests/test_facility_list_view.py
+++ b/src/django/api/tests/test_facility_list_view.py
@@ -32,11 +32,18 @@ class FacilityListViewTest(BaseFacilityListTest):
         file_path = myfile.name
         f = open(file_path, "r")
 
-        response_one = self.client.post("/api/facility-lists/", {'file': f, 'name': 'Test', 'description': 'Test'})
+        response_one = self.client.post("/api/facility-lists/",
+                                        {'file': f,
+                                         'name': 'Test',
+                                         'description': 'Test'})
         self.assertEqual(200, response_one.status_code)
 
-        response_two = self.client.post("/api/facility-lists/", {'file': f, 'name': 'Test', 'description': 'Test | Test'})
-        self.assertEqual(response_two.json()[0], 'Description cannot contain the "|" character.')
+        response_two = self.client.post("/api/facility-lists/",
+                                        {'file': f,
+                                         'name': 'Test',
+                                         'description': 'Test | Test'})
+        self.assertEqual(response_two.json()[0],
+                         'Description cannot contain the "|" character.')
         self.assertEqual(400, response_two.status_code)
 
     def test_superuser_can_list_own_lists(self):

--- a/src/django/api/tests/test_facility_list_view.py
+++ b/src/django/api/tests/test_facility_list_view.py
@@ -1,3 +1,5 @@
+import csv
+
 from unittest.mock import patch
 
 from api.models import FacilityList, Source
@@ -8,6 +10,35 @@ from django.test import override_settings
 
 
 class FacilityListViewTest(BaseFacilityListTest):
+
+    def generate_test_file(self):
+        try:
+            myfile = open('test.csv', 'w')
+            wr = csv.writer(myfile)
+            wr.writerow(('name', 'address', 'country'))
+            wr.writerow(('Test LTD', 'str Test 17 Test', 'Test'))
+            wr.writerow(('Test LTD', 'str Test 78 Test', 'Test'))
+        finally:
+            myfile.close()
+
+        return myfile
+
+    def test_description_field_list_upload(self):
+        self.client.login(
+            email=self.superuser_email, password=self.superuser_password
+        )
+
+        myfile = self.generate_test_file()
+        file_path = myfile.name
+        f = open(file_path, "r")
+
+        response_one = self.client.post("/api/facility-lists/", {'file': f, 'name': 'Test', 'description': 'Test'})
+        self.assertEqual(200, response_one.status_code)
+
+        response_two = self.client.post("/api/facility-lists/", {'file': f, 'name': 'Test', 'description': 'Test | Test'})
+        self.assertEqual(response_two.json()[0], 'Description cannot contain the "|" character.')
+        self.assertEqual(400, response_two.status_code)
+
     def test_superuser_can_list_own_lists(self):
         self.client.login(
             email=self.superuser_email, password=self.superuser_password

--- a/src/django/api/views/facility/facility_list_view_set.py
+++ b/src/django/api/views/facility/facility_list_view_set.py
@@ -165,7 +165,9 @@ class FacilityListViewSet(ModelViewSet):
             description = None
 
         if description is not None and '|' in description:
-            raise ValidationError('Description cannot contain the "|" character.')
+            raise ValidationError(
+                'Description cannot contain the "|" character.'
+            )
 
         replaces = None
         if 'replaces' in request.data:

--- a/src/django/api/views/facility/facility_list_view_set.py
+++ b/src/django/api/views/facility/facility_list_view_set.py
@@ -164,6 +164,9 @@ class FacilityListViewSet(ModelViewSet):
         else:
             description = None
 
+        if description is not None and '|' in description:
+            raise ValidationError('Description cannot contain the "|" character.')
+
         replaces = None
         if 'replaces' in request.data:
             try:


### PR DESCRIPTION
[OSDEV-918](https://opensupplyhub.atlassian.net/browse/OSDEV-918) ContriBot. New lists are not populating in Monday board and are not sent to slack
- Added validation error if description contain "|"