### PR TITLE
[OSDEV-644] Error when trying to delete a facility with only one contributor

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -30,6 +30,7 @@ Move `countries` to a separate module so that it becomes possible to use both `d
 ### Bugfix
 * [OSDEV-716](https://opensupplyhub.atlassian.net/browse/OSDEV-716) Search. Lost refresh icon. The refresh icon has been made visible.
 * [OSDEV-918](https://opensupplyhub.atlassian.net/browse/OSDEV-918) - ContriBot. New lists are not populating in Monday board and are not sent to slack. Added validation to throw an error for users who upload a facility list with `|` in the description field.
+* [OSDEV-644](https://opensupplyhub.atlassian.net/browse/OSDEV-644) Error when trying to delete a facility with only one contributor in case that logic to clear FacilityClaimReviewNote table records missed.
 
 ### What's new
 * [OSDEV-917](https://opensupplyhub.atlassian.net/browse/OSDEV-917) My Account Menu. Update order of the settings tabs. `NON-admin` user sees: My Facility / My Lists / Settings / Logout and `Admin` user sees: Dashboard / My Facility / My Lists / Settings / Logout

--- a/src/django/api/tests/test_facility_delete.py
+++ b/src/django/api/tests/test_facility_delete.py
@@ -626,7 +626,7 @@ class FacilityDeleteTest(APITestCase):
         self.assertEqual(
             0, FacilityMatch.objects.filter(facility=self.facility).count()
         )
-    
+
     def test_can_delete_with_claim_notes(self):
         claim = FacilityClaim.objects.create(
             contributor=self.contributor,
@@ -640,7 +640,7 @@ class FacilityDeleteTest(APITestCase):
         FacilityClaimReviewNote.objects.create(
             claim=claim,
             author=self.user,
-            note=( f'Test' ),
+            note='Test',
         )
 
         self.client.login(
@@ -655,4 +655,3 @@ class FacilityDeleteTest(APITestCase):
         self.assertEqual(
             0, FacilityClaimReviewNote.objects.filter(claim=claim).count()
         )
-

--- a/src/django/api/tests/test_facility_delete.py
+++ b/src/django/api/tests/test_facility_delete.py
@@ -4,6 +4,7 @@ from api.models import (
     Facility,
     FacilityAlias,
     FacilityClaim,
+    FacilityClaimReviewNote,
     FacilityList,
     FacilityListItem,
     FacilityMatch,
@@ -625,3 +626,33 @@ class FacilityDeleteTest(APITestCase):
         self.assertEqual(
             0, FacilityMatch.objects.filter(facility=self.facility).count()
         )
+    
+    def test_can_delete_with_claim_notes(self):
+        claim = FacilityClaim.objects.create(
+            contributor=self.contributor,
+            facility=self.facility,
+            contact_person="test",
+            email="test@test.com",
+            phone_number="1234567890",
+            status=FacilityClaim.DENIED,
+        )
+
+        FacilityClaimReviewNote.objects.create(
+            claim=claim,
+            author=self.user,
+            note=( f'Test' ),
+        )
+
+        self.client.login(
+            email=self.superuser_email,
+            password=self.superuser_password
+        )
+        response = self.client.delete(self.facility_url)
+        self.assertEqual(204, response.status_code)
+        self.assertEqual(
+            0, FacilityClaim.objects.filter(facility=self.facility).count()
+        )
+        self.assertEqual(
+            0, FacilityClaimReviewNote.objects.filter(claim=claim).count()
+        )
+

--- a/src/django/api/views/facility/facilities_view_set.py
+++ b/src/django/api/views/facility/facilities_view_set.py
@@ -790,13 +790,12 @@ class FacilitiesViewSet(ListModelMixin,
             item.save()
 
         def delete_facility_claim_review_notes(claim):
-            FacilityClaimReviewNote. \
+            notes = FacilityClaimReviewNote. \
                 objects. \
-                filter(claim=claim). \
-                update(_change_reason=f'Deleted {facility.id}')
-            FacilityClaimReviewNote. \
-                objects. \
-                filter(claim=claim).delete()
+                filter(claim=claim)
+            for note in notes:
+                note._change_reason=f'Deleted {facility.id}'
+                note.delete()
 
         now = str(timezone.now())
         created_by_contributor = facility.created_from.source.contributor

--- a/src/django/api/views/facility/facilities_view_set.py
+++ b/src/django/api/views/facility/facilities_view_set.py
@@ -790,10 +790,8 @@ class FacilitiesViewSet(ListModelMixin,
             item.save()
 
         def delete_facility_claim_review_notes(claim):
-            notes = FacilityClaimReviewNote.objects.filter(claim=claim)
-            for claim_review_note in notes:
-                claim_review_note._change_reason = f'Deleted {facility.id}'
-                claim_review_note.delete()
+            FacilityClaimReviewNote.objects.filter(claim=claim).update(_change_reason=f'Deleted {facility.id}')
+            FacilityClaimReviewNote.objects.filter(claim=claim).delete()
 
         now = str(timezone.now())
         created_by_contributor = facility.created_from.source.contributor
@@ -917,10 +915,9 @@ class FacilitiesViewSet(ListModelMixin,
                     delete_facility_list_item(other_match.facility_list_item)
 
         claims = FacilityClaim.objects.filter(facility=facility)
-        for claim in claims:
-            delete_facility_claim_review_notes(claim)
 
         for claim in claims:
+            delete_facility_claim_review_notes(claim)
             claim._change_reason = f'Deleted {facility.id}'
             claim.delete()
 

--- a/src/django/api/views/facility/facilities_view_set.py
+++ b/src/django/api/views/facility/facilities_view_set.py
@@ -38,6 +38,7 @@ from ...models import (
     FacilityActivityReport,
     FacilityAlias,
     FacilityClaim,
+    FacilityClaimReviewNote,
     FacilityListItem,
     FacilityListItemTemp,
     FacilityLocation,
@@ -788,6 +789,11 @@ class FacilitiesViewSet(ListModelMixin,
             item.facility = None
             item.save()
 
+        def delete_facility_claim_review_notes(claim):
+            for claim_review_note in FacilityClaimReviewNote.objects.filter(claim=claim):
+                claim_review_note._change_reason = f'Deleted {facility.id}'
+                claim_review_note.delete()
+
         now = str(timezone.now())
         created_by_contributor = facility.created_from.source.contributor
 
@@ -909,7 +915,11 @@ class FacilitiesViewSet(ListModelMixin,
                     delete_facility_match(other_match)
                     delete_facility_list_item(other_match.facility_list_item)
 
-        for claim in FacilityClaim.objects.filter(facility=facility):
+        claims = FacilityClaim.objects.filter(facility=facility)
+        for claim in claims:
+            delete_facility_claim_review_notes(claim)
+
+        for claim in claims:
             claim._change_reason = f'Deleted {facility.id}'
             claim.delete()
 

--- a/src/django/api/views/facility/facilities_view_set.py
+++ b/src/django/api/views/facility/facilities_view_set.py
@@ -790,8 +790,13 @@ class FacilitiesViewSet(ListModelMixin,
             item.save()
 
         def delete_facility_claim_review_notes(claim):
-            FacilityClaimReviewNote.objects.filter(claim=claim).update(_change_reason=f'Deleted {facility.id}')
-            FacilityClaimReviewNote.objects.filter(claim=claim).delete()
+            FacilityClaimReviewNote. \
+                objects. \
+                filter(claim=claim). \
+                update(_change_reason=f'Deleted {facility.id}')
+            FacilityClaimReviewNote. \
+                objects. \
+                filter(claim=claim).delete()
 
         now = str(timezone.now())
         created_by_contributor = facility.created_from.source.contributor

--- a/src/django/api/views/facility/facilities_view_set.py
+++ b/src/django/api/views/facility/facilities_view_set.py
@@ -790,7 +790,8 @@ class FacilitiesViewSet(ListModelMixin,
             item.save()
 
         def delete_facility_claim_review_notes(claim):
-            for claim_review_note in FacilityClaimReviewNote.objects.filter(claim=claim):
+            notes = FacilityClaimReviewNote.objects.filter(claim=claim)
+            for claim_review_note in notes:
                 claim_review_note._change_reason = f'Deleted {facility.id}'
                 claim_review_note.delete()
 

--- a/src/django/api/views/facility/facilities_view_set.py
+++ b/src/django/api/views/facility/facilities_view_set.py
@@ -794,7 +794,7 @@ class FacilitiesViewSet(ListModelMixin,
                 objects. \
                 filter(claim=claim)
             for note in notes:
-                note._change_reason=f'Deleted {facility.id}'
+                note._change_reason = f'Deleted {facility.id}'
                 note.delete()
 
         now = str(timezone.now())


### PR DESCRIPTION
[OSDEV-644](https://opensupplyhub.atlassian.net/browse/OSDEV-644) Error when trying to delete a facility with only one contributor
- Implemented logic to ensure that when we delete a facility, we also clear the corresponding data in the api_facilityclaimreviewnote table.
- Added tests