### PR TITLE
[OSDEV-1184] Add size param validation

### DIFF
--- a/src/django/api/serializers/v1/opensearch_common_validators/size_validator.py
+++ b/src/django/api/serializers/v1/opensearch_common_validators/size_validator.py
@@ -1,0 +1,30 @@
+from api.serializers.v1.opensearch_validation_interface \
+    import OpenSearchValidationInterface
+
+
+class SizeValidator(OpenSearchValidationInterface):
+    def validate_opensearch_params(self, data):
+        errors = []
+        size = data.get('size')
+        size_limit = 250
+
+        if size is None:
+            return errors
+
+        try:
+            size = int(size)
+            if size <= 0 or size > size_limit:
+                errors.append({
+                    "field": "size",
+                    "message": (
+                        f"Size must be a positive integer less than or equal "
+                        f"to {size_limit}."
+                    )
+                })
+        except ValueError:
+            errors.append({
+                "field": "size",
+                "message": "Size must be a valid integer."
+            })
+
+        return errors

--- a/src/django/api/serializers/v1/production_locations_serializer.py
+++ b/src/django/api/serializers/v1/production_locations_serializer.py
@@ -7,6 +7,8 @@ from rest_framework.serializers import (
     Serializer,
     ValidationError
 )
+from api.serializers.v1.opensearch_common_validators.size_validator \
+    import SizeValidator
 from api.serializers.v1.opensearch_error_list_builder  \
     import OpenSearchErrorListBuilder
 from api.serializers.v1.opensearch_common_validators. \
@@ -44,6 +46,7 @@ class ProductionLocationsSerializer(Serializer):
 
     def validate(self, data):
         validators = [
+            SizeValidator(),
             NumberOfWorkersValidator(),
             PercentOfFemaleWorkersValidator(),
             CoordinatesValidator(),


### PR DESCRIPTION
Follow-up PR [OSDEV-1184](https://opensupplyhub.atlassian.net/browse/OSDEV-1184) that introduces validation of the size parameter.

Size parameter:
1. Should be positive integer
2. Should be less or equal to our current OpenSearch output limit (250 entries) 

[OSDEV-1184]: https://opensupplyhub.atlassian.net/browse/OSDEV-1184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ