### PR TITLE
Configure error logging through django settings

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Code/API changes
 * [OSDEV-1100](https://opensupplyhub.atlassian.net/browse/OSDEV-1100) - Replaced all mentions of "facility" and "facilities" with the new production location naming in the Logstash app. Renamed `location` field in the production locations index to `coordinates`.
 * [OSDEV-705](https://opensupplyhub.atlassian.net/browse/OSDEV-705) - Created an additional `RowCoordinatesSerializer` in the ContriCleaner to handle coordinate values ("lat" and "lng"). Moved the conversion of "lat" and "lng" into float point numbers from `FacilityListViewSet` to this serializer.
+* Introduced a general format for all Python logs by updating the Django `LOGGING` constant. Disabled propagation for the `django` logger to the `root` logger to avoid log duplication. Removed unnecessary calls to the `basicConfig` method since only the configuration defined in the `LOGGING` constant in the settings.py file is considered valid by the current Django app.
 
 ### Architecture/Environment changes
 * *Describe architecture/environment changes here.*

--- a/src/django/api/facility_actions/processing_facility_api.py
+++ b/src/django/api/facility_actions/processing_facility_api.py
@@ -24,10 +24,7 @@ from django.core import exceptions as core_exceptions
 from django.utils import timezone
 from django.core.exceptions import ValidationError
 
-# initialize logger
-logging.basicConfig(
-    format='%(asctime)s - %(levelname)s - %(message)s', level=logging.INFO
-)
+# Initialize logger.
 log = logging.getLogger(__name__)
 
 

--- a/src/django/api/facility_actions/processing_facility_list.py
+++ b/src/django/api/facility_actions/processing_facility_list.py
@@ -27,10 +27,7 @@ from django.core.files.uploadedfile import (
     TemporaryUploadedFile,
 )
 
-# initialize logger
-logging.basicConfig(
-    format='%(asctime)s - %(levelname)s - %(message)s', level=logging.INFO
-)
+# Initialize logger.
 log = logging.getLogger(__name__)
 
 

--- a/src/django/api/matching.py
+++ b/src/django/api/matching.py
@@ -659,7 +659,7 @@ class GazetteerCache:
                     # deleted. We don't need to index a deleted facility.
                     if item['id'] in latest_facility_dedupe_records:
                         record = latest_facility_dedupe_records[item['id']]
-                        logger.debug(
+                        logger.info(
                             'Indexing facility {}'.format(str(record)))
                         cls._gazetter.index(record)
                 cls._facility_version = item['history_id']
@@ -719,7 +719,7 @@ class GazetteerCache:
                         # facility.
                         if match and match['is_active']:
                             record = dedupe_record_for_match_item(item)
-                            logger.debug(
+                            logger.info(
                                 'Indexing match {}'.format(str(record)))
                             cls._gazetter.index(record)
                     cls._match_version = item['history_id']

--- a/src/django/api/models/transactions/clean_facilitylistitems.py
+++ b/src/django/api/models/transactions/clean_facilitylistitems.py
@@ -2,10 +2,8 @@ import os
 import logging
 from django.db import transaction, connection
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s'
-)
+# Initialize logger.
+logger = logging.getLogger(__name__)
 
 
 @transaction.atomic
@@ -21,47 +19,47 @@ def clean_facilitylistitems():
 
     with connection.cursor() as cursor:
         try:
-            logging.info('Dropping table triggers...')
+            logger.info('Dropping table triggers...')
             execute_sql_file(cursor, 'drop_table_triggers.sql')
-            logging.info('Table triggers dropped.')
+            logger.info('Table triggers dropped.')
 
-            logging.info(
+            logger.info(
                 'Removing facilitylistitems where facility_id is null...'
             )
             call_procedure(cursor, 'remove_items_where_facility_id_is_null')
-            logging.info(
+            logger.info(
                 'Facilitylistitems where facility_id is null removed.'
             )
 
-            logging.info(
+            logger.info(
                 'Removing facilitylistitems with potential match status more '
                 'than thirty days...'
             )
             call_procedure(cursor, 'remove_old_pending_matches')
-            logging.info(
+            logger.info(
                 'Facilitylistitems with potential match status more than '
                 'thirty days removed.'
             )
 
-            logging.info(
+            logger.info(
                 'Removing facilitylistitems without matches and related '
                 'facilities...'
             )
             call_procedure(
                 cursor, 'remove_items_without_matches_and_related_facilities'
             )
-            logging.info(
+            logger.info(
                 'Facilitylistitems without matches and related facilities '
                 'removed.'
             )
 
-            logging.info('Creating table triggers...')
+            logger.info('Creating table triggers...')
             execute_sql_file(cursor, 'create_table_triggers.sql')
-            logging.info('Table triggers created.')
+            logger.info('Table triggers created.')
 
-            logging.info('Start indexing facilities...')
+            logger.info('Start indexing facilities...')
             call_procedure(cursor, 'index_facilities')
-            logging.info('Facilities indexed.')
+            logger.info('Facilities indexed.')
 
         except Exception as error:
             print(f"An error occurred: {error}")

--- a/src/django/api/views/facility/facilities_view_set.py
+++ b/src/django/api/views/facility/facilities_view_set.py
@@ -98,9 +98,7 @@ from .facility_parameters import (
     facilities_create_parameters,
 )
 
-# initialize logger
-logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s',
-                    level=logging.INFO)
+# Initialize logger.
 log = logging.getLogger(__name__)
 
 

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -291,9 +291,16 @@ CACHES = {
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
+    'formatters': {
+        'simple': {
+            'format': '[{asctime}] [{levelname}] {message}',
+            'style': '{',
+        },
+    },
     'handlers': {
         'console': {
             'class': 'logging.StreamHandler',
+            'formatter': 'simple'
         },
     },
     'root': {
@@ -304,6 +311,7 @@ LOGGING = {
         'django': {
             'handlers': ['console'],
             'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
+            'propagate': False,
         },
     },
 }


### PR DESCRIPTION
- Introduced a general format for all Python logs by updating the Django `LOGGING` constant.
- Disabled propagation for the `django` logger to the `root` logger to avoid log duplication.
- Removed unnecessary calls to the `basicConfig` method since only the configuration defined in the `LOGGING` constant in the settings.py file is considered valid by the current Django app.

Please refer to [the official documentation](https://docs.djangoproject.com/en/3.2/topics/logging/) on configuring Python logging in a Django app.