### PR TITLE
[OSDEV-1176] Fix the spelling of the word 'password' on the Log In page.

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -35,6 +35,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Bugfix
 * Ensure that the OpenSearch domain name is unique for each environment to avoid conflicts when provisioning domains across different environments.
+* [OSDEV-1176](https://opensupplyhub.atlassian.net/browse/OSDEV-1176) - Fixed a spelling mistake in the label for the password field on the LogIn page. After the fix, the label reads "Password".
 
 ### What's new
 * [OSDEV-1144](https://opensupplyhub.atlassian.net/browse/OSDEV-1144) - Claims emails. Updated text for approval, revocation, and denial emails.

--- a/src/react/src/components/LoginForm.jsx
+++ b/src/react/src/components/LoginForm.jsx
@@ -108,7 +108,7 @@ const LoginForm = ({
                     <TogglePasswordField
                         id={LOGIN_PASSWORD}
                         value={password}
-                        label="Passowrd"
+                        label="Password"
                         updatePassword={updatePassword}
                         submitFormOnEnterKeyPress={submitFormOnEnterKeyPress}
                     />


### PR DESCRIPTION
[OSDEV-1176](https://opensupplyhub.atlassian.net/browse/OSDEV-1176) - Fix the spelling of the word 'password' on the Log In page.

Fixed a spelling mistake in the label for the password field on the LogIn page. After the fix, the label reads "Password".