### PR TITLE
Disable using legacy template endpoint for OpenSearch

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-1090](https://opensupplyhub.atlassian.net/browse/OSDEV-1090) - Claims. Remove extra product type field on Claimed Facility Details page.
 * [OSDEV-273](https://opensupplyhub.atlassian.net/browse/OSDEV-273) - Facility Claims. Implement filtering by Country and Status. Set 'pending' claim status as a default filter.
 * [OSDEV-1083](https://opensupplyhub.atlassian.net/browse/OSDEV-1083) - Implemented a 'toggle password visibility' feature in the login, registration, reset password and user profile forms.
+* The legacy `_template` API endpoint was disabled via the configuration file in favor of the new `_index_template` API endpoint, since the composable index template is used for OpenSearch. The `legacy_template` was set to `false` to start using the defined composable index template in the `production_locations.json` file. This change is necessary to avoid omitting the `production_locations.json` index template for the `production-locations` index defined in the Logstash app and to enforce the OpenSearch cluster to use the explicit mapping for the `production-locations` index.
 
 ### Release instructions:
 * Ensure that the following commands are included in the `post_deployment` command:

--- a/src/logstash/pipeline/sync_production_locations.conf
+++ b/src/logstash/pipeline/sync_production_locations.conf
@@ -124,5 +124,6 @@ output {
     document_id => "%{[@metadata][_id]}"
     template_name => "production_locations_template"
     template => "/usr/share/logstash/indexes/production_locations.json"
+    legacy_template => false
   }
 }


### PR DESCRIPTION
- This PR removes the unintended behaviour where OpenSearch applies [dynamic mapping](https://opensearch.org/docs/latest/field-types/#dynamic-mapping) instead of [explicit mapping](https://opensearch.org/docs/latest/field-types/#explicit-mapping) defined in the Logstash app. For instance, this is extremely important for the `coordinates` field, which, by dynamic mapping, is recognized as a simple object with `lat` and `lon` properties. However, it should be of [the geo_point type](https://opensearch.org/docs/latest/field-types/supported-field-types/geo-point/), which is manually set via the `production_locations.json` index template to enable [Geopolygon queries](https://opensearch.org/docs/latest/query-dsl/geo-and-xy/geopolygon/) for the search performed by drawing the boundary on the map.
<img width="1274" alt="Screenshot 2024-07-19 at 19 23 50" src="https://github.com/user-attachments/assets/7c320ea1-b198-4022-80aa-dda7b431f359">

**Tech Details:**
To fix that bug, the legacy `_template` API endpoint was disabled via the configuration file in favor of the new `_index_template` API endpoint, since [the composable index template](https://opensearch.org/docs/latest/im-plugin/index-templates/#composable-index-templates) is used for OpenSearch. The `legacy_template` was set to `false` to start using the defined composable index template in the `production_locations.json` file. See [the documentation](https://opensearch.org/docs/latest/tools/logstash/ship-to-opensearch/#optional-parameters) about the `legacy_template` configuration parameter. This change is necessary to avoid omitting the `production_locations.json` index template for the `production-locations` index defined in the Logstash app and to enforce the OpenSearch cluster to use the [explicit mapping](https://opensearch.org/docs/latest/field-types/#explicit-mapping) for the `production-locations` index.
