### PR TITLE
[OSDEV-943] Verified badges. The claim/verified icon on profiles is cut off at the bottom.

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -30,6 +30,7 @@ Move `countries` to a separate module so that it becomes possible to use both `d
 * [OSDEV-851](https://opensupplyhub.atlassian.net/browse/OSDEV-851) Place 'terraform.tfvar' files to repository and move sensitive info to private repository opensupplyhub/ci-deployment/
 
 ### Bugfix
+* [OSDEV-943](https://opensupplyhub.atlassian.net/browse/OSDEV-943) Verified badges. The claim/verified icon on profiles is cut off at the bottom. The icons have been fixed and show properly.
 * [OSDEV-716](https://opensupplyhub.atlassian.net/browse/OSDEV-716) Search. Lost refresh icon. The refresh icon has been made visible.
 * [OSDEV-918](https://opensupplyhub.atlassian.net/browse/OSDEV-918) - ContriBot. New lists are not populating in Monday board and are not sent to slack. Added validation to throw an error for users who upload a facility list with `|` in the description field.
 * [OSDEV-644](https://opensupplyhub.atlassian.net/browse/OSDEV-644) Error when trying to delete a facility with only one contributor in case that logic to clear FacilityClaimReviewNote table records missed.

--- a/src/app/src/components/FacilityDetailsClaimFlag.jsx
+++ b/src/app/src/components/FacilityDetailsClaimFlag.jsx
@@ -31,6 +31,7 @@ const claimFlagBaseStyles = theme =>
         itemPadding: {
             paddingLeft: theme.spacing.unit * 3,
             paddingTop: theme.spacing.unit,
+            paddingBottom: theme.spacing.unit / 4,
         },
     });
 


### PR DESCRIPTION
[OSDEV-943](https://opensupplyhub.atlassian.net/browse/OSDEV-943) Verified badges. The claim/verified icon on profiles is cut off at the bottom.

* Added padding to show icons properly