### PR TITLE
Increase the resources for the DedupeHub on the Test environment to 4 CPU and 8GB.

### DIFF
--- a/deployment/environments/terraform-test.tfvars
+++ b/deployment/environments/terraform-test.tfvars
@@ -53,3 +53,6 @@ dedupe_hub_name = "deduplicate"
 dedupe_hub_version = 1
 app_cc_ecs_desired_count = 0
 
+app_dd_fargate_cpu = 4096
+app_dd_fargate_memory = 8192
+app_dd_ecs_desired_count = 1


### PR DESCRIPTION
Increase the resources for the DedupeHub on the Test environment to 4 CPU and 8GB.

- Update `app_dd_fargate_cpu`, `app_dd_fargate_memory`, and `app_dd_ecs_desired_count`.