### PR TITLE
Decrease the number of containers for prod and preprod environments

### DIFF
--- a/deployment/environments/terraform-preprod.tfvars
+++ b/deployment/environments/terraform-preprod.tfvars
@@ -23,7 +23,7 @@ rds_database_name = "opensupplyhub" # secure
 rds_multi_az = false # secure
 rds_storage_encrypted = true # secure
 
-app_ecs_desired_count = "16" # secure
+app_ecs_desired_count = "12" # secure
 app_ecs_deployment_min_percent = "100" # secure
 app_ecs_deployment_max_percent = "400" # secure
 app_fargate_cpu = "2048" # secure

--- a/deployment/environments/terraform-production.tfvars
+++ b/deployment/environments/terraform-production.tfvars
@@ -22,7 +22,7 @@ rds_database_name = "opensupplyhub"
 rds_multi_az = true
 rds_storage_encrypted = true
 
-app_ecs_desired_count = "16"
+app_ecs_desired_count = "12"
 app_ecs_deployment_min_percent = "100"
 app_ecs_deployment_max_percent = "400"
 app_ecs_grace_period_seconds = "420"

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -9,11 +9,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * Product name: Open Supply Hub
 * Release date: April 20, 2024
 
-### Database changes
-#### Migrations:
-
-#### Scheme changes
-
 ### Code/API changes
 * [OSDEV-923](https://opensupplyhub.atlassian.net/browse/OSDEV-923) [Uptime] Added more logs around API/List uploads & Dedupe Hub match processing
 * [OSDEV-606](https://opensupplyhub.atlassian.net/browse/OSDEV-606) Contributor Sort: Allow for ascending sort of contributors on the Map page. The sort_by parameter submits type of sorting order for facilities. Default sorting will be primary by public contributors count descending and secondary by name ascending/descending and contributors count ascending.
@@ -30,6 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   * creates temporary postgresdb instance from latest production snaphsot in the `test` AWS account
   * run anonymization query 
   * saves anonymized snapshot and removes the instance
+* In response to recent stability observations, resource allocation has been optimized, reducing the number of containers in both production and pre-production environments from 16 to 12, maintaining system stability.
 
 ### Bugfix
 * [OSDEV-996](https://opensupplyhub.atlassian.net/browse/OSDEV-996) The default sorting order for embedded maps was broken (changed to Descending by # Contributors). The default sorting order for embedded maps has been fixed (changed it back to Ascending by Name).
@@ -49,6 +45,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 `month`, `Total # of list uploads` in a given month (these are uploads that come from external contributors, NOT OS Hub team members), `# of public list uploads` in a given month (these are uploads that come from OS Hub team members AND have “[Public List]” in the contributor name), `Total facility listItems` uploaded in a given month, `# of Facilities` from Public Lists, `Total Facilities w/ status = new facility`, `# Public List Facilities w/ status = new facility`. Data is ordered from most recent to oldest
 * [OSDEV-913](https://opensupplyhub.atlassian.net/browse/OSDEV-913) Claim. Updated the submitted claim auto-reply message for email template.
 * [OSDEV-914](https://opensupplyhub.atlassian.net/browse/OSDEV-914) Claim. Updated the approved claim auto-reply message for email template
+
+### Release instructions:
+* Update code.
+
 
 ## Release 1.10.0
 
@@ -100,6 +100,7 @@ Move `countries` to a separate module so that it becomes possible to use both `d
 ### Release instructions:
 * Update code.
 * Apply DB migrations up to the latest one.
+
 
 ## Release 1.9.0
 

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -25,7 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   * creates temporary postgresdb instance from latest production snaphsot in the `test` AWS account
   * run anonymization query 
   * saves anonymized snapshot and removes the instance
-* In response to recent stability observations, resource allocation has been optimized, reducing the number of containers in both production and pre-production environments from 16 to 12, maintaining system stability.
+* In response to recent stability observations, resource allocation has been optimized, reducing the number of ECS tasks in both production and pre-production environments from 16 to 12, maintaining system stability.
 
 ### Bugfix
 * [OSDEV-996](https://opensupplyhub.atlassian.net/browse/OSDEV-996) The default sorting order for embedded maps was broken (changed to Descending by # Contributors). The default sorting order for embedded maps has been fixed (changed it back to Ascending by Name).


### PR DESCRIPTION
The production environment seems stable enough even with fewer workers/containers than usual. We've been running with 12 for the past two days, so there's no need to spend money on 16. That's why we've decided to decrease the number of containers for the prod and preprod environments to 12.