### PR TITLE
[Osdev-1004] fix opensearch count property

### DIFF
--- a/deployment/terraform/container_service.tf
+++ b/deployment/terraform/container_service.tf
@@ -380,7 +380,9 @@ data "template_file" "app_logstash" {
     image                            = local.app_logstash_image
     log_group_name                   = "log${local.short}AppLogstash"
     aws_region                       = var.aws_region
-    opensearch_endpoint              = "${aws_opensearch_domain.opensearch.endpoint}:${var.opensearch_port}"
+    # TODO: enable opensearch_enpoint once count in opensearch.tf be removed
+    # opensearch_endpoint              = "${aws_opensearch_domain.opensearch.endpoint}:${var.opensearch_port}"
+    opensearch_endpoint              = null
     postgres_host                    = aws_route53_record.database.name
     postgres_port                    = module.database_enc.port
     postgres_user                    = var.rds_database_username

--- a/deployment/terraform/container_service.tf
+++ b/deployment/terraform/container_service.tf
@@ -380,7 +380,8 @@ data "template_file" "app_logstash" {
     image                            = local.app_logstash_image
     log_group_name                   = "log${local.short}AppLogstash"
     aws_region                       = var.aws_region
-    opensearch_endpoint              = "${aws_opensearch_domain.opensearch.endpoint}:${var.opensearch_port}",
+    # TODO: Once count in openseach.tf be removed, remove [count.index] as well.
+    opensearch_endpoint              = "${aws_opensearch_domain.opensearch[count.index].endpoint}:${var.opensearch_port}"
     postgres_host                    = aws_route53_record.database.name
     postgres_port                    = module.database_enc.port
     postgres_user                    = var.rds_database_username

--- a/deployment/terraform/container_service.tf
+++ b/deployment/terraform/container_service.tf
@@ -382,7 +382,7 @@ data "template_file" "app_logstash" {
     aws_region                       = var.aws_region
     # TODO: enable opensearch_enpoint once count in opensearch.tf be removed
     # opensearch_endpoint              = "${aws_opensearch_domain.opensearch.endpoint}:${var.opensearch_port}"
-    opensearch_endpoint              = null
+    opensearch_endpoint              = "dummy-opensearch-endpoint"
     postgres_host                    = aws_route53_record.database.name
     postgres_port                    = module.database_enc.port
     postgres_user                    = var.rds_database_username

--- a/deployment/terraform/container_service.tf
+++ b/deployment/terraform/container_service.tf
@@ -380,8 +380,7 @@ data "template_file" "app_logstash" {
     image                            = local.app_logstash_image
     log_group_name                   = "log${local.short}AppLogstash"
     aws_region                       = var.aws_region
-    # TODO: Once count in openseach.tf be removed, remove [count.index] as well.
-    opensearch_endpoint              = "${aws_opensearch_domain.opensearch[count.index].endpoint}:${var.opensearch_port}"
+    opensearch_endpoint              = "${aws_opensearch_domain.opensearch.endpoint}:${var.opensearch_port}"
     postgres_host                    = aws_route53_record.database.name
     postgres_port                    = module.database_enc.port
     postgres_user                    = var.rds_database_username

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -387,8 +387,9 @@ data "aws_iam_policy_document" "opensearch" {
   statement {
     effect = "Allow"
     resources = [
-      # TODO: Once count in openseach.tf be removed, remove [count.index] as well.
-      aws_opensearch_domain.opensearch[count.index].arn
+      # TODO: Once count in openseach.tf be removed, uncomment this.
+      # aws_opensearch_domain.opensearch.arn
+      "*"
     ]
     actions = [
       "es:ESHttpPost",

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -387,7 +387,8 @@ data "aws_iam_policy_document" "opensearch" {
   statement {
     effect = "Allow"
     resources = [
-      aws_opensearch_domain.opensearch.arn
+      # TODO: Once count in openseach.tf be removed, remove [count.index] as well.
+      aws_opensearch_domain.opensearch[count.index].arn
     ]
     actions = [
       "es:ESHttpPost",

--- a/deployment/terraform/opensearch.tf
+++ b/deployment/terraform/opensearch.tf
@@ -15,6 +15,8 @@ resource "aws_cloudwatch_log_group" "opensearch" {
 
 resource "aws_opensearch_domain" "opensearch" {
   // TODO: remove 'count' meta-argument once OpenSearch will be fully setup
+  // Related procedure should be done in deployment/terraform/iam.tf -> data "aws_iam_policy_document" "opensearch"
+  // and in deployment/terraform/container_service.tf -> opensearch_endpoint
   count          = 0
   domain_name    = "opensearch-domain"
   engine_version = "OpenSearch_2.13"


### PR DESCRIPTION
Fix error while temporal disabling of the OpenSearch:

```
│ Error: Missing resource instance key
│ 
│   on iam.tf line 390, in data "aws_iam_policy_document" "opensearch":
│  390:       aws_opensearch_domain.opensearch.arn
│ 
│ Because aws_opensearch_domain.opensearch has "count" set, its attributes
│ must be accessed on specific instances.
│ 
│ For example, to correlate with indices of a referring resource, use:
│     aws_opensearch_domain.opensearch[count.index]
```

See error message [here](https://github.com/opensupplyhub/open-supply-hub/actions/runs/9594661205/job/26457722475#step:7:170).