### PR TITLE
[OSDEV-1001] Deploy OpenSearch service to our infrastructure

### DIFF
--- a/deployment/terraform/container_service.tf
+++ b/deployment/terraform/container_service.tf
@@ -51,16 +51,6 @@ resource "aws_security_group" "batch" {
   }
 }
 
-resource "aws_security_group" "opensearch" {
-  vpc_id = module.vpc.id
-
-  tags = {
-    Name        = "sgOpenSearch"
-    Project     = var.project
-    Environment = var.environment
-  }
-}
-
 #
 # ALB Resources
 #

--- a/deployment/terraform/container_service.tf
+++ b/deployment/terraform/container_service.tf
@@ -51,6 +51,16 @@ resource "aws_security_group" "batch" {
   }
 }
 
+resource "aws_security_group" "opensearch" {
+  vpc_id = module.vpc.id
+
+  tags = {
+    Name        = "sgOpenSearch"
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
 #
 # ALB Resources
 #

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -345,6 +345,25 @@ resource "aws_iam_role_policy" "step_functions_service_role_policy" {
 }
 
 #
+# OpenSearch IAM resources
+#
+data "aws_iam_policy_document" "opensearch_assume_role" {
+  statement {
+    effect    = "Allow"
+    actions   = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["es.amazonaws.com"]
+    }
+  }
+}
+resource "aws_iam_role" "opensearch_role" {
+  name               = "opensearch-role"
+
+  assume_role_policy = data.aws_iam_policy_document.opensearch_assume_role.json
+}
+
+#
 # CloudWatch Events IAM resources
 #
 data "aws_iam_policy_document" "cloudwatch_events_assume_role" {
@@ -381,4 +400,28 @@ resource "aws_iam_role_policy" "cloudwatch_events_service_role_policy" {
   name   = "cloudWatchEvents${local.short}ServiceRolePolicy"
   role   = aws_iam_role.cloudwatch_events_service_role.name
   policy = data.aws_iam_policy_document.cloudwatch_events_service_role_policy.json
+}
+
+data "aws_iam_policy_document" "opensearch" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["es.amazonaws.com"]
+    }
+
+    actions = [
+      "logs:PutLogEvents",
+      "logs:PutLogEventsBatch",
+      "logs:CreateLogStream",
+    ]
+
+    resources = ["arn:aws:logs:*"]
+  }
+}
+
+resource "aws_cloudwatch_log_resource_policy" "opensearch" {
+  policy_name     = "opensearch"
+  policy_document = data.aws_iam_policy_document.opensearch.json
 }

--- a/deployment/terraform/opensearch.tf
+++ b/deployment/terraform/opensearch.tf
@@ -1,3 +1,13 @@
+resource "aws_security_group" "opensearch" {
+  vpc_id = module.vpc.id
+
+  tags = {
+    Name        = "sgOpenSearch"
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
 resource "aws_opensearch_domain" "opensearch" {
   domain_name    = "opensearch-domain"
   engine_version = "OpenSearch_2.11"

--- a/deployment/terraform/opensearch.tf
+++ b/deployment/terraform/opensearch.tf
@@ -1,0 +1,61 @@
+resource "aws_opensearch_domain" "opensearch" {
+  domain_name    = "opensearch-domain"
+  engine_version = "OpenSearch_2.11"
+
+  cluster_config {
+    instance_type          = "t3.small.search"
+    instance_count         = 2
+    zone_awareness_enabled = true
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = 10
+  }
+
+  advanced_security_options {
+    enabled = true
+    master_user_options {
+      master_user_arn = aws_iam_role.opensearch_role.arn
+    }
+  }
+
+  domain_endpoint_options {
+    enforce_https       = true
+    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+  }
+
+  encrypt_at_rest {
+    enabled = true
+  }
+
+  node_to_node_encryption {
+    enabled = true
+  }
+
+  log_publishing_options {
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.opensearch.arn
+    log_type                 = "INDEX_SLOW_LOGS"
+  }
+
+  log_publishing_options {
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.opensearch.arn
+    log_type                 = "SEARCH_SLOW_LOGS"
+  }
+
+  log_publishing_options {
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.opensearch.arn
+    log_type                 = "ES_APPLICATION_LOGS"
+  }
+
+  log_publishing_options {
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.opensearch.arn
+    log_type                 = "AUDIT_LOGS"
+  }
+
+  vpc_options {
+    subnet_ids         = module.vpc.private_subnet_ids
+
+    security_group_ids = [aws_security_group.opensearch.id]
+  }
+}

--- a/deployment/terraform/opensearch.tf
+++ b/deployment/terraform/opensearch.tf
@@ -14,7 +14,7 @@ resource "aws_opensearch_domain" "opensearch" {
 
   cluster_config {
     instance_type          = "t3.small.search"
-    instance_count         = 2
+    instance_count         = 0
     zone_awareness_enabled = true
   }
 

--- a/deployment/terraform/opensearch.tf
+++ b/deployment/terraform/opensearch.tf
@@ -8,6 +8,11 @@ resource "aws_security_group" "opensearch" {
   }
 }
 
+resource "aws_cloudwatch_log_group" "opensearch" {
+  name              = "log${local.short}OpenSearch"
+  retention_in_days = 30
+}
+
 resource "aws_opensearch_domain" "opensearch" {
   domain_name    = "opensearch-domain"
   engine_version = "OpenSearch_2.11"

--- a/deployment/terraform/opensearch.tf
+++ b/deployment/terraform/opensearch.tf
@@ -14,6 +14,8 @@ resource "aws_cloudwatch_log_group" "opensearch" {
 }
 
 resource "aws_opensearch_domain" "opensearch" {
+  // TODO: remove 'count' meta-argument once OpenSearch will be fully setup
+  count          = 0
   domain_name    = "opensearch-domain"
   engine_version = "OpenSearch_2.11"
 

--- a/deployment/terraform/opensearch.tf
+++ b/deployment/terraform/opensearch.tf
@@ -19,7 +19,7 @@ resource "aws_opensearch_domain" "opensearch" {
 
   cluster_config {
     instance_type          = "t3.small.search"
-    instance_count         = 0
+    instance_count         = 2
     zone_awareness_enabled = true
   }
 

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -33,6 +33,7 @@ Mail templates for the message to the claimant and the claims team signature wer
     * ProcessingFacilityExecutor - class defines which interface to execute for the processing of a facility
 * Resource allocation has been optimized for the Test environment. The number of ECS tasks in the Test environment has been reduced from 4 to 2, while maintaining system stability.
 * [OSDEV-870](https://opensupplyhub.atlassian.net/browse/OSDEV-870) - In `docker-compose` for the `api-app`  added dependency that helps to fix connection with the database during tests pipelines for Dedupe-Hub:
+* [OSDEV-1001](https://opensupplyhub.atlassian.net/browse/OSDEV-1001) - Deploy OpenSearch service to OS Hub infrastructure.
 ```
 database:
     condition: service_healthy
@@ -53,7 +54,6 @@ database:
     * Removed the _Preferred method of contact_ field from both the claim form and the claim details page in the admin dashboard.
     * Implemented redirecting a user to the claim page after navigating to the login page via the CTA link on the claim page for unauthorized users and successful login.
 * [OSDEV-997](https://opensupplyhub.atlassian.net/browse/OSDEV-997) - Facility Claims. A new button, 'Message Claimant' has been added to the update status controls on the Facility Claim Details page. After successfully sending a message, the message text is recorded in the Claim Review Notes.
-* [OSDEV-1001](https://opensupplyhub.atlassian.net/browse/OSDEV-1001) - Deploy OpenSearch service to OS Hub infrastructure.
 
 ### Release instructions:
 * Update code.

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -52,6 +52,7 @@ database:
     * Removed the _Preferred method of contact_ field from both the claim form and the claim details page in the admin dashboard.
     * Implemented redirecting a user to the claim page after navigating to the login page via the CTA link on the claim page for unauthorized users and successful login.
 * [OSDEV-997](https://opensupplyhub.atlassian.net/browse/OSDEV-997) - Facility Claims. A new button, 'Message Claimant' has been added to the update status controls on the Facility Claim Details page. After successfully sending a message, the message text is recorded in the Claim Review Notes.
+* [OSDEV-1001](https://opensupplyhub.atlassian.net/browse/OSDEV-1001) - Deploy OpenSearch service to OS Hub infrastructure.
 
 ### Release instructions:
 * Update code.


### PR DESCRIPTION
Fix https://opensupplyhub.atlassian.net/browse/OSDEV-1001

1. Provision OpenSearch.
2. Apply VPC options that make OpenSearch available at the same subnet as PostgreSQL.
3. Apply security groups for OpenSearch.
4. Prepare bare minimum cluster configs for current setup (2 instances of t3.small.search).
5. Enable advanced security options.
6. Connect all CloudWatch log types to OpenSearch.
