### PR TITLE
[OSDEV-997] Correct message to claimant body template

### DIFF
--- a/src/django/api/templates/mail/message_claimant_body.html
+++ b/src/django/api/templates/mail/message_claimant_body.html
@@ -12,7 +12,7 @@
         <p>Facility Details:</p>
         <ul>
             <li>
-                Facility: {{ facility_name }}, {{ facility_address }}, {{facility_country }}
+                Facility: {{ facility_name }}, {{ facility_address }}, {{ facility_country }}
             </li>
             <li>
                 Facility URL:


### PR DESCRIPTION
[OSDEV-997](https://opensupplyhub.atlassian.net/browse/OSDEV-997) - Correct message to claimant body template
Added fix to the `facility_country` variable in the `message_claimant_body` template.