### PR TITLE
[OSDEV-1088] Disable collecting users' public IP addresses in the Rollbar error tracker

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -44,6 +44,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### What's new
 * [OSDEV-933](https://opensupplyhub.atlassian.net/browse/OSDEV-933) Facility Claims. Add "what is claims" screen. `What is claims` page with radio buttons has been added that explains more about the claim. Updated title and link text for not logged in user who wants to claim a production location.
+* [OSDEV-1088](https://opensupplyhub.atlassian.net/browse/OSDEV-1088) - Collecting users' public IP addresses in the Rollbar error tracker has been disabled to meet GDPR compliance.
 
 ### Release instructions:
 * Update code.

--- a/src/dedupe-hub/api/app/utils/constants.py
+++ b/src/dedupe-hub/api/app/utils/constants.py
@@ -11,6 +11,7 @@ ROLLBAR = {
     'environment': settings.env.lower(),
     'root': BASE_DIR,
     'suppress_reinit_warning': True,
+    'capture_ip': False
 }
 
 COUNTRY_CHOICES = [

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -476,6 +476,7 @@ if not DEBUG:
         'environment': ENVIRONMENT.lower(),
         'root': BASE_DIR,
         'suppress_reinit_warning': True,
+        'capture_ip': False
     }
     import rollbar
     rollbar.init(**ROLLBAR)

--- a/src/react/public/index.html
+++ b/src/react/public/index.html
@@ -83,6 +83,7 @@
           accessToken: window.ENVIRONMENT.REACT_APP_ROLLBAR_CLIENT_SIDE_ACCESS_TOKEN,
           captureUncaught: true,
           captureUnhandledRejections: true,
+          captureIp: false,
           payload: {
             environment: window.ENVIRONMENT.ENVIRONMENT,
             javascript: {


### PR DESCRIPTION
[OSDEV-1088](https://opensupplyhub.atlassian.net/browse/OSDEV-1088) Collecting users' public IP addresses in the Rollbar error tracker has been disabled to meet GDPR compliance.