### PR TITLE
Change format of AWS CloudWatch to not log IP address

### DIFF
--- a/deployment/terraform/task-definitions/app.json
+++ b/deployment/terraform/task-definitions/app.json
@@ -8,7 +8,7 @@
       "--workers=${gunicorn_workers}",
       "--timeout=${gunicorn_worker_timeout}",
       "--access-logfile=-",
-      "--access-logformat=%({X-Forwarded-For}i)s %(h)s %(l)s %(u)s %(t)s \"%(r)s\" %(s)s %(b)s \"%(f)s\" \"%(a)s\"",
+      "--access-logformat=%(t)s '%(r)s' %(s)s '%(a)s' | %(M)sms",
       "--error-logfile=-",
       "--log-level=info",
       "--capture-output",

--- a/deployment/terraform/task-definitions/app.json
+++ b/deployment/terraform/task-definitions/app.json
@@ -8,7 +8,7 @@
       "--workers=${gunicorn_workers}",
       "--timeout=${gunicorn_worker_timeout}",
       "--access-logfile=-",
-      "--access-logformat=%(t)s '%(r)s' %(s)s '%(a)s' | %(M)sms",
+      "--access-logformat=%(t)s '%(r)s' %(s)s | %(M)sms",
       "--error-logfile=-",
       "--log-level=info",
       "--capture-output",

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-1069](https://opensupplyhub.atlassian.net/browse/OSDEV-1069) - The following changes have been made:
     * Changed the Postgres Docker image for the database to use the official one and make the local database setup platform-agnostic, so it doesn't depend on the processor architecture.
     * Built the PostGIS program from source and installed it to avoid LLVM-related errors inside the database Docker container during local development.
+* [OSDEV-1089](https://opensupplyhub.atlassian.net/browse/OSDEV-1089) Change format gunicurn logs not pass IP address to AWS CloudWatch.
 
 ### Bugfix
 * [OSDEV-1019](https://opensupplyhub.atlassian.net/browse/OSDEV-1019) - Fixed an error message to 'Your account is not verified. Check your email for a confirmation link.' when a user tries to log in with an uppercase letter in the email address and their account has not been activated through the confirmation link.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       - "--reload"
       - "--timeout=90"
       - "--access-logfile=-"
-      - "--access-logformat=%(t)s '%(r)s' %(s)s '%(a)s' | %(M)sms"
+      - "--access-logformat=%(t)s '%(r)s' %(s)s | %(M)sms"
       - "--error-logfile=-"
       - "--log-level=info"
       - "oar.wsgi"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,8 +61,9 @@ services:
       - "--reload"
       - "--timeout=90"
       - "--access-logfile=-"
+      - "--access-logformat=%(t)s '%(r)s' %(s)s '%(a)s' | %(M)sms"
       - "--error-logfile=-"
-      - "--log-level=debug"
+      - "--log-level=info"
       - "oar.wsgi"
     ports:
       - "8081:8081"


### PR DESCRIPTION
* update AWS log format so that lines look like this:
`[11/Jun/2024:21:06:48 +0000] 'GET /web/environment.js HTTP/1.1' 200 | 3118ms`