### PR TITLE
Hotfix [OSDEV-981] Reporting. History of contributor uploads.

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -33,7 +33,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
     * including name, ID, contributor type;
     * first upload, including date of the first upload and time since the first upload in days;
     * most recent (or “last”) upload, including date of the last upload and time since the last upload in days;
-    * total (or “lifetime”) uploads and a calculation for uploads per year (= lifetime uploads/time since the first upload (in years)). This data is ordered based on the “date of last upload” column so that contributors who have recently contributed data are at the top of the report.
+    * total (or “lifetime”) uploads and a calculation for uploads per year (= lifetime uploads = total uploads / (current year - first upload year); if “first upload year” = “current year”, then use 1 in denominator). This data is ordered based on the “date of last upload” column so that contributors who have recently contributed data are at the top of the report.
 * [OSDEV-1105](https://opensupplyhub.atlassian.net/browse/OSDEV-1105) - Contribution. Allow commas in list name and update error message.
 * [OSDEV-272](https://opensupplyhub.atlassian.net/browse/OSDEV-272) - Facility Claims Page. Implement ascending/descending and alphabetic sort on FE. Applied proper sorting for lower case/upper case/accented strings.
 * [OSDEV-1036](https://opensupplyhub.atlassian.net/browse/OSDEV-1036) - Claims. Add a sortable "claim decision" column to claims admin page.

--- a/src/django/api/reports/history_of_contributor_uploads.sql
+++ b/src/django/api/reports/history_of_contributor_uploads.sql
@@ -8,13 +8,14 @@ SELECT
   COALESCE(CURRENT_DATE - MAX(l.created_at)::date,CURRENT_DATE - MAX(s.created_at)::date) AS "Time Since Last Upload (Days)",
   COUNT(*) AS "Lifetime Uploads",
   COALESCE(
-    ROUND(
-      CASE
-        WHEN (CURRENT_DATE - COALESCE(MIN(l.created_at), MIN(s.created_at))::date) / 365.25 = 0
-        THEN COUNT(*) / (1 / 365.25)
-        ELSE COUNT(*) / ((CURRENT_DATE - COALESCE(MIN(l.created_at), MIN(s.created_at))::date) / 365.25)
+  ROUND(
+        CASE
+        WHEN EXTRACT(YEAR FROM CURRENT_DATE) - EXTRACT(YEAR FROM COALESCE(MIN(l.created_at), MIN(s.created_at))) = 0
+        THEN COUNT(*)::numeric
+        ELSE COUNT(*)::numeric / NULLIF(EXTRACT(YEAR FROM CURRENT_DATE) - EXTRACT(YEAR FROM COALESCE(MIN(l.created_at), MIN(s.created_at))), 0)::numeric
       END,
-    2), 0
+    2),
+    0
   ) AS "Uploads per Year"
 FROM api_contributor ac
 LEFT JOIN api_source s ON s.contributor_id = ac.id


### PR DESCRIPTION
[OSDEV-981](https://opensupplyhub.atlassian.net/browse/OSDEV-981) Reporting. History of contributor uploads.

* rewritten the formula for uploads per year
* changed the task description
<img width="400" alt="Screenshot 2024-07-11 at 16 00 13" src="https://github.com/opensupplyhub/open-supply-hub/assets/9516550/184b4bff-ded4-4e8d-9421-df641eed9285">


[OSDEV-981]: https://opensupplyhub.atlassian.net/browse/OSDEV-981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ