### PR TITLE
[OSDEV-571] Claimed Facility Details. Make the "Sector" field a dropdown instead of free text field

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-660](https://opensupplyhub.atlassian.net/browse/OSDEV-660) - Remove punctuation issues with duplicated commas and double quotes while facility list uploading.
 
 ### What's new
+* [OSDEV-571](https://opensupplyhub.atlassian.net/browse/OSDEV-571) Claimed Facility Details. Make the "Sector" field a dropdown instead of free text field. The `Sector` field became a dropdown that is pre-populated with the platform’s sector list from Django.
 * [OSDEV-962](https://opensupplyhub.atlassian.net/browse/OSDEV-962) Update Release protocol. The Release protocol has been updated after the automatization of manual processes such as creating a release branch, restoring DB, deploy to AWS.
 * [OSDEV-972](https://opensupplyhub.atlassian.net/browse/OSDEV-972) Reporting. Updating "Facility Uploads" report. Joined one table from two reports and added columns.New table with such columns:
 `month`, `Total # of list uploads` in a given month (these are uploads that come from external contributors, NOT OS Hub team members), `# of public list uploads` in a given month (these are uploads that come from OS Hub team members AND have “[Public List]” in the contributor name), `Total facility listItems` uploaded in a given month, `# of Facilities` from Public Lists, `Total Facilities w/ status = new facility`, `# Public List Facilities w/ status = new facility`. Data is ordered from most recent to oldest

--- a/src/app/src/components/ClaimedFacilitiesDetails.jsx
+++ b/src/app/src/components/ClaimedFacilitiesDetails.jsx
@@ -473,9 +473,8 @@ function ClaimedFacilitiesDetails({
                     disabled={updating}
                     isSelect
                     isMultiSelect
-                    isCreatable
                     selectOptions={sectorOptions || []}
-                    selectPlaceholder="e.g. Apparel - Use <Enter> or <Tab> to add multiple values"
+                    selectPlaceholder="Select..."
                 />
                 <InputSection label="Product Types" />
                 <InputSection


### PR DESCRIPTION
[OSDEV-571](https://opensupplyhub.atlassian.net/browse/OSDEV-571) Claimed Facility Details. Make the "Sector" field a dropdown instead of free text field.

* The Sector field became a dropdown that is pre-populated with the platform’s sector list from Django.