### PR TITLE
[OSDEV-1068] Make a static report that lists the number of POTENTIAL_MATCH records for certain API users

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -36,6 +36,7 @@ and receives information about merges that have occurred for the contributors wi
 ### What's new
 * [OSDEV-1049](https://opensupplyhub.atlassian.net/browse/OSDEV-1049) Update Release protocol.
 * [OSDEV-922](https://opensupplyhub.atlassian.net/browse/OSDEV-922) Consent Message. Update wording of consent opt in message on Open Supply Hub. A user who verifies Open Supply Hub for the first time can see the updated message.
+* [OSDEV-1068](https://opensupplyhub.atlassian.net/browse/OSDEV-1068) - Created report that shows the number of records from the api_facilitymatch table for contributors: 2060, 1045, 685, 3356
 
 ### Release instructions:
 * Update code.

--- a/src/django/api/reports/pending_match_records_for_certain_api_users.sql
+++ b/src/django/api/reports/pending_match_records_for_certain_api_users.sql
@@ -1,0 +1,17 @@
+SELECT 
+    src.contributor_id,
+    ac.name AS contributor_name,
+    COUNT(*) AS pending_matches_count
+FROM 
+    api_facilitymatch afm
+JOIN 
+    api_facilitylistitem afli ON afm.facility_list_item_id = afli.id
+JOIN 
+    api_source src ON afli.source_id = src.id
+JOIN
+    api_contributor ac ON src.contributor_id = ac.id
+WHERE 
+    afm.status = 'PENDING'
+    AND src.contributor_id IN (2060, 1045, 685, 3356)
+GROUP BY 
+    src.contributor_id, ac.name


### PR DESCRIPTION
[OSDEV-1068](https://opensupplyhub.atlassian.net/browse/OSDEV-1068) Make a static report that lists the number of POTENTIAL_MATCH records for certain API users

Created report that shows the number of records from the `api_facilitymatch` table for contributors: [Textile Exchange](https://opensupplyhub.org/admin/api/contributor/2060/change/), [ZDHC](https://opensupplyhub.org/admin/api/contributor/1045/change/), [Worldly](https://opensupplyhub.org/admin/api/contributor/685/change/), [Amfori](https://opensupplyhub.org/admin/api/contributor/3356/change/) 