### PR TITLE
[OSDEV-1030] Site Header & Footer. Add Blog and Career Links, change order of links on footer.

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -29,7 +29,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * *Describe bugfix here.*
 
 ### What's new
-* *Describe what's new here. The changes that can impact user experience should be listed in this section.*
+*   [OSDEV-1030](https://opensupplyhub.atlassian.net/browse/OSDEV-1030) - The following changes have been made:
+    *   Replaced the "Donate" button with a "Blog" button in the header
+    *   Added links to the "Blog" and "Careers" pages in the footer
 
 ### Release instructions:
 * Update code.

--- a/src/react/src/__tests__/components/Footer.test.js
+++ b/src/react/src/__tests__/components/Footer.test.js
@@ -9,7 +9,7 @@ test('Footer component', () => {
             <Footer />
         </Router>
     );
-    
+
     const footer = screen.getByTestId('footer');
     expect(footer).toBeInTheDocument();
 
@@ -22,6 +22,12 @@ test('Footer component', () => {
 
     const faqLink = screen.getByText('FAQs');
     expect(faqLink).toHaveAttribute('href', 'https://info.opensupplyhub.org/faqs');
+
+    const carrerLink = screen.getByText("Careers")
+    expect(carrerLink).toHaveAttribute('href', 'https://info.opensupplyhub.org/work-with-us')
+
+    const blogLink = screen.getByText("Blog")
+    expect(blogLink).toHaveAttribute('href', 'https://blog.opensupplyhub.org')
 
     const privacyPolicyLink = screen.getByText('Privacy Policy');
     expect(privacyPolicyLink).toHaveAttribute('href', 'https://info.opensupplyhub.org/privacy-policy');

--- a/src/react/src/util/constants.jsx
+++ b/src/react/src/util/constants.jsx
@@ -607,6 +607,8 @@ export const minimum100PercentWidthEmbedHeight = '500px';
 
 export const DONATE_LINK = 'https://givebutter.com/opensupplyhub2022';
 
+export const OS_HUB_BLOG_LINK = 'https://blog.opensupplyhub.org';
+
 export const NavbarItems = [
     {
         type: 'link',
@@ -634,8 +636,8 @@ export const NavbarItems = [
                         },
                         {
                             type: 'button',
-                            label: 'Donate',
-                            href: DONATE_LINK,
+                            label: 'Blog',
+                            href: OS_HUB_BLOG_LINK,
                         },
                     ],
                 },

--- a/src/react/src/util/constants.jsx
+++ b/src/react/src/util/constants.jsx
@@ -832,12 +832,14 @@ export const FooterLinks = [
         href: 'https://share.hsforms.com/1bQwXClZUTjihXk3wt1SX2Abujql',
     },
     { label: 'FAQs', href: `${InfoLink}/${InfoPaths.faqs}` },
-    { label: 'Privacy Policy', href: `${InfoLink}/${InfoPaths.privacyPolicy}` },
+    { label: 'Careers', href: `${InfoLink}/work-with-us` },
     { label: 'Media Hub', href: `${InfoLink}/${InfoPaths.mediaHub}` },
+    { label: 'Blog', href: OS_HUB_BLOG_LINK },
     {
         label: 'Terms of Service',
         href: `${InfoLink}/${InfoPaths.termsOfService}`,
     },
+    { label: 'Privacy Policy', href: `${InfoLink}/${InfoPaths.privacyPolicy}` },
     { label: 'Reporting Line', href: 'https://opensupplyhub.allvoices.co/' },
     { label: 'Contact Us', href: `${InfoLink}/${InfoPaths.contactUs}` },
 ];


### PR DESCRIPTION
[OSDEV-1030](https://opensupplyhub.atlassian.net/browse/OSDEV-1030) Site Header & Footer. Add Blog and Career Links, change order of links on footer.

Replaced the "Donate" button with a "Blog" button in the header and added links to the "Blog" and "Careers" pages in the footer. 
These changes ensure a consistent user experience across both ([map site](http://www.opensupplyhub.org/) and [info site](https://info.opensupplyhub.org/)), making navigation easier and more intuitive for users.

