### PR TITLE
[OSDEV-1103] Add normalizer  to the `name` field of production location to enable ASCII search

### DIFF
--- a/src/logstash/indexes/production_locations.json
+++ b/src/logstash/indexes/production_locations.json
@@ -18,6 +18,12 @@
             "type": "asciifolding",
             "preserve_original": true
           }
+        },
+        "normalizer": {
+          "custom_asciifolding_normalizer": {
+            "type": "custom",
+            "filter": "asciifolding"
+          }
         }
       }
     },
@@ -31,7 +37,8 @@
           "analyzer": "custom_asciifolding_analyzer",
           "fields": {
             "keyword": {
-              "type": "keyword"
+              "type": "keyword",
+              "normalizer": "custom_asciifolding_normalizer"
             }
           }
         },


### PR DESCRIPTION
[OSDEV-1103](https://opensupplyhub.atlassian.net/browse/OSDEV-1103) - API v1/production-locations. Enable accent-insensitive search in OpenSearch for the production location name and address.

Added normalizer to the `name` field of production location as a part of designing the index mapping to do ASCII folding for search tokens.