### PR TITLE
[OSDEV-997] Facility Claims. Send messages to claimant from the claim request page.

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -19,6 +19,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Code/API changes
 * [OSDEV-1021](https://opensupplyhub.atlassian.net/browse/OSDEV-1021) Update the release protocol. The release protocol has been updated with the recent changes. Has been added the section about reloading DedupeHub and QA notification.
+* [OSDEV-997](https://opensupplyhub.atlassian.net/browse/OSDEV-997) - A new method, `message_claimant`, was added to the `FacilityClaimViewSet` for handling a POST request on the url-path `message-claimant` for messages to the claimant. 
+Mail templates for the message to the claimant and the claims team signature were also added.
 
 ### Architecture/Environment changes
 * [OSDEV-862](https://opensupplyhub.atlassian.net/browse/OSDEV-862) Fix `DB - Save Anonymized DB` / `DB - Apply Anonymized DB` workflows:
@@ -48,6 +50,7 @@ database:
     * Made the Email field in the claim form uneditable, setting the claimer's email as the default value for this field.
     * Removed the _Preferred method of contact_ field from both the claim form and the claim details page in the admin dashboard.
     * Implemented redirecting a user to the claim page after navigating to the login page via the CTA link on the claim page for unauthorized users and successful login.
+* [OSDEV-997](https://opensupplyhub.atlassian.net/browse/OSDEV-997) - Facility Claims. A new button, 'Message Claimant' has been added to the update status controls on the Facility Claim Details page. After successfully sending a message, the message text is recorded in the Claim Review Notes.
 
 ### Release instructions:
 * Update code.

--- a/src/app/src/__tests__/components/ClaimFacilityDashboardControls.test.js
+++ b/src/app/src/__tests__/components/ClaimFacilityDashboardControls.test.js
@@ -168,4 +168,30 @@ describe("DashboardClaimsDetailsControls", () => {
       expect(store.getActions()).toContainEqual(expectedSuccessAction);
     });
   });
+
+  test("handles message claimant action with failed response", async () => {
+    const message = "Message to claimant.";
+    const expectedFailureAction = {
+      error: false,
+      payload: ["An error prevented messaging to facility claimant"],
+      type: "FAIL_MESSAGE_FACILITY_CLAIMANT",
+    };
+    apiRequest.post.mockRejectedValue(new Error("Failed to message claimant."));
+
+    const { getByText, getByLabelText } = renderComponent(
+      store,
+      defaultProps,
+    );
+    fireEvent.click(getByText("Message Claimant"));
+    const input = getByLabelText(
+      "Enter a message. (This will be emailed to the contact email associated with this claim.)",
+    );
+    fireEvent.change(input, { target: { value: message } });
+    fireEvent.click(getByText("message"));
+
+    await waitFor(() => {
+      expect(apiRequest.post).toHaveBeenCalledWith(expect.anything(), { message });
+      expect(store.getActions()).toContainEqual(expectedFailureAction);
+    });
+  });
 });

--- a/src/app/src/__tests__/components/ClaimFacilityDashboardControls.test.js
+++ b/src/app/src/__tests__/components/ClaimFacilityDashboardControls.test.js
@@ -1,0 +1,154 @@
+import React, { useState } from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import DashboardClaimsDetailsControls from '../../components/DashboardClaimDetailsControls';
+import { Provider } from 'react-redux';
+import { store } from '../../configureStore';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+const middlewares = [thunk];
+const mockStore = configureStore(middlewares);
+
+describe('DashboardClaimsDetailsControls', () => {
+  const defaultProps = {
+    data: {
+      id: 1,
+      status: 'PENDING',
+      created_at: '2020-01-01T00:00:00Z',
+      updated_at: '2020-01-01T00:00:00Z',
+      contact_person: 'John Doe',
+      job_title: 'Manager',
+      email: 'john@gmail.com',
+      phone_number: '123-456-7890',
+      company_name: 'Test Company',
+      website: 'http://www.test.com',
+      facility_description: 'Test description',
+      linkedin_profile: 'http://www.linkedin.com',
+      contributor: {},
+      facility: {
+        id: '1',
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [-122.4194, 37.7749],
+        },
+        properties: {
+          name: 'Test Facility',
+          address: '123 Test St',
+          country_code: 'US',
+          country_name: 'United States',
+        },
+      },
+      status_change: {
+        status_change_by: '',
+        status_change_date: '2020-01-01T00:00:00Z',
+        status_change_reason: '',
+      },
+      notes: [
+        {
+          id: 1,
+          note: 'Test note',
+          created_at: '2020-01-01T00:00:00Z',
+          updated_at: '2020-01-01T00:00:00Z',
+        },
+      ],
+      attachments: [
+        {
+         file_name: 'test.pdf',
+         claim_attachment: 'test.pdf',
+        },
+      ],
+
+
+
+
+    },
+    fetching: false,
+    error: null,
+    messageClaimant: jest.fn(),
+    approveClaim: jest.fn(),
+    denyClaim: jest.fn(),
+    revokeClaim: jest.fn(),
+  };
+
+  let initialState
+
+  beforeEach(() => {
+    initialState = mockStore({
+      claimFacilityDashboard : {
+        statusControls: {
+            fetching: false,
+            error: null
+        },
+        note: {
+            note: "",
+            fetching: false,
+            error: null
+        }
+      }
+    })
+  })  
+
+  test('renders without crashing', () => {
+    render(
+      <Provider store={initialState}>
+        <DashboardClaimsDetailsControls {...defaultProps} />
+      </Provider>
+    );
+  });
+
+  test('renders correct buttons for pending status', () => {
+    const { getByText, queryByText } = render(
+      <Provider store={initialState}>
+        <DashboardClaimsDetailsControls {...defaultProps} />
+      </Provider>
+    );
+    expect(getByText('Message Claimant')).toBeInTheDocument();
+    expect(getByText('Approve Claim')).toBeInTheDocument();
+    expect(getByText('Deny Claim')).toBeInTheDocument();
+    expect(queryByText('Revoke Claim')).not.toBeInTheDocument();
+  });
+
+  test('renders correct button for approved status', () => {
+    const props = {
+      ...defaultProps,
+      data: { ...defaultProps.data, status: 'APPROVED' },
+    };
+    const { getByText, queryByText } = render(
+      <Provider store={initialState}>
+        <DashboardClaimsDetailsControls {...props} />
+      </Provider>
+    );
+    expect(getByText('Revoke Claim')).toBeInTheDocument();
+    expect(queryByText('Message Claimant')).not.toBeInTheDocument();
+    expect(queryByText('Approve Claim')).not.toBeInTheDocument();
+    expect(queryByText('Deny Claim')).not.toBeInTheDocument();
+  });
+
+  test('opens and closes dialog', async () => {
+    const { getByText, getByLabelText, queryByText } = render(
+      <Provider store={initialState}>
+        <DashboardClaimsDetailsControls {...defaultProps} />
+      </Provider>
+    );
+    fireEvent.click(getByText('Message Claimant'));
+    expect(getByText('Send a message to claimant?')).toBeInTheDocument();
+    expect(getByLabelText('Enter a message. (This will be emailed to the contact email associated with this claim.)')).toBeInTheDocument();
+    fireEvent.click(getByText('Cancel'));
+    await waitFor(() => {
+      expect(queryByText('Send a message to claimant?')).not.toBeInTheDocument();
+    });
+  });
+
+  test('updates message to claimant text', async () => {
+    const { getByText, getByLabelText } = render(
+      <Provider store={initialState}>
+        <DashboardClaimsDetailsControls {...defaultProps} />
+      </Provider>
+    );
+    fireEvent.click(getByText('Message Claimant'));
+    const input = getByLabelText('Enter a message. (This will be emailed to the contact email associated with this claim.)');
+    fireEvent.change(input, { target: { value: 'Message to claimant.' } });
+    expect(input.value).toBe('Message to claimant.');
+  });
+});

--- a/src/app/src/__tests__/components/ClaimFacilityDashboardControls.test.js
+++ b/src/app/src/__tests__/components/ClaimFacilityDashboardControls.test.js
@@ -4,13 +4,13 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import thunk from "redux-thunk";
 import DashboardClaimsDetailsControls from "../../components/DashboardClaimDetailsControls";
-import apiRequest from '../../util/apiRequest';
+import apiRequest from "../../util/apiRequest";
 
-jest.mock('../../util/apiRequest', () => ({
-  __esModule: true, 
+jest.mock("../../util/apiRequest", () => ({
+  __esModule: true,
   default: {
     post: jest.fn(),
-  }
+  },
 }));
 
 const middlewares = [thunk];
@@ -122,15 +122,14 @@ describe("DashboardClaimsDetailsControls", () => {
     ).toBeInTheDocument();
     fireEvent.click(getByText("Cancel"));
     await waitFor(() => {
-      expect(queryByText("Send a message to claimant?")).not.toBeInTheDocument();
+      expect(
+        queryByText("Send a message to claimant?"),
+      ).not.toBeInTheDocument();
     });
   });
 
   test("updates message to claimant text", async () => {
-    const { getByText, getByLabelText } = renderComponent(
-      store,
-      defaultProps,
-    );
+    const { getByText, getByLabelText } = renderComponent(store, defaultProps);
     fireEvent.click(getByText("Message Claimant"));
     const input = getByLabelText(
       "Enter a message. (This will be emailed to the contact email associated with this claim.)",
@@ -152,10 +151,7 @@ describe("DashboardClaimsDetailsControls", () => {
       data: { notes: [{ id: 1, note: message }] },
     });
 
-    const { getByText, getByLabelText } = renderComponent(
-      store,
-      defaultProps,
-    );
+    const { getByText, getByLabelText } = renderComponent(store, defaultProps);
     fireEvent.click(getByText("Message Claimant"));
     const input = getByLabelText(
       "Enter a message. (This will be emailed to the contact email associated with this claim.)",
@@ -164,7 +160,9 @@ describe("DashboardClaimsDetailsControls", () => {
     fireEvent.click(getByText("message"));
 
     await waitFor(() => {
-      expect(apiRequest.post).toHaveBeenCalledWith(expect.anything(), { message });
+      expect(apiRequest.post).toHaveBeenCalledWith(expect.anything(), {
+        message,
+      });
       expect(store.getActions()).toContainEqual(expectedSuccessAction);
     });
   });
@@ -178,10 +176,7 @@ describe("DashboardClaimsDetailsControls", () => {
     };
     apiRequest.post.mockRejectedValue(new Error("Failed to message claimant."));
 
-    const { getByText, getByLabelText } = renderComponent(
-      store,
-      defaultProps,
-    );
+    const { getByText, getByLabelText } = renderComponent(store, defaultProps);
     fireEvent.click(getByText("Message Claimant"));
     const input = getByLabelText(
       "Enter a message. (This will be emailed to the contact email associated with this claim.)",
@@ -190,7 +185,9 @@ describe("DashboardClaimsDetailsControls", () => {
     fireEvent.click(getByText("message"));
 
     await waitFor(() => {
-      expect(apiRequest.post).toHaveBeenCalledWith(expect.anything(), { message });
+      expect(apiRequest.post).toHaveBeenCalledWith(expect.anything(), {
+        message,
+      });
       expect(store.getActions()).toContainEqual(expectedFailureAction);
     });
   });

--- a/src/app/src/__tests__/components/ClaimFacilityDashboardControls.test.js
+++ b/src/app/src/__tests__/components/ClaimFacilityDashboardControls.test.js
@@ -1,10 +1,14 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import DashboardClaimsDetailsControls from '../../components/DashboardClaimDetailsControls';
 import { Provider } from 'react-redux';
-import { store } from '../../configureStore';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import { post as mockPost } from '../../util/apiRequest';
+
+jest.mock('../../util/apiRequest', () => ({
+  post: jest.fn()
+}));
 
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
@@ -58,10 +62,6 @@ describe('DashboardClaimsDetailsControls', () => {
          claim_attachment: 'test.pdf',
         },
       ],
-
-
-
-
     },
     fetching: false,
     error: null,
@@ -87,6 +87,7 @@ describe('DashboardClaimsDetailsControls', () => {
         }
       }
     })
+    mockPost.mockClear();
   })  
 
   test('renders without crashing', () => {
@@ -150,5 +151,40 @@ describe('DashboardClaimsDetailsControls', () => {
     const input = getByLabelText('Enter a message. (This will be emailed to the contact email associated with this claim.)');
     fireEvent.change(input, { target: { value: 'Message to claimant.' } });
     expect(input.value).toBe('Message to claimant.');
+  });
+
+  test('dispatches message claimant action and handles response', async () => {
+    const message = 'Message to claimant.';
+    const expectedSuccessAction = {
+        error: false, 
+        payload: {
+          notes: [
+            {id: 1, note: "Message to claimant."}
+          ]
+        }, 
+        type: "COMPLETE_MESSAGE_FACILITY_CLAIMANT"
+      }
+    
+    // Setup mock to resolve with specific data
+    mockPost.mockResolvedValue({
+      data: { notes: [{ id: 1, note: message }] }
+    });
+
+    const { getByText, getByLabelText } = render(
+      <Provider store={initialState}>
+        <DashboardClaimsDetailsControls {...defaultProps} />
+      </Provider>
+    );
+
+    fireEvent.click(getByText('Message Claimant'));
+    const input = getByLabelText('Enter a message. (This will be emailed to the contact email associated with this claim.)');
+    fireEvent.change(input, { target: { value: message } });
+    fireEvent.click(getByText('message'));
+
+    // Wait for async actions to settle
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith(expect.anything(), { message });
+      expect(initialState.getActions()).toContainEqual(expectedSuccessAction);
+    });
   });
 });

--- a/src/app/src/__tests__/components/ClaimFacilityDashboardControls.test.js
+++ b/src/app/src/__tests__/components/ClaimFacilityDashboardControls.test.js
@@ -1,13 +1,16 @@
 import React from "react";
 import { render, fireEvent, waitFor } from "@testing-library/react";
-import DashboardClaimsDetailsControls from "../../components/DashboardClaimDetailsControls";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import thunk from "redux-thunk";
-import { post as mockPost } from "../../util/apiRequest";
+import DashboardClaimsDetailsControls from "../../components/DashboardClaimDetailsControls";
+import apiRequest from '../../util/apiRequest';
 
-jest.mock("../../util/apiRequest", () => ({
-  post: jest.fn(),
+jest.mock('../../util/apiRequest', () => ({
+  __esModule: true, 
+  default: {
+    post: jest.fn(),
+  }
 }));
 
 const middlewares = [thunk];
@@ -82,7 +85,8 @@ describe("DashboardClaimsDetailsControls", () => {
         },
       },
     });
-    mockPost.mockClear();
+
+    apiRequest.post.mockClear();
   });
 
   test("renders without crashing", () => {
@@ -149,7 +153,7 @@ describe("DashboardClaimsDetailsControls", () => {
       },
       type: "COMPLETE_MESSAGE_FACILITY_CLAIMANT",
     };
-    mockPost.mockResolvedValue({
+    apiRequest.post.mockResolvedValue({
       data: { notes: [{ id: 1, note: message }] },
     });
 
@@ -165,7 +169,7 @@ describe("DashboardClaimsDetailsControls", () => {
     fireEvent.click(getByText("message"));
 
     await waitFor(() => {
-      expect(mockPost).toHaveBeenCalledWith(expect.anything(), { message });
+      expect(apiRequest.post).toHaveBeenCalledWith(expect.anything(), { message });
       expect(store.getActions()).toContainEqual(expectedSuccessAction);
     });
   });

--- a/src/app/src/__tests__/components/ClaimFacilityDashboardControls.test.js
+++ b/src/app/src/__tests__/components/ClaimFacilityDashboardControls.test.js
@@ -1,67 +1,62 @@
-import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react';
-import DashboardClaimsDetailsControls from '../../components/DashboardClaimDetailsControls';
-import { Provider } from 'react-redux';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-import { post as mockPost } from '../../util/apiRequest';
+import React from "react";
+import { render, fireEvent, waitFor } from "@testing-library/react";
+import DashboardClaimsDetailsControls from "../../components/DashboardClaimDetailsControls";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import thunk from "redux-thunk";
+import { post as mockPost } from "../../util/apiRequest";
 
-jest.mock('../../util/apiRequest', () => ({
-  post: jest.fn()
+jest.mock("../../util/apiRequest", () => ({
+  post: jest.fn(),
 }));
 
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
 
-describe('DashboardClaimsDetailsControls', () => {
+const renderComponent = (store, props) =>
+  render(
+    <Provider store={store}>
+      <DashboardClaimsDetailsControls {...props} />
+    </Provider>,
+  );
+
+describe("DashboardClaimsDetailsControls", () => {
   const defaultProps = {
     data: {
       id: 1,
-      status: 'PENDING',
-      created_at: '2020-01-01T00:00:00Z',
-      updated_at: '2020-01-01T00:00:00Z',
-      contact_person: 'John Doe',
-      job_title: 'Manager',
-      email: 'john@gmail.com',
-      phone_number: '123-456-7890',
-      company_name: 'Test Company',
-      website: 'http://www.test.com',
-      facility_description: 'Test description',
-      linkedin_profile: 'http://www.linkedin.com',
+      status: "PENDING",
+      created_at: "2020-01-01T00:00:00Z",
+      updated_at: "2020-01-01T00:00:00Z",
+      contact_person: "John Doe",
+      job_title: "Manager",
+      email: "john@gmail.com",
+      phone_number: "123-456-7890",
+      company_name: "Test Company",
+      website: "http://www.test.com",
+      facility_description: "Test description",
+      linkedin_profile: "http://www.linkedin.com",
       contributor: {},
       facility: {
-        id: '1',
-        type: 'Feature',
+        id: "1",
+        type: "Feature",
         geometry: {
-          type: 'Point',
+          type: "Point",
           coordinates: [-122.4194, 37.7749],
         },
         properties: {
-          name: 'Test Facility',
-          address: '123 Test St',
-          country_code: 'US',
-          country_name: 'United States',
+          name: "Test Facility",
+          address: "123 Test St",
+          country_code: "US",
+          country_name: "United States",
         },
       },
       status_change: {
-        status_change_by: '',
-        status_change_date: '2020-01-01T00:00:00Z',
-        status_change_reason: '',
+        status_change_by: "",
+        status_change_date: "",
+        status_change_reason: "",
       },
-      notes: [
-        {
-          id: 1,
-          note: 'Test note',
-          created_at: '2020-01-01T00:00:00Z',
-          updated_at: '2020-01-01T00:00:00Z',
-        },
-      ],
-      attachments: [
-        {
-         file_name: 'test.pdf',
-         claim_attachment: 'test.pdf',
-        },
-      ],
+      notes: [],
+      attachments: [],
     },
     fetching: false,
     error: null,
@@ -71,120 +66,99 @@ describe('DashboardClaimsDetailsControls', () => {
     revokeClaim: jest.fn(),
   };
 
-  let initialState
+  let store;
 
   beforeEach(() => {
-    initialState = mockStore({
-      claimFacilityDashboard : {
+    store = mockStore({
+      claimFacilityDashboard: {
         statusControls: {
-            fetching: false,
-            error: null
+          fetching: false,
+          error: null,
         },
         note: {
-            note: "",
-            fetching: false,
-            error: null
-        }
-      }
-    })
+          note: "",
+          fetching: false,
+          error: null,
+        },
+      },
+    });
     mockPost.mockClear();
-  })  
-
-  test('renders without crashing', () => {
-    render(
-      <Provider store={initialState}>
-        <DashboardClaimsDetailsControls {...defaultProps} />
-      </Provider>
-    );
   });
 
-  test('renders correct buttons for pending status', () => {
-    const { getByText, queryByText } = render(
-      <Provider store={initialState}>
-        <DashboardClaimsDetailsControls {...defaultProps} />
-      </Provider>
-    );
-    expect(getByText('Message Claimant')).toBeInTheDocument();
-    expect(getByText('Approve Claim')).toBeInTheDocument();
-    expect(getByText('Deny Claim')).toBeInTheDocument();
-    expect(queryByText('Revoke Claim')).not.toBeInTheDocument();
+  test("renders without crashing", () => {
+    renderComponent(store, defaultProps);
   });
 
-  test('renders correct button for approved status', () => {
+  test("renders correct buttons for pending status", () => {
+    const { getByText, queryByText } = renderComponent(store, defaultProps);
+    expect(getByText("Message Claimant")).toBeInTheDocument();
+    expect(getByText("Approve Claim")).toBeInTheDocument();
+    expect(getByText("Deny Claim")).toBeInTheDocument();
+    expect(queryByText("Revoke Claim")).not.toBeInTheDocument();
+  });
+
+  test("renders correct button for approved status", () => {
     const props = {
       ...defaultProps,
-      data: { ...defaultProps.data, status: 'APPROVED' },
+      data: { ...defaultProps.data, status: "APPROVED" },
     };
-    const { getByText, queryByText } = render(
-      <Provider store={initialState}>
-        <DashboardClaimsDetailsControls {...props} />
-      </Provider>
-    );
-    expect(getByText('Revoke Claim')).toBeInTheDocument();
-    expect(queryByText('Message Claimant')).not.toBeInTheDocument();
-    expect(queryByText('Approve Claim')).not.toBeInTheDocument();
-    expect(queryByText('Deny Claim')).not.toBeInTheDocument();
+    const { getByText, queryByText } = renderComponent(store, props);
+    expect(getByText("Revoke Claim")).toBeInTheDocument();
+    expect(queryByText("Message Claimant")).not.toBeInTheDocument();
+    expect(queryByText("Approve Claim")).not.toBeInTheDocument();
+    expect(queryByText("Deny Claim")).not.toBeInTheDocument();
   });
 
-  test('opens and closes dialog', async () => {
-    const { getByText, getByLabelText, queryByText } = render(
-      <Provider store={initialState}>
-        <DashboardClaimsDetailsControls {...defaultProps} />
-      </Provider>
+  test("opens and closes dialog", async () => {
+    const { getByText, getByLabelText, queryByText } = renderComponent(
+      store,
+      defaultProps,
     );
-    fireEvent.click(getByText('Message Claimant'));
-    expect(getByText('Send a message to claimant?')).toBeInTheDocument();
-    expect(getByLabelText('Enter a message. (This will be emailed to the contact email associated with this claim.)')).toBeInTheDocument();
-    fireEvent.click(getByText('Cancel'));
-    await waitFor(() => {
-      expect(queryByText('Send a message to claimant?')).not.toBeInTheDocument();
-    });
+    fireEvent.click(getByText("Message Claimant"));
+    expect(getByText("Send a message to claimant?")).toBeInTheDocument();
+    expect(
+      getByLabelText(
+        "Enter a message. (This will be emailed to the contact email associated with this claim.)",
+      ),
+    ).toBeInTheDocument();
+    fireEvent.click(getByText("Cancel"));
+    expect(queryByText("Send a message to claimant?")).not.toBeInTheDocument();
   });
 
-  test('updates message to claimant text', async () => {
-    const { getByText, getByLabelText } = render(
-      <Provider store={initialState}>
-        <DashboardClaimsDetailsControls {...defaultProps} />
-      </Provider>
+  test("updates message to claimant text", async () => {
+    const { getByText, getByLabelText } = renderComponent(store, defaultProps);
+    fireEvent.click(getByText("Message Claimant"));
+    const input = getByLabelText(
+      "Enter a message. (This will be emailed to the contact email associated with this claim.)",
     );
-    fireEvent.click(getByText('Message Claimant'));
-    const input = getByLabelText('Enter a message. (This will be emailed to the contact email associated with this claim.)');
-    fireEvent.change(input, { target: { value: 'Message to claimant.' } });
-    expect(input.value).toBe('Message to claimant.');
+    fireEvent.change(input, { target: { value: "Message to claimant." } });
+    expect(input.value).toBe("Message to claimant.");
   });
 
-  test('dispatches message claimant action and handles response', async () => {
-    const message = 'Message to claimant.';
+  test("dispatches message claimant action and handles response", async () => {
+    const message = "Message to claimant.";
     const expectedSuccessAction = {
-        error: false, 
-        payload: {
-          notes: [
-            {id: 1, note: "Message to claimant."}
-          ]
-        }, 
-        type: "COMPLETE_MESSAGE_FACILITY_CLAIMANT"
-      }
-    
-    // Setup mock to resolve with specific data
+      error: false,
+      payload: {
+        notes: [{ id: 1, note: "Message to claimant." }],
+      },
+      type: "COMPLETE_MESSAGE_FACILITY_CLAIMANT",
+    };
     mockPost.mockResolvedValue({
-      data: { notes: [{ id: 1, note: message }] }
+      data: { notes: [{ id: 1, note: message }] },
     });
 
-    const { getByText, getByLabelText } = render(
-      <Provider store={initialState}>
-        <DashboardClaimsDetailsControls {...defaultProps} />
-      </Provider>
+    const { getByText, getByLabelText } = renderComponent(store, defaultProps);
+    fireEvent.click(getByText("Message Claimant"));
+    const input = getByLabelText(
+      "Enter a message. (This will be emailed to the contact email associated with this claim.)",
     );
-
-    fireEvent.click(getByText('Message Claimant'));
-    const input = getByLabelText('Enter a message. (This will be emailed to the contact email associated with this claim.)');
     fireEvent.change(input, { target: { value: message } });
-    fireEvent.click(getByText('message'));
+    fireEvent.click(getByText("message"));
 
-    // Wait for async actions to settle
     await waitFor(() => {
       expect(mockPost).toHaveBeenCalledWith(expect.anything(), { message });
-      expect(initialState.getActions()).toContainEqual(expectedSuccessAction);
+      expect(store.getActions()).toContainEqual(expectedSuccessAction);
     });
   });
 });

--- a/src/app/src/__tests__/components/ClaimFacilityDashboardControls.test.js
+++ b/src/app/src/__tests__/components/ClaimFacilityDashboardControls.test.js
@@ -78,11 +78,6 @@ describe("DashboardClaimsDetailsControls", () => {
           fetching: false,
           error: null,
         },
-        note: {
-          note: "",
-          fetching: false,
-          error: null,
-        },
       },
     });
 
@@ -113,7 +108,7 @@ describe("DashboardClaimsDetailsControls", () => {
     expect(queryByText("Deny Claim")).not.toBeInTheDocument();
   });
 
-  test("opens and closes dialog", async () => {
+  test("toggles message dialog visibility", async () => {
     const { getByText, getByLabelText, queryByText } = renderComponent(
       store,
       defaultProps,
@@ -126,9 +121,9 @@ describe("DashboardClaimsDetailsControls", () => {
       ),
     ).toBeInTheDocument();
     fireEvent.click(getByText("Cancel"));
-    expect(
-      queryByText("Send a message to claimant?"),
-    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(queryByText("Send a message to claimant?")).not.toBeInTheDocument();
+    });
   });
 
   test("updates message to claimant text", async () => {
@@ -144,7 +139,7 @@ describe("DashboardClaimsDetailsControls", () => {
     expect(input.value).toBe("Message to claimant.");
   });
 
-  test("dispatches message claimant action and handles response", async () => {
+  test("handles message claimant action with successful response", async () => {
     const message = "Message to claimant.";
     const expectedSuccessAction = {
       error: false,

--- a/src/app/src/__tests__/components/ClaimFacilityDashboardControls.test.js
+++ b/src/app/src/__tests__/components/ClaimFacilityDashboardControls.test.js
@@ -122,11 +122,16 @@ describe("DashboardClaimsDetailsControls", () => {
       ),
     ).toBeInTheDocument();
     fireEvent.click(getByText("Cancel"));
-    expect(queryByText("Send a message to claimant?")).not.toBeInTheDocument();
+    expect(
+      queryByText("Send a message to claimant?"),
+    ).not.toBeInTheDocument();
   });
 
   test("updates message to claimant text", async () => {
-    const { getByText, getByLabelText } = renderComponent(store, defaultProps);
+    const { getByText, getByLabelText } = renderComponent(
+      store,
+      defaultProps,
+    );
     fireEvent.click(getByText("Message Claimant"));
     const input = getByLabelText(
       "Enter a message. (This will be emailed to the contact email associated with this claim.)",
@@ -148,7 +153,10 @@ describe("DashboardClaimsDetailsControls", () => {
       data: { notes: [{ id: 1, note: message }] },
     });
 
-    const { getByText, getByLabelText } = renderComponent(store, defaultProps);
+    const { getByText, getByLabelText } = renderComponent(
+      store,
+      defaultProps,
+    );
     fireEvent.click(getByText("Message Claimant"));
     const input = getByLabelText(
       "Enter a message. (This will be emailed to the contact email associated with this claim.)",

--- a/src/app/src/actions/claimFacilityDashboard.jsx
+++ b/src/app/src/actions/claimFacilityDashboard.jsx
@@ -5,6 +5,7 @@ import apiRequest from '../util/apiRequest';
 import {
     makeGetFacilityClaimsURL,
     logErrorAndDispatchFailure,
+    makeMessageFacilityClaimantByClaimIDURL,
     makeGetFacilityClaimByClaimIDURL,
     makeApproveFacilityClaimByClaimIDURL,
     makeDenyFacilityClaimByClaimIDURL,
@@ -111,6 +112,9 @@ export function fetchSingleFacilityClaim(claimID) {
     };
 }
 
+export const startMessageFacilityClaimant = createAction(
+    'START_MESSAGE_FACILITY_CLAIMANT',
+);
 export const startApproveFacilityClaim = createAction(
     'START_APPROVE_FACILITY_CLAIM',
 );
@@ -118,12 +122,18 @@ export const startDenyFacilityClaim = createAction('START_DENY_FACILITY_CLAIM');
 export const startRevokeFacilityClaim = createAction(
     'START_REVOKE_FACILITY_CLAIM',
 );
+export const failMessageFacilityClaimant = createAction(
+    'FAIL_MESSAGE_FACILITY_CLAIMANT',
+);
 export const failApproveFacilityClaim = createAction(
     'FAIL_APPROVE_FACILITY_CLAIM',
 );
 export const failDenyFacilityClaim = createAction('FAIL_DENY_FACILITY_CLAIM');
 export const failRevokeFacilityClaim = createAction(
     'FAIL_REVOKE_FACILITY_CLAIM',
+);
+export const completeMessageFacilityClaimant = createAction(
+    'COMPLETE_MESSAGE_FACILITY_CLAIMANT',
 );
 export const completeApproveFacilityClaim = createAction(
     'COMPLETE_APPROVE_FACILITY_CLAIM',
@@ -137,6 +147,29 @@ export const completeRevokeFacilityClaim = createAction(
 export const resetFacilityClaimControls = createAction(
     'RESET_FACILITY_CLAIM_CONTROLS',
 );
+
+export function messageFacilityClaimant(claimID, message) {
+    return dispatch => {
+        if (!claimID) {
+            return null;
+        }
+
+        dispatch(startMessageFacilityClaimant());
+
+        return apiRequest
+            .post(makeMessageFacilityClaimantByClaimIDURL(claimID), { message })
+            .then(({ data }) => dispatch(completeMessageFacilityClaimant(data)))
+            .catch(err =>
+                dispatch(
+                    logErrorAndDispatchFailure(
+                        err,
+                        'An error prevented messaging to facility claimant',
+                        failMessageFacilityClaimant,
+                    ),
+                ),
+            );
+    };
+}
 
 export function approveFacilityClaim(claimID, reason = '') {
     return dispatch => {

--- a/src/app/src/components/DashboardClaimDetailsControls.jsx
+++ b/src/app/src/components/DashboardClaimDetailsControls.jsx
@@ -30,6 +30,7 @@ const dialogTypesEnum = Object.freeze({
     APPROVE: 'APPROVE',
     DENY: 'DENY',
     REVOKE: 'REVOKE',
+    MESSAGE_CLAIMANT: 'MESSAGE_CLAIMANT',
 });
 
 const dashboardClaimsControlsStyles = Object.freeze({
@@ -96,6 +97,8 @@ function DashboardClaimsDetailsControls({
     const [statusChangeText, setStatusChangeText] = useState('');
     const [displayedDialogType, setDisplayedDialogType] = useState(null);
 
+    const openMessageClaimantDialog = () =>
+        setDisplayedDialogType(dialogTypesEnum.MESSAGE_CLAIMANT);
     const openApproveDialog = () =>
         setDisplayedDialogType(dialogTypesEnum.APPROVE);
     const openDenyDialog = () => setDisplayedDialogType(dialogTypesEnum.DENY);
@@ -109,6 +112,11 @@ function DashboardClaimsDetailsControls({
 
     const handleUpdateStatusChangeText = e =>
         setStatusChangeText(getValueFromEvent(e));
+
+    const handleMessageClaimant = () => {
+        console.log('Message claimant:', statusChangeText);
+        closeDialog();
+    };
 
     const handleApproveClaim = () => {
         approveClaim(statusChangeText);
@@ -134,7 +142,7 @@ function DashboardClaimsDetailsControls({
             return (
                 <>
                     <Button
-                        onClick={openApproveDialog}
+                        onClick={openMessageClaimantDialog}
                         variant="contained"
                         style={{
                             ...dashboardClaimsControlsStyles.buttonStyles,
@@ -188,20 +196,37 @@ function DashboardClaimsDetailsControls({
         </Typography>
     );
 
+    const dialogInputLabelDefault =
+        'Enter a reason. (This will be emailed to the person who submitted the facility claim.)';
+    const dialogInputLabelMessageClaimant =
+        'Enter a message. (This will be emailed to the contact email associated with this claim.)';
+
     const dialogContentData = get(
         Object.freeze({
+            [dialogTypesEnum.MESSAGE_CLAIMANT]: Object.freeze({
+                title: 'Send a message to claimant?',
+                inputLabel: dialogInputLabelMessageClaimant,
+                action: handleMessageClaimant,
+                actionTerm: 'message',
+                actionButtonStyle: {
+                    backgroundColor: theme.palette.action.main,
+                },
+            }),
             [dialogTypesEnum.APPROVE]: Object.freeze({
                 title: 'Approve this facility claim?',
+                inputLabel: dialogInputLabelDefault,
                 action: handleApproveClaim,
                 actionTerm: 'approve',
             }),
             [dialogTypesEnum.DENY]: Object.freeze({
                 title: 'Deny this facility claim?',
+                inputLabel: dialogInputLabelDefault,
                 action: handleDenyClaim,
                 actionTerm: 'deny',
             }),
             [dialogTypesEnum.REVOKE]: Object.freeze({
                 title: 'Revoke this facility claim?',
+                inputLabel: dialogInputLabelDefault,
                 action: handleRevokeClaim,
                 actionTerm: 'revoke',
             }),
@@ -265,8 +290,7 @@ function DashboardClaimsDetailsControls({
                         <DialogContent>
                             <InputLabel htmlFor="dialog-text-field">
                                 <Typography variant="body2">
-                                    Enter a reason. (This will be emailed to the
-                                    person who submitted the facility claim.)
+                                    {dialogContentData.inputLabel}
                                 </Typography>
                             </InputLabel>
                             <TextField
@@ -298,6 +322,9 @@ function DashboardClaimsDetailsControls({
                                 variant="contained"
                                 color="secondary"
                                 onClick={dialogContentData.action}
+                                style={
+                                    dialogContentData.actionButtonStyle || {}
+                                }
                             >
                                 {dialogContentData.actionTerm}
                             </Button>

--- a/src/app/src/components/DashboardClaimDetailsControls.jsx
+++ b/src/app/src/components/DashboardClaimDetailsControls.jsx
@@ -15,6 +15,7 @@ import get from 'lodash/get';
 import includes from 'lodash/includes';
 
 import {
+    messageFacilityClaimant,
     approveFacilityClaim,
     denyFacilityClaim,
     revokeFacilityClaim,
@@ -89,6 +90,7 @@ function DashboardClaimsDetailsControls({
     data: { id: claimID, status },
     fetching,
     error,
+    messageClaimant,
     approveClaim,
     denyClaim,
     revokeClaim,
@@ -114,7 +116,7 @@ function DashboardClaimsDetailsControls({
         setStatusChangeText(getValueFromEvent(e));
 
     const handleMessageClaimant = () => {
-        console.log('Message claimant:', statusChangeText);
+        messageClaimant(statusChangeText);
         closeDialog();
     };
 
@@ -367,6 +369,8 @@ function mapDispatchToProps(dispatch, { data: { id } }) {
         approveClaim: reason => dispatch(approveFacilityClaim(id, reason)),
         denyClaim: reason => dispatch(denyFacilityClaim(id, reason)),
         revokeClaim: reason => dispatch(revokeFacilityClaim(id, reason)),
+        messageClaimant: message =>
+            dispatch(messageFacilityClaimant(id, message)),
     };
 }
 

--- a/src/app/src/components/DashboardClaimDetailsControls.jsx
+++ b/src/app/src/components/DashboardClaimDetailsControls.jsx
@@ -134,6 +134,14 @@ function DashboardClaimsDetailsControls({
                     <Button
                         onClick={openApproveDialog}
                         variant="contained"
+                        color="action"
+                        style={dashboardClaimsControlsStyles.buttonStyles}
+                    >
+                        Message Claimant
+                    </Button>
+                    <Button
+                        onClick={openApproveDialog}
+                        variant="contained"
                         color="primary"
                         style={dashboardClaimsControlsStyles.buttonStyles}
                     >

--- a/src/app/src/components/DashboardClaimDetailsControls.jsx
+++ b/src/app/src/components/DashboardClaimDetailsControls.jsx
@@ -97,19 +97,30 @@ function DashboardClaimsDetailsControls({
     theme,
 }) {
     const [statusChangeText, setStatusChangeText] = useState('');
+    const [isOpenDialog, setIsOpenDialog] = useState(false);
     const [displayedDialogType, setDisplayedDialogType] = useState(null);
 
-    const openMessageClaimantDialog = () =>
+    const openMessageClaimantDialog = () => {
         setDisplayedDialogType(dialogTypesEnum.MESSAGE_CLAIMANT);
-    const openApproveDialog = () =>
+        setIsOpenDialog(true);
+    };
+    const openApproveDialog = () => {
         setDisplayedDialogType(dialogTypesEnum.APPROVE);
-    const openDenyDialog = () => setDisplayedDialogType(dialogTypesEnum.DENY);
-    const openRevokeDialog = () =>
+        setIsOpenDialog(true);
+    };
+    const openDenyDialog = () => {
+        setDisplayedDialogType(dialogTypesEnum.DENY);
+        setIsOpenDialog(true);
+    };
+    const openRevokeDialog = () => {
         setDisplayedDialogType(dialogTypesEnum.REVOKE);
+        setIsOpenDialog(true);
+    };
 
     const closeDialog = () => {
         setDisplayedDialogType(null);
         setStatusChangeText('');
+        setIsOpenDialog(false);
     };
 
     const handleUpdateStatusChangeText = e =>
@@ -281,7 +292,7 @@ function DashboardClaimsDetailsControls({
                 </div>
             )}
             <Dialog
-                open={displayedDialogType || false}
+                open={isOpenDialog}
                 aria-labelledby="alert-dialog-title"
                 aria-describedby="alert-dialog-description"
                 style={dashboardClaimsControlsStyles.dialogContainerStyles}

--- a/src/app/src/components/DashboardClaimDetailsControls.jsx
+++ b/src/app/src/components/DashboardClaimDetailsControls.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { arrayOf, bool, func, string } from 'prop-types';
 import { connect } from 'react-redux';
+import { withTheme } from '@material-ui/core';
 import Button from '@material-ui/core/Button';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import Typography from '@material-ui/core/Typography';
@@ -90,6 +91,7 @@ function DashboardClaimsDetailsControls({
     approveClaim,
     denyClaim,
     revokeClaim,
+    theme,
 }) {
     const [statusChangeText, setStatusChangeText] = useState('');
     const [displayedDialogType, setDisplayedDialogType] = useState(null);
@@ -134,8 +136,10 @@ function DashboardClaimsDetailsControls({
                     <Button
                         onClick={openApproveDialog}
                         variant="contained"
-                        color="action"
-                        style={dashboardClaimsControlsStyles.buttonStyles}
+                        style={{
+                            ...dashboardClaimsControlsStyles.buttonStyles,
+                            backgroundColor: theme.palette.action.main,
+                        }}
                     >
                         Message Claimant
                     </Button>
@@ -339,7 +343,9 @@ function mapDispatchToProps(dispatch, { data: { id } }) {
     };
 }
 
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps,
-)(DashboardClaimsDetailsControls);
+export default withTheme()(
+    connect(
+        mapStateToProps,
+        mapDispatchToProps,
+    )(DashboardClaimsDetailsControls),
+);

--- a/src/app/src/reducers/ClaimFacilityDashboardReducer.jsx
+++ b/src/app/src/reducers/ClaimFacilityDashboardReducer.jsx
@@ -28,6 +28,9 @@ import {
     completeAddNewFacilityClaimReviewNote,
     clearFacilityClaimReviewNote,
     updateFacilityClaimReviewNote,
+    startMessageFacilityClaimant,
+    failMessageFacilityClaimant,
+    completeMessageFacilityClaimant,
 } from '../actions/claimFacilityDashboard';
 
 const initialState = Object.freeze({
@@ -172,6 +175,9 @@ export default createReducer(
             update(state, {
                 detail: { $set: initialState.detail },
             }),
+        [startMessageFacilityClaimant]: handleStartChangeStatus,
+        [failMessageFacilityClaimant]: handleFailChangeStatus,
+        [completeMessageFacilityClaimant]: handleCompleteChangeStatus,
         [startApproveFacilityClaim]: handleStartChangeStatus,
         [startDenyFacilityClaim]: handleStartChangeStatus,
         [startRevokeFacilityClaim]: handleStartChangeStatus,

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -206,6 +206,8 @@ export const makeGetAPIFeatureFlagsURL = () => '/api-feature-flags/';
 export const makeGetFacilityClaimsURL = () => '/api/facility-claims/';
 export const makeGetFacilityClaimByClaimIDURL = claimID =>
     `/api/facility-claims/${claimID}/`;
+export const makeMessageFacilityClaimantByClaimIDURL = claimID =>
+    `/api/facility-claims/${claimID}/message/`;
 export const makeApproveFacilityClaimByClaimIDURL = claimID =>
     `/api/facility-claims/${claimID}/approve/`;
 export const makeDenyFacilityClaimByClaimIDURL = claimID =>

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -207,7 +207,7 @@ export const makeGetFacilityClaimsURL = () => '/api/facility-claims/';
 export const makeGetFacilityClaimByClaimIDURL = claimID =>
     `/api/facility-claims/${claimID}/`;
 export const makeMessageFacilityClaimantByClaimIDURL = claimID =>
-    `/api/facility-claims/${claimID}/message/`;
+    `/api/facility-claims/${claimID}/message-claimant/`;
 export const makeApproveFacilityClaimByClaimIDURL = claimID =>
     `/api/facility-claims/${claimID}/approve/`;
 export const makeDenyFacilityClaimByClaimIDURL = claimID =>

--- a/src/django/api/mail.py
+++ b/src/django/api/mail.py
@@ -65,6 +65,30 @@ def send_claim_facility_confirmation_email(request, facility_claim):
     )
 
 
+def send_message_to_claimant_email(request, facility_claim, message):
+    subj_template = get_template('mail/message_claimant_subject.txt')
+    text_template = get_template('mail/message_claimant_body.txt')
+    html_template = get_template('mail/message_claimant_body.html')
+
+    facility_country = COUNTRY_NAMES[facility_claim.facility.country_code]
+
+    message_dictionary = {
+        'message_to_claimant': message,
+        'facility_name': facility_claim.facility.name,
+        'facility_address': facility_claim.facility.address,
+        'facility_country': facility_country,
+        'facility_url': make_facility_url(request, facility_claim.facility),
+    }
+
+    send_mail(
+        subj_template.render().rstrip(),
+        text_template.render(message_dictionary),
+        settings.CLAIM_FROM_EMAIL,
+        [facility_claim.contributor.admin.email],
+        html_message=html_template.render(message_dictionary)
+    )
+
+
 def send_claim_facility_approval_email(request, facility_claim):
     subj_template = get_template('mail/claim_facility_approval_subject.txt')
     text_template = get_template('mail/claim_facility_approval_body.txt')

--- a/src/django/api/templates/mail/claims_team_signature_block.html
+++ b/src/django/api/templates/mail/claims_team_signature_block.html
@@ -1,0 +1,1 @@
+<p>OS Hub Claims Team</p>

--- a/src/django/api/templates/mail/claims_team_signature_block.txt
+++ b/src/django/api/templates/mail/claims_team_signature_block.txt
@@ -1,0 +1,3 @@
+{% block content %}
+OS Hub Claims Team
+{% endblock content %}

--- a/src/django/api/templates/mail/message_claimant_body.html
+++ b/src/django/api/templates/mail/message_claimant_body.html
@@ -39,6 +39,6 @@
             get in touch if we need any additional information.
         </p>
         <p>Best wishes,</p>
-        {% include "mail/data_team_signature_block.html" %}
+        {% include "mail/claims_team_signature_block.html" %}
     </body>
 </html>

--- a/src/django/api/templates/mail/message_claimant_body.html
+++ b/src/django/api/templates/mail/message_claimant_body.html
@@ -39,6 +39,6 @@
             get in touch if we need any additional information.
         </p>
         <p>Best wishes,</p>
-        {% include "mail/claims_team_signature_block.html" %}
+        {% include "mail/data_team_signature_block.html" %}
     </body>
 </html>

--- a/src/django/api/templates/mail/message_claimant_body.html
+++ b/src/django/api/templates/mail/message_claimant_body.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>Your Facility claim request on OS Hub - Action Required</title>
+    </head>
+    <body>
+        <p>Hi,</p>
+        <p>
+            You're receiving this email because you were listed as the contact
+            for a facility claim request on Open Supply Hub.
+        </p>
+        <p>Facility Details:</p>
+        <ul>
+            <li>
+                Facility: {{ facility_name }}, {{ facility_address }}, {{
+                facility_country }}
+            </li>
+            <li>
+                Facility URL:
+                <a href="{{ facility_url }}">{{ facility_url }}</a>
+            </li>
+        </ul>
+        <p>
+            We have completed our review of the material(s) submitted with the
+            request and require additional information to proceed with this
+            claim. A Facility Claim request will only be approved when it is
+            submitted by a facility owner and/or senior management staff at the
+            facility location in question. Additional information about our
+            claims process can be found
+            <a href="https://info.opensupplyhub.org/resources/claim-a-facility"
+                >here</a
+            >.
+        </p>
+        <p>Action Items:</p>
+        <p>{{ message_to_claimant }}</p>
+        <p>
+            Please reply to this message with the requested items. From there,
+            we can process this straight away. We'll review the materials and
+            get in touch if we need any additional information.
+        </p>
+        <p>Best wishes,</p>
+        {% include "mail/claims_team_signature_block.html" %}
+    </body>
+</html>

--- a/src/django/api/templates/mail/message_claimant_body.txt
+++ b/src/django/api/templates/mail/message_claimant_body.txt
@@ -18,5 +18,5 @@ Please reply to this message with the requested items. From there, we can proces
 
 Best wishes,
 
-{% include "mail/claims_team_signature_block.html" %}
+{% include "mail/data_team_signature_block.html" %}
 {% endblock content %}

--- a/src/django/api/templates/mail/message_claimant_body.txt
+++ b/src/django/api/templates/mail/message_claimant_body.txt
@@ -1,0 +1,22 @@
+{% block content %}
+Hi,
+
+You're receiving this email because you were listed as the contact for a facility claim request on Open Supply Hub.
+
+Facility Details:
+
+- Facility: {{ facility_name }}, {{ facility_address }}, {{ facility_country }}
+- Facility URL: {{ facility_url }}
+
+We have completed our review of the material(s) submitted with the request and require additional information to proceed with this claim. A Facility Claim request will only be approved when it is submitted by a facility owner and/or senior management staff at the facility location in question. Additional information about our claims process can be found here. (https://info.opensupplyhub.org/resources/claim-a-facility)
+
+Action Items:
+
+{{ message_to_claimant }}
+
+Please reply to this message with the requested items. From there, we can process this straight away. We'll review the materials and get in touch if we need any additional information.
+
+Best wishes,
+
+{% include "mail/claims_team_signature_block.html" %}
+{% endblock content %}

--- a/src/django/api/templates/mail/message_claimant_body.txt
+++ b/src/django/api/templates/mail/message_claimant_body.txt
@@ -18,5 +18,5 @@ Please reply to this message with the requested items. From there, we can proces
 
 Best wishes,
 
-{% include "mail/data_team_signature_block.html" %}
+{% include "mail/claims_team_signature_block.html" %}
 {% endblock content %}

--- a/src/django/api/templates/mail/message_claimant_subject.txt
+++ b/src/django/api/templates/mail/message_claimant_subject.txt
@@ -1,0 +1,1 @@
+Your Facility claim request on OS Hub - Action Required

--- a/src/django/api/tests/test_facility_claim_view_set.py
+++ b/src/django/api/tests/test_facility_claim_view_set.py
@@ -1,0 +1,123 @@
+from api.models import (
+    Contributor,
+    Facility,
+    FacilityClaim,
+    FacilityClaimReviewNote,
+    FacilityList,
+    FacilityListItem,
+    Source,
+    User,
+)
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from django.contrib.gis.geos import Point
+from django.core import mail
+
+
+class FacilityClaimViewSetTest(APITestCase):
+    def setUp(self):
+        self.email = "test@example.com"
+        self.password = "example123"
+        self.user = User.objects.create(email=self.email)
+        self.user.set_password(self.password)
+        self.user.save()
+
+        self.superuser = User.objects.create_superuser(
+            "superuser@example.com", "superuser"
+        )
+
+        self.contributor = Contributor.objects.create(
+            admin=self.user,
+            name="test contributor",
+            contrib_type=Contributor.OTHER_CONTRIB_TYPE,
+        )
+
+        self.list = FacilityList.objects.create(
+            header="header", file_name="one", name="List"
+        )
+
+        self.source = Source.objects.create(
+            facility_list=self.list,
+            source_type=Source.LIST,
+            is_active=True,
+            is_public=True,
+            contributor=self.contributor,
+        )
+
+        self.list_item = FacilityListItem.objects.create(
+            name="Item",
+            address="Address",
+            country_code="US",
+            sector=["Apparel"],
+            row_index=1,
+            status=FacilityListItem.CONFIRMED_MATCH,
+            source=self.source,
+        )
+
+        self.facility = Facility.objects.create(
+            name="Name",
+            address="Address",
+            country_code="US",
+            location=Point(0, 0),
+            created_from=self.list_item,
+        )
+
+        self.facility_claim = FacilityClaim.objects.create(
+            contributor=self.contributor,
+            facility=self.facility,
+            contact_person="Name",
+            phone_number=12345,
+            company_name="Test",
+            website="http://example.com",
+            facility_description="description",
+        )
+
+        self.client.login(email="superuser@example.com", password="superuser")
+
+    def _post_message_claimant(self, claim_id, message):
+        return self.client.post(
+            "/api/facility-claims/{}/message-claimant/".format(claim_id),
+            {"message": message},
+        )
+
+    def test_message_claimant_permission_denied(self):
+        self.client.logout()
+        self.client.login(username='user', password='userpass')
+
+        response = self._post_message_claimant(
+            self.facility_claim.id, "Hello, claimant!"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(
+            response.data['detail'],
+            'Authentication credentials were not provided.',
+        )
+
+    def test_message_claimant_not_found(self):
+        not_exist_id = 9999
+        response = self._post_message_claimant(
+            not_exist_id, "Hello, claimant!"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_message_claimant_no_message(self):
+        response = self._post_message_claimant(self.facility_claim.id, "")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['detail'], 'Message is required.')
+
+    def test_message_claimant_success(self):
+        response = self._post_message_claimant(
+            self.facility_claim.id, "Hello, claimant!"
+        )
+        notes_count = FacilityClaimReviewNote.objects.filter(
+            claim=self.facility_claim
+        ).count()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['notes'][0]['note'], 'Hello, claimant!')
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(notes_count, 1)

--- a/src/django/api/views/facility/facility_claim_view_set.py
+++ b/src/django/api/views/facility/facility_claim_view_set.py
@@ -93,6 +93,9 @@ class FacilityClaimViewSet(ModelViewSet):
             claim = FacilityClaim.objects.get(pk=pk)
             message = request.data.get('message', '')
 
+            if not message:
+                raise BadRequestException('Message is required.')
+
             FacilityClaimReviewNote.objects.create(
                 claim=claim,
                 author=request.user,


### PR DESCRIPTION
[OSDEV-997](https://opensupplyhub.atlassian.net/browse/OSDEV-997) - Facility Claims. Send messages to claimant from the claim request page.

A new button, 'Message Claimant' has been added to the update status controls on the Facility Claim Details page. After successfully sending a message, the message text is recorded in the Claim Review Notes.
A new method, `message_claimant`, was added to the `FacilityClaimViewSet` for handling a POST request on the url-path `message-claimant` for messages to the claimant. 
Mail templates for the message to the claimant and the claims team signature were also added.