### PR TITLE
[OSDEV-952] Restore correct prod configuration

### DIFF
--- a/deployment/environments/terraform-production.tfvars
+++ b/deployment/environments/terraform-production.tfvars
@@ -1,38 +1,36 @@
 project = "OpenSupplyHub"
-environment = "Test"
-py_environment = "Test"
+environment = "Production"
+py_environment = "Production"
 
 aws_region = "eu-west-1"
 aws_availability_zones = ["eu-west-1a", "eu-west-1b"]
 
 r53_private_hosted_zone = "osh.internal"
-r53_service_discovery_zone = "sd.internal"
-r53_public_hosted_zone = "os-hub.net"
+r53_public_hosted_zone = "opensupplyhub.org"
 
 cloudfront_price_class = "PriceClass_All"
 
 bastion_ami = "ami-0bb3fad3c0286ebd5"
-bastion_instance_type = "t3.medium"
+bastion_instance_type = "t3.nano"
 
 rds_allocated_storage = "128"
 rds_engine_version = "12"
 rds_parameter_group_family = "postgres12"
 rds_instance_type = "db.t3.2xlarge"
-rds_database_identifier = "opensupplyhub-enc-tst"
+rds_database_identifier = "opensupplyhub-enc-prd"
 rds_database_name = "opensupplyhub"
-rds_multi_az = false
+rds_multi_az = true
 rds_storage_encrypted = true
 
 app_ecs_desired_count = "16"
 app_ecs_deployment_min_percent = "100"
 app_ecs_deployment_max_percent = "400"
+app_ecs_grace_period_seconds = "420"
 app_fargate_cpu = "2048"
 app_fargate_memory = "8192"
 
 cli_fargate_cpu = "2048"
 cli_fargate_memory = "8192"
-
-gunicorn_worker_timeout = "240"
 
 batch_default_ce_spot_fleet_bid_percentage = 60
 batch_ami_id = "ami-002e2fef4b94f8fd0"
@@ -43,13 +41,17 @@ batch_default_job_memory = 8192
 
 batch_default_ce_instance_types = ["c5", "m5"]
 
-app_ecs_grace_period_seconds = 300
+gunicorn_worker_timeout = "360"
 
-ec_memcached_identifier = "opensupplyhub-tst"
-rds_final_snapshot_identifier = "opensupplyhub-rds-tst"
+ec_memcached_identifier = "opensupplyhub-prd"
+
+rds_final_snapshot_identifier = "opensupplyhub-rds-prd"
 topic_dedup_basic_name = "basic-name"
 dedupe_hub_live = true
 dedupe_hub_name = "deduplicate"
 dedupe_hub_version = 1
 app_cc_ecs_desired_count = 0
-
+app_dd_fargate_cpu = 4096
+app_dd_fargate_memory = 8192
+app_dd_ecs_desired_count = 1
+django_log_level="DEBUG"


### PR DESCRIPTION
During deploy to production it's turned out that terraform configuration is mislead. This pr restores original configuration.