### PR TITLE
[OSDEV-272] Adjust sorting for accented strings

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -28,7 +28,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### What's new
 * [OSDEV-1105](https://opensupplyhub.atlassian.net/browse/OSDEV-1105) - Contribution. Allow commas in list name and update error message.
-* [OSDEV-272](https://opensupplyhub.atlassian.net/browse/OSDEV-272) - Facility Claims Page. Implement ascending/descending and alphabetic sort on FE.
+* [OSDEV-272](https://opensupplyhub.atlassian.net/browse/OSDEV-272) - Facility Claims Page. Implement ascending/descending and alphabetic sort on FE. Applied proper sorting for lower case/upper case/accented strings.
 
 ### Release instructions:
 * *Provide release instructions here.*

--- a/src/react/package.json
+++ b/src/react/package.json
@@ -45,6 +45,7 @@
         "redux-logger": "3.0.6",
         "redux-persist": "5.10.0",
         "redux-thunk": "2.3.0",
+        "remove-accents": "^0.5.0",
         "sass": "^1.54.9",
         "typeface-darker-grotesque": "^1.1.13",
         "user-event": "2.0.1",

--- a/src/react/src/__tests__/components/DashboardClaimsListTable.test.js
+++ b/src/react/src/__tests__/components/DashboardClaimsListTable.test.js
@@ -77,6 +77,66 @@ const data = [
         "facility_country_name": "Greece",
         "status": "REVOKED"
     },
+    {
+        "id": 187,
+        "created_at": "2024-06-16T12:34:56.789012Z",
+        "updated_at": "2024-06-16T13:34:56.789012Z",
+        "contributor_id": 1007,
+        "os_id": "TR5021177AKVM78",
+        "contributor_name": "Contributor Ç",
+        "facility_name": "Facility Ş",
+        "facility_address": "987 Şehit Avenue, Şehit City, Türkiye",
+        "facility_country_name": "Türkiye",
+        "status": "PENDING"
+    },
+    {
+        "id": 188,
+        "created_at": "2024-06-17T12:34:56.789012Z",
+        "updated_at": "2024-06-17T13:34:56.789012Z",
+        "contributor_id": 1008,
+        "os_id": "TR6021177AKVM89",
+        "contributor_name": "Contributor İ",
+        "facility_name": "Facility Ü",
+        "facility_address": "321 Üsküdar Road, Üsküdar City, Türkiye",
+        "facility_country_name": "Türkiye",
+        "status": "APPROVED"
+    },
+    {
+        "id": 189,
+        "created_at": "2024-06-18T12:34:56.789012Z",
+        "updated_at": "2024-06-18T13:34:56.789012Z",
+        "contributor_id": 1009,
+        "os_id": "TR7021177AKVM90",
+        "contributor_name": "Contributor Ö",
+        "facility_name": "Facility Ğ",
+        "facility_address": "654 Ğazi Road, Ğazi City, Türkiye",
+        "facility_country_name": "Türkiye",
+        "status": "PENDING"
+    },
+    {
+        "id": 190,
+        "created_at": "2024-06-19T12:34:56.789012Z",
+        "updated_at": "2024-06-19T13:34:56.789012Z",
+        "contributor_id": 1010,
+        "os_id": "TR8021177AKVM91",
+        "contributor_name": "Contributor ü",
+        "facility_name": "Facility ş",
+        "facility_address": "753 şehitler Road, şehitler City, Türkiye",
+        "facility_country_name": "Türkiye",
+        "status": "PENDING"
+    },
+    {
+        "id": 191,
+        "created_at": "2024-06-20T12:34:56.789012Z",
+        "updated_at": "2024-06-20T13:34:56.789012Z",
+        "contributor_id": 1011,
+        "os_id": "TR9021177AKVM92",
+        "contributor_name": "Contributor ö",
+        "facility_name": "Facility ğ",
+        "facility_address": "852 ğazi Road, ğazi City, Türkiye",
+        "facility_country_name": "Türkiye",
+        "status": "APPROVED"
+    }
 ];
 
 describe('DashboardClaimsListTable component', () => {
@@ -103,7 +163,7 @@ describe('DashboardClaimsListTable component', () => {
             expect(handleSortClaimsMock).toHaveBeenCalled();
             const sortedData = handleSortClaimsMock.mock.calls[0][0];
             expect(sortedData[0].id).toBe(3);
-            expect(sortedData[sortedData.length - 1].id).toBe(184);
+            expect(sortedData[sortedData.length - 1].id).toBe(191);
         });
     });
 
@@ -118,7 +178,14 @@ describe('DashboardClaimsListTable component', () => {
             expect(sortedData[0].facility_name).toBe('Facility Alpha');
             expect(sortedData[1].facility_name).toBe('Facility Beta');
             expect(sortedData[2].facility_name).toBe('facility beta (lowercase test)');
-            expect(sortedData[sortedData.length - 1].facility_name).toBe('Facility Gamma');
+            expect(sortedData[3].facility_name).toBe('Facility Delta');
+            expect(sortedData[4].facility_name).toBe('Facility Epsilon');
+            expect(sortedData[5].facility_name).toBe('Facility Ğ');
+            expect(sortedData[6].facility_name).toBe('Facility ğ');
+            expect(sortedData[7].facility_name).toBe('Facility Gamma');
+            expect(sortedData[8].facility_name).toBe('Facility Ş');
+            expect(sortedData[9].facility_name).toBe('Facility ş');
+            expect(sortedData[sortedData.length - 1].facility_name).toBe('Facility Ü');
         });
     });
 
@@ -133,20 +200,14 @@ describe('DashboardClaimsListTable component', () => {
             expect(sortedData[0].contributor_name).toBe('Contributor A');
             expect(sortedData[1].contributor_name).toBe('Contributor B');
             expect(sortedData[2].contributor_name).toBe('contributor b (lowercase test)');
-            expect(sortedData[sortedData.length - 1].contributor_name).toBe('Contributor E');
-        });
-    });
-
-    it('sort by country in ascending order', async () => {
-        act(() => {
-            fireEvent.click(screen.getByText('Country'));
-        });
-
-        await waitFor(() => {
-            expect(handleSortClaimsMock).toHaveBeenCalled();
-            const sortedData = handleSortClaimsMock.mock.calls[0][0];
-            expect(sortedData[0].facility_country_name).toBe('China');
-            expect(sortedData[sortedData.length - 1].facility_country_name).toBe('United Kingdom');
+            expect(sortedData[3].contributor_name).toBe('Contributor C');
+            expect(sortedData[4].contributor_name).toBe('Contributor Ç');
+            expect(sortedData[5].contributor_name).toBe('Contributor D');
+            expect(sortedData[6].contributor_name).toBe('Contributor E');
+            expect(sortedData[7].contributor_name).toBe('Contributor İ');
+            expect(sortedData[8].contributor_name).toBe('Contributor Ö');
+            expect(sortedData[9].contributor_name).toBe('Contributor ö');
+            expect(sortedData[sortedData.length - 1].contributor_name).toBe('Contributor ü');
         });
     });
 
@@ -172,7 +233,7 @@ describe('DashboardClaimsListTable component', () => {
             expect(handleSortClaimsMock).toHaveBeenCalled();
             const sortedData = handleSortClaimsMock.mock.calls[0][0];
             expect(sortedData[0].created_at).toBe('2024-06-13T00:24:49.566190Z');
-            expect(sortedData[sortedData.length - 1].created_at).toBe('2024-06-15T04:58:23.352025Z');
+            expect(sortedData[sortedData.length - 1].created_at).toBe('2024-06-20T12:34:56.789012Z');
         });
     });
 
@@ -185,7 +246,7 @@ describe('DashboardClaimsListTable component', () => {
             expect(handleSortClaimsMock).toHaveBeenCalled();
             const sortedData = handleSortClaimsMock.mock.calls[0][0];
             expect(sortedData[0].updated_at).toBe('2024-06-13T00:24:49.566204Z');
-            expect(sortedData[sortedData.length - 1].updated_at).toBe('2024-06-15T05:23:10.352040Z');
+            expect(sortedData[sortedData.length - 1].updated_at).toBe('2024-06-20T13:34:56.789012Z');
         });
     });
 

--- a/src/react/src/util/util.js
+++ b/src/react/src/util/util.js
@@ -33,6 +33,7 @@ import { featureCollection, bbox } from '@turf/turf';
 import hash from 'object-hash';
 import * as XLSX from 'xlsx';
 import moment from 'moment';
+import removeAccents from 'remove-accents';
 
 import {
     OTHER,
@@ -1149,10 +1150,10 @@ function descendingComparator(a, b, orderBy) {
     let bValue = b[orderBy];
 
     if (typeof aValue === 'string') {
-        aValue = aValue.toLowerCase();
+        aValue = removeAccents(aValue.toLowerCase());
     }
     if (typeof bValue === 'string') {
-        bValue = bValue.toLowerCase();
+        bValue = removeAccents(bValue.toLowerCase());
     }
 
     if (bValue < aValue) {

--- a/src/react/yarn.lock
+++ b/src/react/yarn.lock
@@ -13080,6 +13080,11 @@ relateurl@^0.2.7:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
+remove-accents@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.5.0.tgz#77991f37ba212afba162e375b627631315bed687"
+  integrity sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"


### PR DESCRIPTION
Introduce right sorting for accented strings as follow-up patch for [OSDEV-272](https://opensupplyhub.atlassian.net/browse/OSDEV-272)

[OSDEV-272]: https://opensupplyhub.atlassian.net/browse/OSDEV-272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ