### PR TITLE
Make logstash and opensearch related resources unique per env

### DIFF
--- a/deployment/terraform/efs.tf
+++ b/deployment/terraform/efs.tf
@@ -1,7 +1,7 @@
 # EFS for Logstash
 
 resource "aws_efs_file_system" "efs_app_logstash" {
-  creation_token = "${replace(var.project, " ", "")}-${var.environment}-efs-app-logstash"
+  creation_token = "${lower(replace(var.project, " ", ""))}-${lower(var.environment)}-efs-app-logstash"
 
   tags = {
     Name         = "efsAppLogstash"

--- a/deployment/terraform/efs.tf
+++ b/deployment/terraform/efs.tf
@@ -1,7 +1,7 @@
 # EFS for Logstash
 
 resource "aws_efs_file_system" "efs_app_logstash" {
-  creation_token = "efs-app-logstash"
+  creation_token = "${replace(var.project, " ", "")}-${var.environment}-efs-app-logstash"
 
   tags = {
     Name         = "efsAppLogstash"

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -358,7 +358,7 @@ data "aws_iam_policy_document" "opensearch_assume_role" {
   }
 }
 resource "aws_iam_role" "opensearch_role" {
-  name               = "opensearch-role"
+  name               = "opensearch${local.short}ServiceRole"
 
   assume_role_policy = data.aws_iam_policy_document.opensearch_assume_role.json
 }


### PR DESCRIPTION
The error that occurred during deployment to the Test environment -> https://github.com/opensupplyhub/open-supply-hub/actions/runs/9076795226/job/24940323859

**Fix:**
Made Logstash and OpenSearch-related resources unique per environment, specifically the IAM role for OpenSearch and the EFS for Logstash.

_Note: I tested the changes for the Development environment -> https://github.com/opensupplyhub/open-supply-hub/actions/runs/9077362009 and for the Test environment -> https://github.com/opensupplyhub/open-supply-hub/actions/runs/9077422395_