### PR TITLE
[OSDEV-1098] Reporting. A columns values in the report "Contributor type by %" are not cumulative.

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -40,7 +40,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * For the job `clean_ecr_repositories` of Destroy Environment action, it was added a new line to the script responsible for deleting ECR repositories, specifically targeting the `opensupplyhub-logstash` repository.
 
 ### Bugfix
-* *Describe bugfix here.*
+* [OSDEV-1098](https://opensupplyhub.atlassian.net/browse/OSDEV-1098) Reporting. A columns values in the report "Contributor type by %" are not cumulative. The SQL for the report has been rewritten in such a way that first calculates the monthly counts, then computes the cumulative counts for each month, and finally applies the calc_column function to get the desired percentages. This gives us the accumulated values for each month.
 
 ### What's new
 * [OSDEV-933](https://opensupplyhub.atlassian.net/browse/OSDEV-933) Facility Claims. Add "what is claims" screen. `What is claims` page with radio buttons has been added that explains more about the claim. Updated title and link text for not logged in user who wants to claim a production location.

--- a/src/django/api/reports/contributor_type_by_percent.sql
+++ b/src/django/api/reports/contributor_type_by_percent.sql
@@ -1,38 +1,68 @@
+-- Count the total number of contributors which cumulate each month
+-- Count cumulative level of contributor type by % only for contributors that have active data.
+
 CREATE OR REPLACE FUNCTION calc_column(total_count bigint, filtered_count bigint)
 RETURNS text AS $$
 DECLARE
-begin
-	IF total_count=0 then
+BEGIN
+    IF total_count = 0 THEN
         RETURN '0%';
     ELSE
-        RETURN round(100.0 * filtered_count /total_count,2) || '%';
+        RETURN round(100.0 * filtered_count / total_count, 2) || '%';
     END IF;
 END;
 $$ LANGUAGE plpgsql;
-SELECT
-  month,
-  COUNT(*) AS total_contributors,
-  calc_column(COUNT(*), COUNT(*) filter (where contrib_type ='Brand / Retailer')) as "Brand / Retailer",
-  calc_column(COUNT(*), COUNT(*) filter (where contrib_type ='Civil Society Organization')) as "Civil Society Organization",
-  calc_column(COUNT(*), COUNT(*) filter (where contrib_type ='Facility / Factory / Manufacturing Group / Supplier / Vendor')) as "Facility / Factory / Manufacturing Group / Supplier / Vendor",
-  calc_column(COUNT(*), COUNT(*) filter (where contrib_type ='Multi-Stakeholder Initiative')) as "Multi-Stakeholder Initiative",
-  calc_column(COUNT(*), COUNT(*) filter (where contrib_type ='Auditor / Certification Scheme / Service Provider')) as "Auditor / Certification Scheme / Service Provider",
-  calc_column(COUNT(*), COUNT(*) filter (where contrib_type ='Academic / Researcher / Journalist / Student')) as "Academic / Researcher / Journalist / Student",
-  calc_column(COUNT(*), COUNT(*) filter (where contrib_type ='Other')) as "Other"
-FROM (
-  SELECT distinct
+WITH base_query AS (
+  SELECT
     min(to_char(s.created_at, 'YYYY-MM')) AS month,
     c.id,
     c.contrib_type
-    FROM api_facilitymatch m
-        JOIN api_facilitylistitem i on m.facility_list_item_id = i.id
-        JOIN api_source s on i.source_id = s.id
-        JOIN api_contributor c ON s.contributor_id = c.id
-        JOIN api_user u ON u.id = c.admin_id
-    WHERE m.status NOT IN ('REJECTED', 'PENDING')
+  FROM api_facilitymatch m
+    JOIN api_facilitylistitem i ON m.facility_list_item_id = i.id
+    JOIN api_source s ON i.source_id = s.id
+    JOIN api_contributor c ON s.contributor_id = c.id
+    JOIN api_user u ON u.id = c.admin_id
+  WHERE m.status NOT IN ('REJECTED', 'PENDING')
     AND u.email NOT LIKE '%openapparel.org%'
     AND u.email NOT LIKE '%opensupplyhub.org%'
   GROUP BY c.id, c.contrib_type
-) q
-GROUP BY month
+),
+monthly_counts AS (
+  SELECT
+    month,
+    COUNT(*) AS total_contributors,
+    COUNT(*) FILTER (WHERE contrib_type = 'Brand / Retailer') AS "Brand / Retailer",
+    COUNT(*) FILTER (WHERE contrib_type = 'Civil Society Organization') AS "Civil Society Organization",
+    COUNT(*) FILTER (WHERE contrib_type = 'Facility / Factory / Manufacturing Group / Supplier / Vendor') AS "Facility / Factory / Manufacturing Group / Supplier / Vendor",
+    COUNT(*) FILTER (WHERE contrib_type = 'Multi-Stakeholder Initiative') AS "Multi-Stakeholder Initiative",
+    COUNT(*) FILTER (WHERE contrib_type = 'Auditor / Certification Scheme / Service Provider') AS "Auditor / Certification Scheme / Service Provider",
+    COUNT(*) FILTER (WHERE contrib_type = 'Academic / Researcher / Journalist / Student') AS "Academic / Researcher / Journalist / Student",
+    COUNT(*) FILTER (WHERE contrib_type = 'Other') AS "Other"
+  FROM base_query
+  GROUP BY month
+),
+cumulative_counts AS (
+  SELECT
+    month,
+    SUM(total_contributors) OVER (ORDER BY month) AS total_contributors,
+    SUM("Brand / Retailer") OVER (ORDER BY month) AS "Brand / Retailer",
+    SUM("Civil Society Organization") OVER (ORDER BY month) AS "Civil Society Organization",
+    SUM("Facility / Factory / Manufacturing Group / Supplier / Vendor") OVER (ORDER BY month) AS "Facility / Factory / Manufacturing Group / Supplier / Vendor",
+    SUM("Multi-Stakeholder Initiative") OVER (ORDER BY month) AS "Multi-Stakeholder Initiative",
+    SUM("Auditor / Certification Scheme / Service Provider") OVER (ORDER BY month) AS "Auditor / Certification Scheme / Service Provider",
+    SUM("Academic / Researcher / Journalist / Student") OVER (ORDER BY month) AS "Academic / Researcher / Journalist / Student",
+    SUM("Other") OVER (ORDER BY month) AS "Other"
+  FROM monthly_counts
+)
+SELECT
+  month,
+  total_contributors,
+  calc_column(total_contributors, "Brand / Retailer") AS "Brand / Retailer",
+  calc_column(total_contributors, "Civil Society Organization") AS "Civil Society Organization",
+  calc_column(total_contributors, "Facility / Factory / Manufacturing Group / Supplier / Vendor") AS "Facility / Factory / Manufacturing Group / Supplier / Vendor",
+  calc_column(total_contributors, "Multi-Stakeholder Initiative") AS "Multi-Stakeholder Initiative",
+  calc_column(total_contributors, "Auditor / Certification Scheme / Service Provider") AS "Auditor / Certification Scheme / Service Provider",
+  calc_column(total_contributors, "Academic / Researcher / Journalist / Student") AS "Academic / Researcher / Journalist / Student",
+  calc_column(total_contributors, "Other") AS "Other"
+FROM cumulative_counts
 ORDER BY month DESC;


### PR DESCRIPTION
[OSDEV-1098](https://opensupplyhub.atlassian.net/browse/OSDEV-1098) Reporting. A column's values in the report "Contributor type by %" are not cumulative.

 The SQL for the report has been rewritten in such a way that first calculates the monthly counts, then computes the cumulative counts for each month, and finally applies the calc_column function to get the desired 
percentages. This gives us the accumulated values for each month.

<img width="500" alt="Screenshot 2024-06-21 at 12 06 22" src="https://github.com/opensupplyhub/open-supply-hub/assets/9516550/f02a2917-41cc-4c50-a39f-27e69b82d964">