### PR TITLE
[OSDEV-1145]  Fix the error handling for errors from the BE

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * *Describe architecture/environment changes here.*
 
 ### Bugfix
+* [OSDEV-1145](https://opensupplyhub.atlassian.net/browse/OSDEV-1145) - Error message appearing as red dot with no context. Error display has been fixed. Simplified displaying logic of errors. Changed error prop type
 * [OSDEV-576](https://opensupplyhub.atlassian.net/browse/OSDEV-576) - Implemented one source of truth to Search query source & Production Location Details page source for field `number_of_workers`.
 ### What's new
 * [OSDEV-1090](https://opensupplyhub.atlassian.net/browse/OSDEV-1090) - Claims. Remove extra product type field on Claimed Facility Details page.

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -24,7 +24,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * *Describe architecture/environment changes here.*
 
 ### Bugfix
-* [OSDEV-1145](https://opensupplyhub.atlassian.net/browse/OSDEV-1145) - Error message appearing as red dot with no context. Error display has been fixed. Simplified displaying logic of errors. Changed error prop type
+* [OSDEV-1145](https://opensupplyhub.atlassian.net/browse/OSDEV-1145) - Error message appearing as red dot with no context. Error display has been fixed. Simplified displaying logic of errors. Changed error property type.
 * [OSDEV-576](https://opensupplyhub.atlassian.net/browse/OSDEV-576) - Implemented one source of truth to Search query source & Production Location Details page source for field `number_of_workers`.
 ### What's new
 * [OSDEV-1090](https://opensupplyhub.atlassian.net/browse/OSDEV-1090) - Claims. Remove extra product type field on Claimed Facility Details page.

--- a/src/react/src/__tests__/utils.tests.js
+++ b/src/react/src/__tests__/utils.tests.js
@@ -115,10 +115,10 @@ it('gets correct error message component', () => {
     const noFileDataErrors = createUploadFormErrorMessages(correctListName, noFile);
     const noDataErrors = createUploadFormErrorMessages(correctListName, file);
 
-    expect(isEqual(emptyListNameDataErrors[0].errorComponent, componentsWithErrorMessage.missingListName)).toBe(true);
-    expect(isEqual(listNameWithInvalidCharactersDataErrors[0].errorComponent, componentsWithErrorMessage.invalidCharacters)).toBe(true);
-    expect(isEqual(listNameWithOnlySymbolsAndNumbersDataErrors[0].errorComponent, componentsWithErrorMessage.mustConsistOfLetters)).toBe(true);
-    expect(isEqual(noFileDataErrors[0].errorComponent, componentsWithErrorMessage.missingFile)).toBe(true);
+    expect(isEqual(emptyListNameDataErrors[0], componentsWithErrorMessage.missingListName)).toBe(true);
+    expect(isEqual(listNameWithInvalidCharactersDataErrors[0], componentsWithErrorMessage.invalidCharacters)).toBe(true);
+    expect(isEqual(listNameWithOnlySymbolsAndNumbersDataErrors[0], componentsWithErrorMessage.mustConsistOfLetters)).toBe(true);
+    expect(isEqual(noFileDataErrors[0], componentsWithErrorMessage.missingFile)).toBe(true);
     expect(isEqual(noDataErrors.length, 0)).toBe(true);
 });
 

--- a/src/react/src/components/ContributeForm.jsx
+++ b/src/react/src/components/ContributeForm.jsx
@@ -1,5 +1,13 @@
 import React, { Component } from 'react';
-import { arrayOf, bool, func, number, object, string } from 'prop-types';
+import {
+    arrayOf,
+    bool,
+    func,
+    number,
+    string,
+    oneOfType,
+    element,
+} from 'prop-types';
 import { connect } from 'react-redux';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import MaterialButton from '@material-ui/core/Button';
@@ -115,11 +123,8 @@ class ContributeForm extends Component {
                 <React.Fragment>
                     <ul>
                         {error.map(err => (
-                            <li
-                                key={err.errorComponent}
-                                style={{ color: 'red' }}
-                            >
-                                {err.errorComponent}
+                            <li key={err} style={{ color: 'red' }}>
+                                {err}
                             </li>
                         ))}
                     </ul>
@@ -229,7 +234,7 @@ ContributeForm.propTypes = {
     filename: string.isRequired,
     replaces: number.isRequired,
     fetching: bool.isRequired,
-    error: arrayOf(object),
+    error: arrayOf(oneOfType([element, string])),
     updateName: func.isRequired,
     updateDescription: func.isRequired,
     updateFileName: func.isRequired,

--- a/src/react/src/util/constants.jsx
+++ b/src/react/src/util/constants.jsx
@@ -1274,7 +1274,7 @@ export const facilityClaimStepsNames = Object.freeze({
 });
 
 export const componentsWithErrorMessage = Object.freeze({
-    missingListName: <>Missing required Facility List Name</>,
+    missingListName: 'Missing required Facility List Name.',
     invalidCharacters: (
         <>
             The <b>List Name</b> you entered contains invalid characters.
@@ -1284,6 +1284,6 @@ export const componentsWithErrorMessage = Object.freeze({
             ). Characters that contain accents are not allowed.
         </>
     ),
-    mustConsistOfLetters: <>Facility List Name must also consist of letters</>,
-    missingFile: <>Missing required Facility List File</>,
+    mustConsistOfLetters: 'Facility List Name must also consist of letters.',
+    missingFile: 'Missing required Facility List File.',
 });

--- a/src/react/src/util/util.js
+++ b/src/react/src/util/util.js
@@ -604,28 +604,20 @@ export function createUploadFormErrorMessages(name, file) {
     const errorMessages = [];
 
     if (!name) {
-        errorMessages.push({
-            errorComponent: componentsWithErrorMessage.missingListName,
-        });
+        errorMessages.push(componentsWithErrorMessage.missingListName);
     } else {
         // Didn't allow name with invalid characters.
         if (!allowedCharsRegex.test(name)) {
-            errorMessages.push({
-                errorComponent: componentsWithErrorMessage.invalidCharacters,
-            });
+            errorMessages.push(componentsWithErrorMessage.invalidCharacters);
         }
         // Didn't allow name that consists only of symbols or numbers.
         if (restrictedCharsRegex.test(name)) {
-            errorMessages.push({
-                errorComponent: componentsWithErrorMessage.mustConsistOfLetters,
-            });
+            errorMessages.push(componentsWithErrorMessage.mustConsistOfLetters);
         }
     }
 
     if (!file) {
-        errorMessages.push({
-            errorComponent: componentsWithErrorMessage.missingFile,
-        });
+        errorMessages.push(componentsWithErrorMessage.missingFile);
     }
 
     return errorMessages;


### PR DESCRIPTION
[OSDEV-1145](https://opensupplyhub.atlassian.net/browse/OSDEV-1145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ) (https://opensupplyhub.atlassian.net/browse/OSDEV-1145) Error message appearing as a red dot with no context.

* Simplified displaying logic of errors 
* Changed error prop type

The task which was implemented [OSDEV-1105](https://opensupplyhub.atlassian.net/browse/OSDEV-1105)

[OSDEV-1145]: https://opensupplyhub.atlassian.net/browse/OSDEV-1145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OSDEV-1105]: https://opensupplyhub.atlassian.net/browse/OSDEV-1105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ