### PR TITLE
Allow push database anonymizer image to ECR

### DIFF
--- a/.github/workflows/deploy_to_aws.yml
+++ b/.github/workflows/deploy_to_aws.yml
@@ -222,7 +222,7 @@ jobs:
         with:
           context: deployment/terraform/database_anonymizer_sheduled_task/docker
           file: deployment/terraform/database_anonymizer_sheduled_task/docker/Dockerfile
-          push: false
+          push: true
           tags: ${{ vars.ECR_REGISTRY }}/${{ vars.IMAGE_NAME }}-database-anonymizer-${{ steps.get_env_name.outputs.lowercase }}:${{ env.GIT_COMMIT }}
 
 


### PR DESCRIPTION
This change allows pushing database-anonimyzer image to ECR.
Must be merged only after merging configuration changes.

