### PR TITLE
Make the OpenSearch domain name unique per environment to avoid conflicts.

### DIFF
--- a/deployment/terraform/opensearch.tf
+++ b/deployment/terraform/opensearch.tf
@@ -14,7 +14,7 @@ resource "aws_cloudwatch_log_group" "opensearch" {
 }
 
 resource "aws_opensearch_domain" "opensearch" {
-  domain_name    = "opensearch-domain"
+  domain_name    = local.opensearch_domain_name
   engine_version = "OpenSearch_2.13"
 
   access_policies = data.aws_iam_policy_document.opensearch_access_policy.json

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -1,6 +1,7 @@
 locals {
-  short             = "${replace(var.project, " ", "")}${var.environment}"
-  files_bucket_name = lower("${replace(var.project, " ", "")}-${var.environment}-files-${var.aws_region}")
+  short                  = "${replace(var.project, " ", "")}${var.environment}"
+  files_bucket_name      = lower("${replace(var.project, " ", "")}-${var.environment}-files-${var.aws_region}")
+  opensearch_domain_name = "${lower("${var.environment}")}-os-domain"
 }
 
 variable "project" {

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -29,7 +29,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-1005](https://opensupplyhub.atlassian.net/browse/OSDEV-1005) - Enable deployment of the Logstash and OpenSearch infra to AWS environments.
 
 ### Bugfix
-* *Describe bugfix here.*
+* Ensure that the OpenSearch domain name is unique for each environment to avoid conflicts when provisioning domains across different environments.
 
 ### What's new
 * [OSDEV-1144](https://opensupplyhub.atlassian.net/browse/OSDEV-1144) - Claims emails. Updated text for approval, revocation, and denial emails.


### PR DESCRIPTION
Bugfix: Make the OpenSearch domain name unique per environment to avoid conflicts.

The domain name was shortened due to this restriction: `invalid value for domain_name (must start with a lowercase alphabet and be at least 3 and no more than 28 characters long. Valid characters are a-z (lowercase letters), 0-9, and - (hyphen).)`