### PR TITLE
Remove calling clean_facilitylistitems command from post_deployment command

### DIFF
--- a/src/django/api/management/commands/post_deployment.py
+++ b/src/django/api/management/commands/post_deployment.py
@@ -9,4 +9,3 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         call_command('migrate')
-        call_command('clean_facilitylistitems')


### PR DESCRIPTION
Removed calling `clean_facilitylistitems` command from `post_deployment` command.