### PR TITLE
[OSDEV-982] Bring back missing os_id param setting

### DIFF
--- a/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
+++ b/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
@@ -8,6 +8,7 @@ class OpenSearchQueryDirector:
             V1_PARAMETERS_LIST.DESCRIPTION: 'match',
             V1_PARAMETERS_LIST.ADDRESS: 'match',
             V1_PARAMETERS_LIST.NAME: 'terms',
+            V1_PARAMETERS_LIST.OS_ID: 'terms',
             V1_PARAMETERS_LIST.NAME_LOCAL: 'terms',
             V1_PARAMETERS_LIST.COUNTRY: 'terms',
             V1_PARAMETERS_LIST.SECTOR: 'terms',


### PR DESCRIPTION
Follow up PR for [OSDEV-982](https://opensupplyhub.atlassian.net/browse/OSDEV-982) that brings back missing os_id param setting that has been lost while merge conflict resolving.

[OSDEV-983]: https://opensupplyhub.atlassian.net/browse/OSDEV-983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OSDEV-982]: https://opensupplyhub.atlassian.net/browse/OSDEV-982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ