### PR TITLE
[OSDEV-1006] Format response output

### DIFF
--- a/src/django/api/services/search.py
+++ b/src/django/api/services/search.py
@@ -16,8 +16,8 @@ class OpenSearchServiceException(Exception):
 
 
 class OpenSearchService(SearchInterface):
-    def __init__(self):
-        self.__client = OpenSearchServiceConnection().client
+    def __init__(self, client=None):
+        self.__client = client or OpenSearchServiceConnection().client
 
     def __prepare_opensearch_response(self, response):
         if not response or "hits" not in response:

--- a/src/django/api/services/search.py
+++ b/src/django/api/services/search.py
@@ -6,29 +6,6 @@ from opensearchpy.exceptions import OpenSearchException
 logger = logging.getLogger(__name__)
 
 
-def prepare_opensearch_response(response):
-    if not response or "hits" not in response:
-        logger.error(f"Invalid response format: {response}")
-        raise OpenSearchServiceException(
-            "Invalid response format from OpenSearch."
-            )
-
-    total_hits = response.get("hits", {}).get("total", {}).get("value", 0)
-    hits = response.get("hits", {}).get("hits", [])
-
-    data = []
-    for hit in hits:
-        if "_source" in hit:
-            data.append(hit["_source"])
-        else:
-            logger.warning(f"Missing '_source' in hit: {hit}")
-
-    return {
-        "count": total_hits,
-        "data": data
-    }
-
-
 class OpenSearchServiceException(Exception):
     def __init__(
         self,
@@ -42,10 +19,32 @@ class OpenSearchService(SearchInterface):
     def __init__(self):
         self.__client = OpenSearchServiceConnection().client
 
+    def __prepare_opensearch_response(self, response):
+        if not response or "hits" not in response:
+            logger.error(f"Invalid response format: {response}")
+            raise OpenSearchServiceException(
+                "Invalid response format from OpenSearch."
+                )
+
+        total_hits = response.get("hits", {}).get("total", {}).get("value", 0)
+        hits = response.get("hits", {}).get("hits", [])
+
+        data = []
+        for hit in hits:
+            if "_source" in hit:
+                data.append(hit["_source"])
+            else:
+                logger.warning(f"Missing '_source' in hit: {hit}")
+
+        return {
+            "count": total_hits,
+            "data": data
+        }
+
     def search_index(self, index_name, query_body):
         try:
             response = self.__client.search(body=query_body, index=index_name)
-            return prepare_opensearch_response(response)
+            return self.__prepare_opensearch_response(response)
 
         except OpenSearchException as e:
             logger.error(f"An error occurred while searching in \

--- a/src/django/api/services/search.py
+++ b/src/django/api/services/search.py
@@ -30,9 +30,10 @@ def prepare_opensearch_response(response):
 
 
 class OpenSearchServiceException(Exception):
-    def __init__(self,
-                 message="An unexpected error occurred  \
-                    while processing the request."):
+    def __init__(
+        self,
+        message="An unexpected error occurred while processing the request."
+    ):
         self.message = message
         super().__init__(self.message)
 

--- a/src/django/api/tests/test_opensearch_response_formatter.py
+++ b/src/django/api/tests/test_opensearch_response_formatter.py
@@ -1,0 +1,89 @@
+import unittest
+from unittest.mock import patch
+from api.services.search import \
+    prepare_opensearch_response, OpenSearchServiceException
+
+
+class TestPrepareOpenSearchResponse(unittest.TestCase):
+
+    @patch('api.services.search.logger')
+    def test_prepare_opensearch_response_valid_response(self, mock_logger):
+        response = {
+            "hits": {
+                "total": {"value": 10},
+                "hits": [
+                    {"_source": {"field1": "value1"}},
+                    {"_source": {"field2": "value2"}}
+                ]
+            }
+        }
+        expected_result = {
+            "count": 10,
+            "data": [
+                {"field1": "value1"},
+                {"field2": "value2"}
+            ]
+        }
+
+        result = prepare_opensearch_response(response)
+        self.assertEqual(result, expected_result)
+        mock_logger.warning.assert_not_called()
+
+    @patch('api.services.search.logger')
+    def test_prepare_opensearch_response_missing_source(self, mock_logger):
+        response = {
+            "hits": {
+                "total": {"value": 10},
+                "hits": [
+                    {"_source": {"field1": "value1"}},
+                    {"other_field": {"field2": "value2"}}
+                ]
+            }
+        }
+        expected_result = {
+            "count": 10,
+            "data": [
+                {"field1": "value1"}
+            ]
+        }
+
+        result = prepare_opensearch_response(response)
+        self.assertEqual(result, expected_result)
+        mock_logger.warning.assert_called_once_with(
+            "Missing '_source' in hit: {'other_field': {'field2': 'value2'}}"
+        )
+
+    @patch('api.services.search.logger')
+    def test_prepare_opensearch_response_no_hits(self, mock_logger):
+        response = {"hits": {"total": {"value": 0}, "hits": []}}
+        expected_result = {"count": 0, "data": []}
+
+        result = prepare_opensearch_response(response)
+        self.assertEqual(result, expected_result)
+        mock_logger.warning.assert_not_called()
+
+    @patch('api.services.search.logger')
+    def test_prepare_opensearch_response_invalid_response_format(
+        self,
+        mock_logger
+    ):
+        response = {}
+        with self.assertRaises(OpenSearchServiceException):
+            prepare_opensearch_response(response)
+        mock_logger.error.assert_called_once_with(
+            "Invalid response format: {}"
+            )
+
+    @patch('api.services.search.logger')
+    def test_prepare_opensearch_response_none_response(
+        self,
+        mock_logger
+    ):
+        with self.assertRaises(OpenSearchServiceException):
+            prepare_opensearch_response(None)
+        mock_logger.error.assert_called_once_with(
+            "Invalid response format: None")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/django/api/tests/test_opensearch_response_formatter.py
+++ b/src/django/api/tests/test_opensearch_response_formatter.py
@@ -1,13 +1,14 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from api.services.search import \
     OpenSearchService, OpenSearchServiceException
 
 
 class TestPrepareOpenSearchResponse(unittest.TestCase):
 
-    def setUp(self) -> None:
-        self.service = OpenSearchService()
+    def setUp(self):
+        self.mock_client = MagicMock()
+        self.service = OpenSearchService(client=self.mock_client)
 
     @patch('api.services.search.logger')
     def test_prepare_opensearch_response_valid_response(self, mock_logger):

--- a/src/django/api/tests/test_opensearch_response_formatter.py
+++ b/src/django/api/tests/test_opensearch_response_formatter.py
@@ -1,10 +1,13 @@
 import unittest
 from unittest.mock import patch
 from api.services.search import \
-    prepare_opensearch_response, OpenSearchServiceException
+    OpenSearchService, OpenSearchServiceException
 
 
 class TestPrepareOpenSearchResponse(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.service = OpenSearchService()
 
     @patch('api.services.search.logger')
     def test_prepare_opensearch_response_valid_response(self, mock_logger):
@@ -25,7 +28,8 @@ class TestPrepareOpenSearchResponse(unittest.TestCase):
             ]
         }
 
-        result = prepare_opensearch_response(response)
+        result = self.service. \
+            _OpenSearchService__prepare_opensearch_response(response)
         self.assertEqual(result, expected_result)
         mock_logger.warning.assert_not_called()
 
@@ -47,7 +51,8 @@ class TestPrepareOpenSearchResponse(unittest.TestCase):
             ]
         }
 
-        result = prepare_opensearch_response(response)
+        result = self.service. \
+            _OpenSearchService__prepare_opensearch_response(response)
         self.assertEqual(result, expected_result)
         mock_logger.warning.assert_called_once_with(
             "Missing '_source' in hit: {'other_field': {'field2': 'value2'}}"
@@ -58,7 +63,8 @@ class TestPrepareOpenSearchResponse(unittest.TestCase):
         response = {"hits": {"total": {"value": 0}, "hits": []}}
         expected_result = {"count": 0, "data": []}
 
-        result = prepare_opensearch_response(response)
+        result = self.service. \
+            _OpenSearchService__prepare_opensearch_response(response)
         self.assertEqual(result, expected_result)
         mock_logger.warning.assert_not_called()
 
@@ -69,7 +75,8 @@ class TestPrepareOpenSearchResponse(unittest.TestCase):
     ):
         response = {}
         with self.assertRaises(OpenSearchServiceException):
-            prepare_opensearch_response(response)
+            self.service. \
+                _OpenSearchService__prepare_opensearch_response(response)
         mock_logger.error.assert_called_once_with(
             "Invalid response format: {}"
             )
@@ -80,7 +87,8 @@ class TestPrepareOpenSearchResponse(unittest.TestCase):
         mock_logger
     ):
         with self.assertRaises(OpenSearchServiceException):
-            prepare_opensearch_response(None)
+            self.service. \
+                _OpenSearchService__prepare_opensearch_response(None)
         mock_logger.error.assert_called_once_with(
             "Invalid response format: None")
 


### PR DESCRIPTION
Follow-up PR for [OSDEV-1006](https://opensupplyhub.atlassian.net/browse/OSDEV-1006)
Restructure OpenSearch response to this format:
```
{
    "count": <Number (total hits in DB)>
    "data": <array[Object]>
}
```
The `<array[Object]>` is represented by array of production locations entries.

[OSDEV-1006]: https://opensupplyhub.atlassian.net/browse/OSDEV-1006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ