### PR TITLE
[OSDEV-888] Fix an error that occurs when trying to open a facility from the Status Reports page

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -3,6 +3,34 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). The format is based on the `RELEASE-NOTES-TEMPLATE.md` file.
 
+## Release 1.11.0
+
+## Introduction
+* Product name: Open Supply Hub
+* Release date: April 20, 2024
+
+### Database changes
+#### Migrations:
+* *Describe migrations here.*
+
+#### Scheme changes
+* *Describe scheme changes here.*
+
+### Code/API changes
+* *Describe code/API changes here.*
+
+### Architecture/Environment changes
+* *Describe architecture/environment changes here.*
+
+### Bugfix
+* [OSDEV-888](https://opensupplyhub.atlassian.net/browse/OSDEV-888) - Facility Profile. An error occurs when trying to open a facility from the Status Reports page. Modified the `format_date` function to prevent an error when argument `date` evaluates to False. The error occurred due to activity reports with the status `pending` containing fields with `null` values and these values pass to the `format_date` function as an argument.
+
+### What's new
+* *Describe what's new here. The changes that can impact user experience should be listed in this section.*
+
+### Release instructions:
+* *Provide release instructions here.*
+
 ## Release 1.10.0
 
 ## Introduction

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -23,7 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * *Describe architecture/environment changes here.*
 
 ### Bugfix
-* [OSDEV-888](https://opensupplyhub.atlassian.net/browse/OSDEV-888) - Facility Profile. An error occurs when trying to open a facility from the Status Reports page. Modified the `format_date` function to prevent an error when argument `date` evaluates to False. The error occurred due to activity reports with the status `pending` containing fields with `null` values and these values pass to the `format_date` function as an argument.
+* [OSDEV-888](https://opensupplyhub.atlassian.net/browse/OSDEV-888) - Facility Profile. An error occurs when trying to open a facility from the Status Reports page. The error occurred due to activity reports with the status `pending` containing fields with `null` values and these values pass to the `format_date` function as an argument. Modified the `get_activity_reports` method in the `FacilityIndexDetailsSerializer` to prevent passing a falsy `date` argument into the `format_date` function. 
 
 ### What's new
 * *Describe what's new here. The changes that can impact user experience should be listed in this section.*

--- a/src/django/api/serializers/facility/facility_index_details_serializer.py
+++ b/src/django/api/serializers/facility/facility_index_details_serializer.py
@@ -190,26 +190,23 @@ class FacilityIndexDetailsSerializer(FacilityIndexSerializer):
     def get_activity_reports(self, facility):
         return [
             {
-                'facility': item['facility'] or None,
-                'reported_by_contributor': (
-                    item['reported_by_contributor'] or None
+                'facility': item.get('facility'),
+                'reported_by_contributor': item.get('reported_by_contributor'),
+                'closure_state': item.get('closure_state'),
+                'approved_at': format_date(item.get('approved_at')),
+                'status_change_reason': item.get('status_change_reason'),
+                'status': item.get('status'),
+                'status_change_by': item.get('status_change_by'),
+                'status_change_date': format_date(
+                    item.get('status_change_date')
                 ),
-                'closure_state': item['closure_state'] or None,
-                'approved_at': format_date(item['approved_at']) or None,
-                'status_change_reason': item['status_change_reason'] or None,
-                'status': item['status'] or None,
-                'status_change_by': item['status_change_by'] or None,
-                'status_change_date': (
-                    format_date(item['status_change_date']) or None
-                ),
-                'created_at': format_date(item['created_at']) or None,
-                'updated_at': format_date(item['updated_at']) or None,
-                'id': item['id'] or None,
-                'reason_for_report': item['reason_for_report'] or None,
-                'facility_name': item['facility_name'] or None,
+                'created_at': format_date(item.get('created_at')),
+                'updated_at': format_date(item.get('updated_at')),
+                'id': item.get('id'),
+                'reason_for_report': item.get('reason_for_report'),
+                'facility_name': item.get('facility_name'),
             }
-            for item
-            in facility.activity_reports_info
+            for item in facility.activity_reports_info
         ]
 
     def get_contributor_fields(self, facility):

--- a/src/django/api/serializers/facility/facility_index_details_serializer.py
+++ b/src/django/api/serializers/facility/facility_index_details_serializer.py
@@ -193,12 +193,18 @@ class FacilityIndexDetailsSerializer(FacilityIndexSerializer):
                 'facility': item.get('facility'),
                 'reported_by_contributor': item.get('reported_by_contributor'),
                 'closure_state': item.get('closure_state'),
-                'approved_at': format_date(item.get('approved_at')),
+                'approved_at': (
+                    format_date(item.get('approved_at'))
+                    if item.get('approved_at')
+                    else None
+                ),
                 'status_change_reason': item.get('status_change_reason'),
                 'status': item.get('status'),
                 'status_change_by': item.get('status_change_by'),
-                'status_change_date': format_date(
-                    item.get('status_change_date')
+                'status_change_date': (
+                    format_date(item.get('status_change_date'))
+                    if item.get('status_change_date')
+                    else None
                 ),
                 'created_at': format_date(item.get('created_at')),
                 'updated_at': format_date(item.get('updated_at')),

--- a/src/django/api/serializers/facility/utils.py
+++ b/src/django/api/serializers/facility/utils.py
@@ -410,9 +410,6 @@ def regroup_claims_for_sector_field(claims: list,
 
 
 def format_date(date: str) -> str:
-    if not date:
-        return None
-
     # Parse the datetime string into a datetime object.
     original_datetime = parser.isoparse(date)
 

--- a/src/django/api/serializers/facility/utils.py
+++ b/src/django/api/serializers/facility/utils.py
@@ -410,6 +410,9 @@ def regroup_claims_for_sector_field(claims: list,
 
 
 def format_date(date: str) -> str:
+    if date is None:
+        return None
+
     # Parse the datetime string into a datetime object.
     original_datetime = parser.isoparse(date)
 

--- a/src/django/api/serializers/facility/utils.py
+++ b/src/django/api/serializers/facility/utils.py
@@ -410,7 +410,7 @@ def regroup_claims_for_sector_field(claims: list,
 
 
 def format_date(date: str) -> str:
-    if date is None:
+    if not date:
         return None
 
     # Parse the datetime string into a datetime object.

--- a/src/django/api/tests/test_facility_index_details_serializer.py
+++ b/src/django/api/tests/test_facility_index_details_serializer.py
@@ -10,6 +10,7 @@ from api.models import (
     Source,
     User,
 )
+from api.models.facility.facility_activity_report import FacilityActivityReport
 from api.models.facility.facility_index import FacilityIndex
 from api.serializers import (
     FacilityIndexDetailsSerializer,
@@ -18,6 +19,10 @@ from api.serializers import (
 
 from django.contrib.gis.geos import Point
 from django.test import TestCase
+
+from api.serializers.facility.facility_activity_report_serializer import (
+    FacilityActivityReportSerializer
+)
 
 
 class FacilityIndexDetailsSerializerTest(TestCase):
@@ -348,3 +353,30 @@ class FacilityIndexDetailsSerializerTest(TestCase):
         expected_other_names = []
         actual_other_names = serializer.get_other_names(facility_index)
         self.assertEqual(expected_other_names, actual_other_names)
+
+    def test_get_activity_reports(self):
+        FacilityActivityReport.objects.create(
+            id=1,
+            facility=self.facility,
+            reported_by_user=self.user_one,
+            reported_by_contributor=self.contrib_one,
+            reason_for_report="reason",
+            closure_state=FacilityActivityReport.CLOSED,
+            status=FacilityActivityReport.PENDING,
+        )
+
+        activity_reports_data = FacilityActivityReportSerializer(
+            FacilityActivityReport.objects.get(id=1)
+        ).data
+
+        facility_index = FacilityIndex.objects.get(id=self.facility.id)
+        facility_index.activity_reports_info.append(activity_reports_data)
+        facility_index.save()
+
+        serializer = FacilityIndexDetailsSerializer(facility_index)
+        actual_activity_reports = serializer.get_activity_reports(
+            facility_index
+        )
+
+        for key, value in actual_activity_reports[0].items():
+            self.assertEqual(activity_reports_data.get(key), value)


### PR DESCRIPTION
[OSDEV-888](https://opensupplyhub.atlassian.net/browse/OSDEV-888): Fix an error that occurs when trying to open a facility from the Status Reports page

The error occurred due to activity reports with the status `pending` containing fields with `null` values and these values pass to the `format_date` function as an argument.
Modified the `get_activity_reports` method in the `FacilityIndexDetailsSerializer` to prevent passing a falsy `date` argument into the `format_date` function. 

