### PR TITLE
Remove triggering indexing in the post deployment command

### DIFF
--- a/src/django/api/management/commands/post_deployment.py
+++ b/src/django/api/management/commands/post_deployment.py
@@ -9,4 +9,3 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         call_command('migrate')
-        call_command('index_facilities_new')


### PR DESCRIPTION
Removed the triggering of indexing in the post-deployment command since it is not necessary for the 1.18.0 release.