### PR TITLE
[OSDEV-745] New "Portuguese" translated resources option is not visible on production website.

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -27,7 +27,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### What's new
 * [OSDEV-945](https://opensupplyhub.atlassian.net/browse/OSDEV-945) - Facility Claim. Update text of claim link on profile to "I want to claim this site"
-* [OSDEV-745](https://opensupplyhub.atlassian.net/browse/OSDEV-745) - New "Portuguese" translated resources option is not visible on production website.
+* [OSDEV-745](https://opensupplyhub.atlassian.net/browse/OSDEV-745) - New "Portuguese" translated resources option added to international menu.
 
 ## Release 1.11.0
 

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### What's new
 * [OSDEV-945](https://opensupplyhub.atlassian.net/browse/OSDEV-945) - Facility Claim. Update text of claim link on profile to "I want to claim this site"
+* [OSDEV-745](https://opensupplyhub.atlassian.net/browse/OSDEV-745) - New "Portuguese" translated resources option is not visible on production website.
 
 ## Release 1.11.0
 

--- a/src/app/src/components/Navbar/InternationalMenu.jsx
+++ b/src/app/src/components/Navbar/InternationalMenu.jsx
@@ -57,6 +57,13 @@ function Submenu() {
                 </a>
                 <a
                     className="nav-submenu__link "
+                    href="https://info.opensupplyhub.org/brasil"
+                    target=""
+                >
+                    <span>Portuguese</span>
+                </a>
+                <a
+                    className="nav-submenu__link "
                     href="https://info.opensupplyhub.org/turkey"
                     target=""
                 >

--- a/src/app/src/components/Navbar/MobileInternationalMenu.jsx
+++ b/src/app/src/components/Navbar/MobileInternationalMenu.jsx
@@ -68,6 +68,15 @@ export default function MobileInternationalMenu({
                 <div className="mobile-nav__item">
                     <a
                         className="mobile-nav-link "
+                        href="https://info.opensupplyhub.org/brasil"
+                        target=""
+                    >
+                        Portuguese
+                    </a>
+                </div>
+                <div className="mobile-nav__item">
+                    <a
+                        className="mobile-nav-link "
                         href="https://info.opensupplyhub.org/turkey"
                         target=""
                     >


### PR DESCRIPTION
[OSDEV-745](https://opensupplyhub.atlassian.net/browse/OSDEV-745) New "Portuguese" translated resources option is not visible on production website.
- Added Portuguese" translated resources to International menu