### PR TITLE
Delete the 'public' scheme before database restore

### DIFF
--- a/src/anon-tools/do_restore.sh
+++ b/src/anon-tools/do_restore.sh
@@ -15,4 +15,16 @@ ssh-keyscan $bastion > ~/.ssh/known_hosts
 
 ssh -f -i /keys/key -L 5433:database.service.osh.internal:5432 -N ec2-user@$bastion
 
+SQL_SCRIPT="DO \$\$
+DECLARE
+BEGIN
+  DROP SCHEMA public CASCADE;
+  CREATE SCHEMA public;
+
+  -- GRANT ALL ON SCHEMA public TO postgres;
+  GRANT ALL ON SCHEMA public TO public;
+END \$\$;"
+
+echo "Dropping tables"
+psql -d $DATABASE_NAME -U $DATABASE_USERNAME -h localhost -p 5433 -c "$SQL_SCRIPT"
 pg_restore --verbose --clean --no-acl --no-owner -d $DATABASE_NAME -U $DATABASE_USERNAME -h localhost -p 5433 < /dumps/osh_prod_large.dump


### PR DESCRIPTION
* if newer database has changes with new relations/constraints, restoring the database from dumps leads to conflicts. So removing schema allows not to have conflicting data and restoring database from empty state