### PR TITLE
 [OSDEV-857] [Bug] Pre-prod isn't deleted by the 'terraform destroy' script.

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -21,6 +21,9 @@ jobs:
         uses: Entepotenz/change-string-case-action-min-dependencies@v1
         with:
           string: ${{ inputs.deploy-env }}
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
       - name: Delete erc repostiroy for ${{ inputs.deploy-env }}
         run: |
           ./deployment/delete_ecr opensupplyhub-batch-${{ steps.get_env_name.outputs.lowercase }}

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Delete erc repostiroy for ${{ vars.ENV_NAME }}
         run: |
           ./deployment/delete_ecr opensupplyhub-batch-${{ steps.get_env_name.outputs.lowercase }}
+          ./deployment/delete_ecr opensupplyhub-${{ steps.get_env_name.outputs.lowercase }}
+          ./deployment/delete_ecr opensupplyhub-kafka-${{ steps.get_env_name.outputs.lowercase }}
+          ./deployment/delete_ecr opensupplyhub-deduplicate-${{ steps.get_env_name.outputs.lowercase }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -24,6 +24,13 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       
+      - name: Checkout config repository
+        uses: actions/checkout@v4
+        with:
+          repository: 'opensupplyhub/ci-deployment'
+          path: 'terraform-config'
+          token: ${{ secrets.PAT }}
+
       - name: Copy tfvars for ${{ vars.ENV_NAME }}
         run: |
           cat "terraform-config/environments/${{ env.TFVAR_NAME }}"  "deployment/environments/${{env.TFVAR_NAME}}"  > "deployment/terraform/${{ env.SETTINGS_BUCKET }}.tfvars"

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -23,7 +23,7 @@ jobs:
           string: ${{ inputs.deploy-env }}
       - name: Delete erc repostiroy for ${{ inputs.deploy-env }}
         run: |
-          ./deployment/infra clean_ecr_repositories opensupplyhub-batch-${{ steps.get_env_name.outputs.lowercase }}
+          ./deployment/delete_ecr opensupplyhub-batch-${{ steps.get_env_name.outputs.lowercase }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       deploy-env:
-        description: 'Environment to destroy'     
+        description: 'Environment to destroy'
         required: true
         type: choice
         options:
@@ -12,9 +12,27 @@ on:
         default: Pre-prod
 
 jobs:
+  clean_ecr_repositories:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.deploy-env }}
+    steps:
+      - name: Get Environment Name for ${{ inputs.deploy-env }}
+        id: get_env_name
+        uses: Entepotenz/change-string-case-action-min-dependencies@v1
+        with:
+          string: ${{ inputs.deploy-env }}
+      - name: Delete erc repostiroy for ${{ inputs.deploy-env }}
+        run: |
+          ./deployment/infra clean_ecr_repositories opensupplyhub-batch-${{ steps.get_env_name.outputs.lowercase }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: "eu-west-1"
+
   destroy:
     runs-on: ubuntu-latest
     environment: ${{ inputs.deploy-env }}
+    needs: clean_ecr_repositories
     steps:
       - name: Get Environment Name for ${{ vars.ENV_NAME }}
         id: get_env_name
@@ -23,7 +41,7 @@ jobs:
           string: ${{ vars.ENV_NAME }}
       - name: Checkout repo
         uses: actions/checkout@v4
-      
+
       - name: Checkout config repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -16,15 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.deploy-env }}
     steps:
-      - name: Get Environment Name for ${{ inputs.deploy-env }}
+      - name: Get Environment Name for ${{ vars.ENV_NAME }}
         id: get_env_name
         uses: Entepotenz/change-string-case-action-min-dependencies@v1
         with:
-          string: ${{ inputs.deploy-env }}
+          string: ${{ vars.ENV_NAME }}
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Delete erc repostiroy for ${{ inputs.deploy-env }}
+      - name: Delete erc repostiroy for ${{ vars.ENV_NAME }}
         run: |
           ./deployment/delete_ecr opensupplyhub-batch-${{ steps.get_env_name.outputs.lowercase }}
         env:

--- a/deployment/delete_ecr
+++ b/deployment/delete_ecr
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+aws ecr batch-delete-image \
+    --repository-name $1 \
+    --image-ids "$(aws ecr list-images --repository-name $1 --query 'imageIds[*]' --output json
+)" || true

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -3,6 +3,34 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). The format is based on the `RELEASE-NOTES-TEMPLATE.md` file.
 
+## Release 1.11.0
+
+## Introduction
+* Product name: Open Supply Hub
+* Release date: *Provide release date*
+
+### Database changes
+#### Migrations:
+* *Describe migrations here.*
+
+#### Scheme changes
+* *Describe scheme changes here.*
+
+### Code/API changes
+* *Describe code/API changes here.*
+
+### Architecture/Environment changes
+* *Describe architecture/environment changes here.*
+
+### Bugfix
+* [OSDEV-857](https://opensupplyhub.atlassian.net/browse/OSDEV-857) [Bug] Pre-prod isn't deleted by the 'terraform destroy' script. Command for destroying repositories on AWS pre-prod has been added.
+
+### What's new
+* *Describe what's new here. The changes that can impact user experience should be listed in this section.*
+
+### Release instructions:
+* *Provide release instructions here.*
+
 ## Release 1.10.0
 
 ## Introduction
@@ -33,8 +61,8 @@ Move `countries` to a separate module so that it becomes possible to use both `d
 * [OSDEV-938](https://opensupplyhub.atlassian.net/browse/OSDEV-938) Move cleanup helper functions to the serializer
 * [OSDEV-851](https://opensupplyhub.atlassian.net/browse/OSDEV-851) Place 'terraform.tfvar' files to repository and move sensitive info to private repository opensupplyhub/ci-deployment
 * [OSDEV-894](https://opensupplyhub.atlassian.net/browse/OSDEV-894) Implement Contricleaner library into create facility API endpoint (`facilities_view_set.py`)
-* [OSDEV-536](https://opensupplyhub.atlassian.net/browse/OSDEV-536) In the Contricleaner library, implement parsing of fields `sector_product_type`, `sector`, and `product_type` based on commas and vertical bars. 
-* [OSDEV-760](https://opensupplyhub.atlassian.net/browse/OSDEV-760) In the Contricleaner library, implement parsing of fields `facility_type_processing_type`, `facility_type`, and `processing_type` based on commas and vertical bars. 
+* [OSDEV-536](https://opensupplyhub.atlassian.net/browse/OSDEV-536) In the Contricleaner library, implement parsing of fields `sector_product_type`, `sector`, and `product_type` based on commas and vertical bars.
+* [OSDEV-760](https://opensupplyhub.atlassian.net/browse/OSDEV-760) In the Contricleaner library, implement parsing of fields `facility_type_processing_type`, `facility_type`, and `processing_type` based on commas and vertical bars.
 * [OSDEV-893](https://opensupplyhub.atlassian.net/browse/OSDEV-893) - Implement the ContriCleaner parser for parsing facility lists immediately after list upload.
 
 ### Bugfix


### PR DESCRIPTION
 [OSDEV-857](https://opensupplyhub.atlassian.net/browse/OSDEV-857) [Bug] Pre-prod isn't deleted by the 'terraform destroy' script. 
 
 * Command for destroying ecr repositories on AWS pre-prod has been added.
 ( Need to add settings to the command for destroying DB Instance to complete the job)