### PR TITLE
[OSDEV-1103] Enable accent-insensitive search in OpenSearch for the production location name and address.

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -25,7 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
     * `grouped` (optional): If present, returns sectors grouped by their sector groups.
 * [OSDEV-1184](https://opensupplyhub.atlassian.net/browse/OSDEV-1184) - Handle validation errors for size, sort_by and order_by parameters of "api/v1/production-locations" endpoint.
 * [OSDEV-982](https://opensupplyhub.atlassian.net/browse/OSDEV-982) - Search, API. Add OS ID query parameter to v1/production-locations. Implement "api/v1/production-locations/{os_id}" endpoint.
-* [OSDEV-1103](https://opensupplyhub.atlassian.net/browse/OSDEV-1103) - Enabled accent-insensitive search for `name` and `address` fields by designing the index mapping to do ASCII folding for search tokens.
+* [OSDEV-1103](https://opensupplyhub.atlassian.net/browse/OSDEV-1103) - Enabled accent-insensitive search for `name` and `address` fields of production location by designing the index mapping to do ASCII folding for search tokens.
 
 ### Architecture/Environment changes
 * [OSDEV-1165](https://opensupplyhub.atlassian.net/browse/OSDEV-1165) - Updated the release protocol to include information about quick fixes and how to perform them. Additionally, updated the GitFlow diagram to visually depict this process.

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
     * `grouped` (optional): If present, returns sectors grouped by their sector groups.
 * [OSDEV-1184](https://opensupplyhub.atlassian.net/browse/OSDEV-1184) - Handle validation errors for size, sort_by and order_by parameters of "api/v1/production-locations" endpoint.
 * [OSDEV-982](https://opensupplyhub.atlassian.net/browse/OSDEV-982) - Search, API. Add OS ID query parameter to v1/production-locations. Implement "api/v1/production-locations/{os_id}" endpoint.
+* [OSDEV-1103](https://opensupplyhub.atlassian.net/browse/OSDEV-1103) - Enabled accent-insensitive search for `name` and `address` fields by designing the index mapping to do ASCII folding for search tokens.
 
 ### Architecture/Environment changes
 * [OSDEV-1165](https://opensupplyhub.atlassian.net/browse/OSDEV-1165) - Updated the release protocol to include information about quick fixes and how to perform them. Additionally, updated the GitFlow diagram to visually depict this process.

--- a/src/logstash/indexes/production_locations.json
+++ b/src/logstash/indexes/production_locations.json
@@ -3,6 +3,24 @@
     "production-locations*"
   ],
   "template": {
+    "settings": {
+      "analysis": {
+        "analyzer": {
+          "custom_asciifolding": {
+            "tokenizer": "standard",
+            "filter": [
+              "my_ascii_folding"
+            ]
+          }
+        },
+        "filter": {
+          "my_ascii_folding": {
+            "type": "asciifolding",
+            "preserve_original": true
+          }
+        }
+      }
+    },
     "mappings": {
       "properties": {
         "os_id": {
@@ -10,6 +28,7 @@
         },
         "name": {
           "type": "text",
+          "analyzer": "custom_asciifolding",
           "fields": {
             "keyword": {
               "type": "keyword"
@@ -34,6 +53,7 @@
         },
         "address": {
           "type": "text",
+          "analyzer": "custom_asciifolding",
           "fields": {
             "keyword": {
               "type": "keyword"

--- a/src/logstash/indexes/production_locations.json
+++ b/src/logstash/indexes/production_locations.json
@@ -6,15 +6,15 @@
     "settings": {
       "analysis": {
         "analyzer": {
-          "custom_asciifolding": {
+          "custom_asciifolding_analyzer": {
             "tokenizer": "standard",
             "filter": [
-              "my_ascii_folding"
+              "custom_asciifolding_filter"
             ]
           }
         },
         "filter": {
-          "my_ascii_folding": {
+          "custom_asciifolding_filter": {
             "type": "asciifolding",
             "preserve_original": true
           }
@@ -28,7 +28,7 @@
         },
         "name": {
           "type": "text",
-          "analyzer": "custom_asciifolding",
+          "analyzer": "custom_asciifolding_analyzer",
           "fields": {
             "keyword": {
               "type": "keyword"
@@ -53,7 +53,7 @@
         },
         "address": {
           "type": "text",
-          "analyzer": "custom_asciifolding",
+          "analyzer": "custom_asciifolding_analyzer",
           "fields": {
             "keyword": {
               "type": "keyword"


### PR DESCRIPTION
[OSDEV-1103](https://opensupplyhub.atlassian.net/browse/OSDEV-1103) API v1/production-locations. Enable accent-insensitive search in OpenSearch for the production location name and address.

Enabled accent-insensitive search for `name` and `address` fields of production location by designing the index mapping to do ASCII folding for search tokens.

[OSDEV-1103]: https://opensupplyhub.atlassian.net/browse/OSDEV-1103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ