### PR TITLE
[OSDEV-1036] Claims. Add a sortable "claim decision" column to claims admin page. 

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### What's new
 * [OSDEV-1105](https://opensupplyhub.atlassian.net/browse/OSDEV-1105) - Contribution. Allow commas in list name and update error message.
 * [OSDEV-272](https://opensupplyhub.atlassian.net/browse/OSDEV-272) - Facility Claims Page. Implement ascending/descending and alphabetic sort on FE.
+* [OSDEV-1036](https://opensupplyhub.atlassian.net/browse/OSDEV-1036) - Claims. Add a sortable "claim decision" column to claims admin page.
 
 ### Release instructions:
 * *Provide release instructions here.*

--- a/src/django/api/serializers/facility/facility_claim_serializer.py
+++ b/src/django/api/serializers/facility/facility_claim_serializer.py
@@ -13,13 +13,13 @@ class FacilityClaimSerializer(ModelSerializer):
     contributor_id = SerializerMethodField()
     facility_address = SerializerMethodField()
     facility_country_name = SerializerMethodField()
-    last_decision = SerializerMethodField()
+    claim_decision = SerializerMethodField()
 
     class Meta:
         model = FacilityClaim
         fields = ('id', 'created_at', 'updated_at', 'contributor_id', 'os_id',
                   'contributor_name', 'facility_name', 'facility_address',
-                  'facility_country_name', 'status', 'last_decision')
+                  'facility_country_name', 'status', 'claim_decision')
 
     def get_facility_name(self, claim):
         return claim.facility.name
@@ -39,5 +39,5 @@ class FacilityClaimSerializer(ModelSerializer):
     def get_facility_country_name(self, claim):
         return COUNTRY_NAMES.get(claim.facility.country_code, '')
     
-    def get_last_decision(self, claim):
+    def get_claim_decision(self, claim):
         return claim.status_change_date

--- a/src/django/api/serializers/facility/facility_claim_serializer.py
+++ b/src/django/api/serializers/facility/facility_claim_serializer.py
@@ -13,12 +13,13 @@ class FacilityClaimSerializer(ModelSerializer):
     contributor_id = SerializerMethodField()
     facility_address = SerializerMethodField()
     facility_country_name = SerializerMethodField()
+    last_decision = SerializerMethodField()
 
     class Meta:
         model = FacilityClaim
         fields = ('id', 'created_at', 'updated_at', 'contributor_id', 'os_id',
                   'contributor_name', 'facility_name', 'facility_address',
-                  'facility_country_name', 'status')
+                  'facility_country_name', 'status', 'last_decision')
 
     def get_facility_name(self, claim):
         return claim.facility.name
@@ -37,3 +38,6 @@ class FacilityClaimSerializer(ModelSerializer):
 
     def get_facility_country_name(self, claim):
         return COUNTRY_NAMES.get(claim.facility.country_code, '')
+    
+    def get_last_decision(self, claim):
+        return claim.status_change_date

--- a/src/django/api/serializers/facility/facility_claim_serializer.py
+++ b/src/django/api/serializers/facility/facility_claim_serializer.py
@@ -38,6 +38,6 @@ class FacilityClaimSerializer(ModelSerializer):
 
     def get_facility_country_name(self, claim):
         return COUNTRY_NAMES.get(claim.facility.country_code, '')
-    
+
     def get_claim_decision(self, claim):
         return claim.status_change_date

--- a/src/django/api/tests/test_facility_claim_serializer.py
+++ b/src/django/api/tests/test_facility_claim_serializer.py
@@ -8,7 +8,9 @@ from api.models import (
     User,
 )
 from api.serializers import ApprovedFacilityClaimSerializer
+from api.serializers import FacilityClaimSerializer
 
+from django.utils import timezone
 from django.contrib.gis.geos import Point
 from django.test import TestCase
 
@@ -70,3 +72,22 @@ class FacilityClaimSerializerTest(TestCase):
         self.assertIn("production_type_choices", data)
         self.assertIsNotNone(data["production_type_choices"])
         self.assertNotEqual([], data["production_type_choices"])
+    
+    def test_claim_decision(self):
+        claim_one = FacilityClaim.objects.create(
+            contributor=self.contributor,
+            facility=self.facility,
+            status=FacilityClaim.PENDING,
+        )
+        data_one = FacilityClaimSerializer(claim_one).data
+
+        self.assertIsNone(data_one["claim_decision"])
+
+        date = timezone.now()
+
+        claim_one.status_change_date = date
+        claim_one.save()
+
+        data_two = FacilityClaimSerializer(claim_one).data
+
+        self.assertEqual(data_two["claim_decision"], date)

--- a/src/django/api/tests/test_facility_claim_serializer.py
+++ b/src/django/api/tests/test_facility_claim_serializer.py
@@ -72,7 +72,7 @@ class FacilityClaimSerializerTest(TestCase):
         self.assertIn("production_type_choices", data)
         self.assertIsNotNone(data["production_type_choices"])
         self.assertNotEqual([], data["production_type_choices"])
-    
+
     def test_claim_decision(self):
         claim_one = FacilityClaim.objects.create(
             contributor=self.contributor,

--- a/src/react/src/__tests__/components/DashboardClaimsListTable.test.js
+++ b/src/react/src/__tests__/components/DashboardClaimsListTable.test.js
@@ -9,6 +9,7 @@ const data = [
         "id": 184,
         "created_at": "2024-06-14T10:45:53.857805Z",
         "updated_at": "2024-06-14T13:25:49.835368Z",
+        "claim_decision": "2024-06-14T13:25:49.835368Z",
         "contributor_id": 1002,
         "os_id": "TR2024425AKVM2E",
         "contributor_name": "Contributor B",
@@ -21,6 +22,7 @@ const data = [
         "id": 45,
         "created_at": "2024-06-13T05:38:41.859592Z",
         "updated_at": "2024-06-13T05:38:41.859607Z",
+        "claim_decision": null,
         "contributor_id": 1003,
         "os_id": "UK2661125AKVMHV",
         "contributor_name": "Contributor C",
@@ -33,6 +35,7 @@ const data = [
         "id": 24,
         "created_at": "2024-06-13T00:48:46.677503Z",
         "updated_at": "2024-06-13T00:48:46.677518Z",
+        "claim_decision": null,
         "contributor_id": 1004,
         "os_id": "CN3023325AKVMQ3",
         "contributor_name": "Contributor D",
@@ -45,6 +48,7 @@ const data = [
         "id": 12,
         "created_at": "2024-06-15T04:52:16.352025Z",
         "updated_at": "2024-06-15T04:52:16.352040Z",
+        "claim_decision": "2024-06-15T04:52:16.352040Z",
         "contributor_id": 1001,
         "os_id": "CN2021177AKVM66",
         "contributor_name": "Contributor A",
@@ -57,6 +61,7 @@ const data = [
         "id": 3,
         "created_at": "2024-06-13T00:24:49.566190Z",
         "updated_at": "2024-06-13T00:24:49.566204Z",
+        "claim_decision": "2024-06-13T00:24:49.566204Z",
         "contributor_id": 1005,
         "os_id": "SP2421145AKVMH4",
         "contributor_name": "Contributor E",
@@ -69,6 +74,7 @@ const data = [
         "id": 20,
         "created_at": "2024-06-15T04:58:23.352025Z",
         "updated_at": "2024-06-15T05:23:10.352040Z",
+        "claim_decision": "2024-06-15T05:23:10.352040Z",
         "contributor_id": 1006,
         "os_id": "DM5021177DCET89",
         "contributor_name": "contributor b (lowercase test)",
@@ -199,6 +205,19 @@ describe('DashboardClaimsListTable component', () => {
             const sortedData = handleSortClaimsMock.mock.calls[0][0];
             expect(sortedData[0].status).toBe('APPROVED');
             expect(sortedData[sortedData.length - 1].status).toBe('REVOKED');
+        });
+    });
+
+    it('sort by claim decision in ascending order', async () => {
+        act(() => {
+            fireEvent.click(screen.getByText('Claim Decision'));
+        });
+
+        await waitFor(() => {
+            expect(handleSortClaimsMock).toHaveBeenCalled();
+            const sortedData = handleSortClaimsMock.mock.calls[0][0];
+            expect(sortedData[0].claim_decision).toBe('2024-06-13T00:24:49.566204Z');
+            expect(sortedData[sortedData.length - 1].claim_decision).toBe(null);
         });
     });
 });

--- a/src/react/src/components/DashboardClaimsListTable.jsx
+++ b/src/react/src/components/DashboardClaimsListTable.jsx
@@ -165,6 +165,9 @@ function DashboardClaimsListTable({
                                 <TableCell padding="dense">
                                     {claim.status}
                                 </TableCell>
+                                <TableCell padding="dense">
+                                    {claim.last_decision}
+                                </TableCell>
                             </TableRow>
                         ))}
                     </TableBody>

--- a/src/react/src/components/DashboardClaimsListTable.jsx
+++ b/src/react/src/components/DashboardClaimsListTable.jsx
@@ -160,13 +160,17 @@ function DashboardClaimsListTable({
                                     {moment(claim.created_at).format('LL')}
                                 </TableCell>
                                 <TableCell padding="dense">
-                                    {moment(claim.updated_at).format('LL')}
+                                    {claim.claim_decision !== null
+                                        ? moment(claim.claim_decision).format(
+                                              'LL',
+                                          )
+                                        : 'N/A'}
                                 </TableCell>
                                 <TableCell padding="dense">
                                     {claim.status}
                                 </TableCell>
                                 <TableCell padding="dense">
-                                    {claim.last_decision}
+                                    {moment(claim.updated_at).format('LL')}
                                 </TableCell>
                             </TableRow>
                         ))}

--- a/src/react/src/components/DashboardClaimsListTableHeader.jsx
+++ b/src/react/src/components/DashboardClaimsListTableHeader.jsx
@@ -68,6 +68,12 @@ const claimsListHeadCells = [
         disablePadding: true,
         label: 'Status',
     },
+    {
+        id: 'last_decision',
+        numeric: false,
+        disablePadding: true,
+        label: 'Last Decision',
+    },
 ];
 
 function DashboardClaimsListTableHeader({

--- a/src/react/src/components/DashboardClaimsListTableHeader.jsx
+++ b/src/react/src/components/DashboardClaimsListTableHeader.jsx
@@ -57,10 +57,10 @@ const claimsListHeadCells = [
         label: 'Created',
     },
     {
-        id: 'updated_at',
+        id: 'claim_decision',
         numeric: false,
         disablePadding: true,
-        label: 'Last Updated',
+        label: 'Claim Decision',
     },
     {
         id: 'status',
@@ -69,10 +69,10 @@ const claimsListHeadCells = [
         label: 'Status',
     },
     {
-        id: 'last_decision',
+        id: 'updated_at',
         numeric: false,
         disablePadding: true,
-        label: 'Last Decision',
+        label: 'Last Updated',
     },
 ];
 

--- a/src/react/src/components/DashboardClaimsListTableHeader.jsx
+++ b/src/react/src/components/DashboardClaimsListTableHeader.jsx
@@ -19,9 +19,6 @@ const DashboardClaimsListTableHeaderStyles = Object.freeze({
     fourthTh: {
         width: '90px',
     },
-    sixthTh: {
-        width: '100px',
-    },
 });
 
 // Table header ids should match keys from BE
@@ -93,7 +90,9 @@ function DashboardClaimsListTableHeader({
             case 3:
                 return classes.fourTh;
             case 5:
-                return classes.sixthTh;
+                return classes.thirdTh;
+            case 7:
+                return classes.thirdTh;
             default:
                 return {};
         }

--- a/src/react/src/util/propTypes.js
+++ b/src/react/src/util/propTypes.js
@@ -334,6 +334,7 @@ export const facilityClaimsListPropType = arrayOf(
         contributor_name: string.isRequired,
         facility_country_name: string.isRequired,
         status: oneOf(Object.values(facilityClaimStatusChoicesEnum)).isRequired,
+        last_decision: string.isReqired,
     }).isRequired,
 );
 

--- a/src/react/src/util/propTypes.js
+++ b/src/react/src/util/propTypes.js
@@ -334,7 +334,7 @@ export const facilityClaimsListPropType = arrayOf(
         contributor_name: string.isRequired,
         facility_country_name: string.isRequired,
         status: oneOf(Object.values(facilityClaimStatusChoicesEnum)).isRequired,
-        last_decision: string.isReqired,
+        claim_decision: string.isReqired,
     }).isRequired,
 );
 

--- a/src/react/src/util/util.js
+++ b/src/react/src/util/util.js
@@ -1145,6 +1145,12 @@ export const logErrorToRollbar = (window, error, user) => {
 };
 
 function descendingComparator(a, b, orderBy) {
+    if (a[orderBy] === null) {
+        return -1;
+    }
+    if (b[orderBy] === null) {
+        return 1;
+    }
     if (b[orderBy] < a[orderBy]) {
         return -1;
     }
@@ -1166,10 +1172,6 @@ export function sort(array, comparator) {
         const order = comparator(a[0], b[0]);
         if (order !== 0) {
             return order;
-        }
-        // to handle 'N/A' or null
-        if (order === 0) {
-            return -1;
         }
         return a[1] - b[1];
     });

--- a/src/react/src/util/util.js
+++ b/src/react/src/util/util.js
@@ -1155,16 +1155,10 @@ function descendingComparator(a, b, orderBy) {
         bValue = bValue.toLowerCase();
     }
 
-    if (aValue === null) {
+    if (aValue === null || bValue < aValue) {
         return -1;
     }
-    if (bValue === null) {
-        return 1;
-    }
-    if (bValue < aValue) {
-        return -1;
-    }
-    if (bValue > aValue) {
+    if (bValue === null || bValue > aValue) {
         return 1;
     }
     return 0;

--- a/src/react/src/util/util.js
+++ b/src/react/src/util/util.js
@@ -1167,6 +1167,10 @@ export function sort(array, comparator) {
         if (order !== 0) {
             return order;
         }
+        // to handle 'N/A' or null
+        if (order === 0) {
+            return -1;
+        }
         return a[1] - b[1];
     });
     return stabilizedThis.map(el => el[0]);


### PR DESCRIPTION
[OSDEV-1036](https://opensupplyhub.atlassian.net/browse/OSDEV-1036) **Claims. Add a sortable "claim decision" column to claims admin page.**
- added new data point 'claim_decision' to response & create new column on page
- update styling & location of the field
- update sort logic for null value


[OSDEV-1036]: https://opensupplyhub.atlassian.net/browse/OSDEV-1036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ