### PR TITLE
[OSDEV-1019] Login page. User did not click confirmation link.

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -27,9 +27,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Bugfix
 * [OSDEV-1019](https://opensupplyhub.atlassian.net/browse/OSDEV-1019) - Fixed an error message to 'Your account is not verified. Check your email for a confirmation link.' when a user tries to log in with an uppercase letter in the email address and their account has not been activated through the confirmation link.
 
-### Bugfix
-* *Describe bugfix here.*
-
 ### What's new
 * *Describe what's new here. The changes that can impact user experience should be listed in this section.*
 

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -20,13 +20,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * *Describe code/API changes here.*
 
 ### Architecture/Environment changes
-* *Describe architecture/environment changes here.*
-
-### Bugfix
-* [OSDEV-1019](https://opensupplyhub.atlassian.net/browse/OSDEV-1019) - Fixed an error message to 'Your account is not verified. Check your email for a confirmation link.' when a user tries to log in with an uppercase letter in the email address and their account has not been activated through the confirmation link.
 * [OSDEV-1069](https://opensupplyhub.atlassian.net/browse/OSDEV-1069) - The following changes have been made:
     * Changed the Postgres Docker image for the database to use the official one and make the local database setup platform-agnostic, so it doesn't depend on the processor architecture.
     * Built the PostGIS program from source and installed it to avoid LLVM-related errors inside the database Docker container during local development.
+
+### Bugfix
+* [OSDEV-1019](https://opensupplyhub.atlassian.net/browse/OSDEV-1019) - Fixed an error message to 'Your account is not verified. Check your email for a confirmation link.' when a user tries to log in with an uppercase letter in the email address and their account has not been activated through the confirmation link.
 
 ### Bugfix
 * *Describe bugfix here.*

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -3,6 +3,34 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). The format is based on the `RELEASE-NOTES-TEMPLATE.md` file.
 
+## Release 1.14.0
+
+## Introduction
+* Product name: Open Supply Hub
+* Release date: June 15, 2024
+
+### Database changes
+#### Migrations:
+* *Describe migrations here.*
+
+#### Scheme changes
+* *Describe scheme changes here.*
+
+### Code/API changes
+* *Describe code/API changes here.*
+
+### Architecture/Environment changes
+* *Describe architecture/environment changes here.*
+
+### Bugfix
+* [OSDEV-1019](https://opensupplyhub.atlassian.net/browse/OSDEV-1019) - Fixed an error message to 'Your account is not verified. Check your email for a confirmation link.' when a user tries to log in with an uppercase letter in the email address and their account has not been activated through the confirmation link.
+
+### What's new
+* *Describe what's new here. The changes that can impact user experience should be listed in this section.*
+
+### Release instructions:
+* *Provide release instructions here.*
+
 ## Release 1.13.0
 
 ## Introduction

--- a/src/django/api/tests/test_login_to_oar_client.py
+++ b/src/django/api/tests/test_login_to_oar_client.py
@@ -16,6 +16,11 @@ class LoginToOARClientTest(APITestCase):
         )
         self.login_url = reverse('login_to_oar_client')
 
+    def create_email_address(self, verified):
+        return EmailAddress.objects.create(
+            user=self.user, email=self.email, verified=verified, primary=True
+        )
+
     def test_missing_email_or_password(self):
         response = self.client.post(self.login_url, {'email': self.email})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -33,9 +38,7 @@ class LoginToOARClientTest(APITestCase):
         )
 
     def test_unconfirmed_user_login(self):
-        EmailAddress.objects.create(
-            user=self.user, email=self.email, verified=False, primary=True
-        )
+        self.create_email_address(verified=False)
         response = self.client.post(
             self.login_url, {'email': self.email, 'password': self.password}
         )
@@ -47,9 +50,7 @@ class LoginToOARClientTest(APITestCase):
         )
 
     def test_successful_login(self):
-        EmailAddress.objects.create(
-            user=self.user, email=self.email, verified=True, primary=True
-        )
+        self.create_email_address(verified=True)
         response = self.client.post(
             self.login_url, {'email': self.email, 'password': self.password}
         )
@@ -57,9 +58,7 @@ class LoginToOARClientTest(APITestCase):
         self.assertEqual(response.data['email'], self.email)
 
     def test_successful_login_with_various_case_emails(self):
-        EmailAddress.objects.create(
-            user=self.user, email=self.email, verified=True, primary=True
-        )
+        self.create_email_address(verified=True)
         test_cases = ['TESTUSER@EXAMPLE.COM', 'TestUser@Example.Com']
         for case in test_cases:
             with self.subTest(email=case):
@@ -70,9 +69,7 @@ class LoginToOARClientTest(APITestCase):
                 self.assertEqual(response.data['email'], self.email)
 
     def test_unconfirmed_user_login_with_various_case_emails(self):
-        EmailAddress.objects.create(
-            user=self.user, email=self.email, verified=False, primary=True
-        )
+        self.create_email_address(verified=False)
         test_cases = ['TESTUSER@EXAMPLE.COM', 'TestUser@Example.Com']
         for case in test_cases:
             with self.subTest(email=case):
@@ -89,9 +86,7 @@ class LoginToOARClientTest(APITestCase):
                 )
 
     def test_unconfirmed_user_login_resends_confirmation_email(self):
-        EmailAddress.objects.create(
-            user=self.user, email=self.email, verified=False, primary=True
-        )
+        self.create_email_address(verified=False)
         with patch.object(
             EmailAddress, 'send_confirmation'
         ) as mock_send_confirmation:

--- a/src/django/api/tests/test_login_to_oar_client.py
+++ b/src/django/api/tests/test_login_to_oar_client.py
@@ -1,0 +1,134 @@
+from unittest.mock import patch
+from django.urls import reverse
+from api.models.user import User
+from rest_framework import status
+
+from allauth.account.models import EmailAddress
+from rest_framework.test import APITestCase
+
+
+class LoginToOARClientTest(APITestCase):
+
+    def setUp(self):
+        self.email = 'testuser@example.com'
+        self.password = 'password'
+        self.user = User(email=self.email)
+        self.user.set_password(self.password)
+        self.user.save()
+        self.login_url = reverse('login_to_oar_client')
+
+    def test_missing_email_or_password(self):
+        response = self.client.post(
+            self.login_url, {'email': 'testuser@example.com'}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn(
+            'Email and password are required', response.data['detail']
+        )
+
+    def test_invalid_credentials(self):
+        response = self.client.post(
+            self.login_url,
+            {'email': 'testuser@example.com', 'password': 'wrongpassword'},
+        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn(
+            'Unable to login with those credentials', response.data['detail']
+        )
+
+    def test_unconfirmed_user_login(
+        self,
+    ):
+        self.email_address = EmailAddress.objects.create(
+            user=self.user, email=self.email, verified=False, primary=True
+        )
+        response = self.client.post(
+            self.login_url,
+            {
+                'email': 'testuser@example.com',
+                'password': 'password',
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn(
+            'Your account is not verified. '
+            'Check your email for a confirmation link.',
+            response.data['detail'],
+        )
+
+    def test_successful_login(self):
+        self.email_address = EmailAddress.objects.create(
+            user=self.user, email=self.email, verified=True, primary=True
+        )
+
+        response = self.client.post(
+            self.login_url,
+            {'email': 'testuser@example.com', 'password': 'password'},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['email'], 'testuser@example.com')
+
+    def test_successful_login_with_uppercase_email(self):
+        self.email_address = EmailAddress.objects.create(
+            user=self.user, email=self.email, verified=True, primary=True
+        )
+        response = self.client.post(
+            self.login_url,
+            {'email': 'TESTUSER@EXAMPLE.COM', 'password': 'password'},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['email'], 'testuser@example.com')
+
+    def test_successful_login_with_mixed_case_email(self):
+        self.email_address = EmailAddress.objects.create(
+            user=self.user, email=self.email, verified=True, primary=True
+        )
+        response = self.client.post(
+            self.login_url,
+            {'email': 'TestUser@Example.Com', 'password': 'password'},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['email'], 'testuser@example.com')
+
+    def unconfirmed_user_login_with_uppercase_email(self):
+        self.email_address = EmailAddress.objects.create(
+            user=self.user, email=self.email, verified=False, primary=True
+        )
+        response = self.client.post(
+            self.login_url,
+            {'email': 'TestUser@example.Com', 'password': 'password'},
+        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn(
+            'Your account is not verified. '
+            'Check your email for a confirmation link.',
+            response.data['detail'],
+        )
+
+    def test_unconfirmed_user_login_resends_confirmation_email(self):
+        self.email_address = EmailAddress.objects.create(
+            user=self.user, email=self.email, verified=False, primary=True
+        )
+
+        with patch.object(
+            EmailAddress, 'send_confirmation'
+        ) as mock_send_confirmation:
+            response = self.client.post(
+                self.login_url,
+                {
+                    'email': 'testuser@example.com',
+                    'password': 'password',
+                },
+            )
+
+            self.assertEqual(
+                response.status_code, status.HTTP_401_UNAUTHORIZED
+            )
+            self.assertIn(
+                'Your account is not verified. '
+                'Check your email for a confirmation link.',
+                response.data['detail'],
+            )
+            mock_send_confirmation.assert_called_once()

--- a/src/django/api/tests/test_login_to_oar_client.py
+++ b/src/django/api/tests/test_login_to_oar_client.py
@@ -2,7 +2,6 @@ from unittest.mock import patch
 from django.urls import reverse
 from api.models.user import User
 from rest_framework import status
-
 from allauth.account.models import EmailAddress
 from rest_framework.test import APITestCase
 
@@ -12,123 +11,100 @@ class LoginToOARClientTest(APITestCase):
     def setUp(self):
         self.email = 'testuser@example.com'
         self.password = 'password'
-        self.user = User(email=self.email)
-        self.user.set_password(self.password)
-        self.user.save()
+        self.user = User.objects.create_user(
+            email=self.email, password=self.password
+        )
         self.login_url = reverse('login_to_oar_client')
 
     def test_missing_email_or_password(self):
-        response = self.client.post(
-            self.login_url, {'email': 'testuser@example.com'}
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-        self.assertIn(
-            'Email and password are required', response.data['detail']
+        response = self.client.post(self.login_url, {'email': self.email})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data['detail'], 'Email and password are required'
         )
 
     def test_invalid_credentials(self):
         response = self.client.post(
-            self.login_url,
-            {'email': 'testuser@example.com', 'password': 'wrongpassword'},
+            self.login_url, {'email': self.email, 'password': 'wrongpassword'}
         )
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-        self.assertIn(
-            'Unable to login with those credentials', response.data['detail']
+        self.assertEqual(
+            response.data['detail'], 'Unable to login with those credentials'
         )
 
-    def test_unconfirmed_user_login(
-        self,
-    ):
-        self.email_address = EmailAddress.objects.create(
+    def test_unconfirmed_user_login(self):
+        EmailAddress.objects.create(
             user=self.user, email=self.email, verified=False, primary=True
         )
         response = self.client.post(
-            self.login_url,
-            {
-                'email': 'testuser@example.com',
-                'password': 'password',
-            },
+            self.login_url, {'email': self.email, 'password': self.password}
         )
-
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-        self.assertIn(
+        self.assertEqual(
+            response.data['detail'],
             'Your account is not verified. '
             'Check your email for a confirmation link.',
-            response.data['detail'],
         )
 
     def test_successful_login(self):
-        self.email_address = EmailAddress.objects.create(
-            user=self.user, email=self.email, verified=True, primary=True
-        )
-
-        response = self.client.post(
-            self.login_url,
-            {'email': 'testuser@example.com', 'password': 'password'},
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['email'], 'testuser@example.com')
-
-    def test_successful_login_with_uppercase_email(self):
-        self.email_address = EmailAddress.objects.create(
+        EmailAddress.objects.create(
             user=self.user, email=self.email, verified=True, primary=True
         )
         response = self.client.post(
-            self.login_url,
-            {'email': 'TESTUSER@EXAMPLE.COM', 'password': 'password'},
+            self.login_url, {'email': self.email, 'password': self.password}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['email'], 'testuser@example.com')
+        self.assertEqual(response.data['email'], self.email)
 
-    def test_successful_login_with_mixed_case_email(self):
-        self.email_address = EmailAddress.objects.create(
+    def test_successful_login_with_various_case_emails(self):
+        EmailAddress.objects.create(
             user=self.user, email=self.email, verified=True, primary=True
         )
-        response = self.client.post(
-            self.login_url,
-            {'email': 'TestUser@Example.Com', 'password': 'password'},
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['email'], 'testuser@example.com')
+        test_cases = ['TESTUSER@EXAMPLE.COM', 'TestUser@Example.Com']
+        for case in test_cases:
+            with self.subTest(email=case):
+                response = self.client.post(
+                    self.login_url, {'email': case, 'password': self.password}
+                )
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertEqual(response.data['email'], self.email)
 
-    def unconfirmed_user_login_with_uppercase_email(self):
-        self.email_address = EmailAddress.objects.create(
+    def test_unconfirmed_user_login_with_various_case_emails(self):
+        EmailAddress.objects.create(
             user=self.user, email=self.email, verified=False, primary=True
         )
-        response = self.client.post(
-            self.login_url,
-            {'email': 'TestUser@example.Com', 'password': 'password'},
-        )
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-        self.assertIn(
-            'Your account is not verified. '
-            'Check your email for a confirmation link.',
-            response.data['detail'],
-        )
+        test_cases = ['TESTUSER@EXAMPLE.COM', 'TestUser@Example.Com']
+        for case in test_cases:
+            with self.subTest(email=case):
+                response = self.client.post(
+                    self.login_url, {'email': case, 'password': self.password}
+                )
+                self.assertEqual(
+                    response.status_code, status.HTTP_401_UNAUTHORIZED
+                )
+                self.assertEqual(
+                    response.data['detail'],
+                    'Your account is not verified. '
+                    'Check your email for a confirmation link.',
+                )
 
     def test_unconfirmed_user_login_resends_confirmation_email(self):
-        self.email_address = EmailAddress.objects.create(
+        EmailAddress.objects.create(
             user=self.user, email=self.email, verified=False, primary=True
         )
-
         with patch.object(
             EmailAddress, 'send_confirmation'
         ) as mock_send_confirmation:
             response = self.client.post(
                 self.login_url,
-                {
-                    'email': 'testuser@example.com',
-                    'password': 'password',
-                },
+                {'email': self.email, 'password': self.password},
             )
-
             self.assertEqual(
                 response.status_code, status.HTTP_401_UNAUTHORIZED
             )
-            self.assertIn(
+            self.assertEqual(
+                response.data['detail'],
                 'Your account is not verified. '
                 'Check your email for a confirmation link.',
-                response.data['detail'],
             )
             mock_send_confirmation.assert_called_once()

--- a/src/django/api/tests/test_login_to_oar_client.py
+++ b/src/django/api/tests/test_login_to_oar_client.py
@@ -11,9 +11,9 @@ class LoginToOARClientTest(APITestCase):
     def setUp(self):
         self.email = 'testuser@example.com'
         self.password = 'password'
-        self.user = User.objects.create_user(
-            email=self.email, password=self.password
-        )
+        self.user = User(email=self.email)
+        self.user.set_password(self.password)
+        self.user.save()
         self.login_url = reverse('login_to_oar_client')
 
     def create_email_address(self, verified):
@@ -23,7 +23,7 @@ class LoginToOARClientTest(APITestCase):
 
     def test_missing_email_or_password(self):
         response = self.client.post(self.login_url, {'email': self.email})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(
             response.data['detail'], 'Email and password are required'
         )

--- a/src/django/api/views/auth/login_to_oar_client.py
+++ b/src/django/api/views/auth/login_to_oar_client.py
@@ -17,7 +17,8 @@ class LoginToOARClient(LoginView):
         if email is None or password is None:
             raise AuthenticationFailed('Email and password are required')
 
-        user = authenticate(email=email.lower(), password=password)
+        email = email.lower()
+        user = authenticate(email=email, password=password)
 
         if user is None:
             raise AuthenticationFailed(

--- a/src/django/api/views/auth/login_to_oar_client.py
+++ b/src/django/api/views/auth/login_to_oar_client.py
@@ -17,8 +17,8 @@ class LoginToOARClient(LoginView):
         if email is None or password is None:
             raise AuthenticationFailed('Email and password are required')
 
-        email = email.lower()
-        user = authenticate(email=email, password=password)
+        normalized_email = email.lower()
+        user = authenticate(email=normalized_email, password=password)
 
         if user is None:
             raise AuthenticationFailed(
@@ -29,7 +29,7 @@ class LoginToOARClient(LoginView):
         if not request.user.did_register_and_confirm_email:
             # Mimic the behavior of django-allauth and resend the confirmation
             # email if an unconfirmed user tries to log in.
-            email_address = EmailAddress.objects.get(email=email)
+            email_address = EmailAddress.objects.get(email=normalized_email)
             email_address.send_confirmation(request)
 
             raise AuthenticationFailed(

--- a/src/django/api/views/auth/login_to_oar_client.py
+++ b/src/django/api/views/auth/login_to_oar_client.py
@@ -33,7 +33,7 @@ class LoginToOARClient(LoginView):
             email_address.send_confirmation(request)
 
             raise AuthenticationFailed(
-                'Account is not verified. '
+                'Your account is not verified. '
                 'Check your email for a confirmation link.'
             )
 


### PR DESCRIPTION
[OSDEV-1019](https://opensupplyhub.atlassian.net/browse/OSDEV-1019) Login page. User did not click confirmation link.

 Fixed an error message to 'Your account is not verified. Check your email for a confirmation link.' when a user tries to log in with an uppercase letter in the email address and their account has not been activated through the confirmation link.