### PR TITLE
[OSDEV-1103] Change query_type for name and name_local fields from `terms` to `match` to enable ASCII search.

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -25,7 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
     * `grouped` (optional): If present, returns sectors grouped by their sector groups.
 * [OSDEV-1184](https://opensupplyhub.atlassian.net/browse/OSDEV-1184) - Handle validation errors for size, sort_by and order_by parameters of "api/v1/production-locations" endpoint.
 * [OSDEV-982](https://opensupplyhub.atlassian.net/browse/OSDEV-982) - Search, API. Add OS ID query parameter to v1/production-locations. Implement "api/v1/production-locations/{os_id}" endpoint.
-* [OSDEV-1103](https://opensupplyhub.atlassian.net/browse/OSDEV-1103) - Enabled accent-insensitive search for `name` and `address` fields of production location by designing the index mapping to do ASCII folding for search tokens.
+* [OSDEV-1103](https://opensupplyhub.atlassian.net/browse/OSDEV-1103) - Enabled accent-insensitive search for `name` and `address` fields of production location by designing the index mapping to do ASCII folding for search tokens. Additionally, there were changed query_type for the `name` and `name_local` fields from `terms` to `match`.
 
 ### Architecture/Environment changes
 * [OSDEV-1165](https://opensupplyhub.atlassian.net/browse/OSDEV-1165) - Updated the release protocol to include information about quick fixes and how to perform them. Additionally, updated the GitFlow diagram to visually depict this process.

--- a/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
+++ b/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
@@ -7,9 +7,9 @@ class OpenSearchQueryDirector:
         self.__opensearch_template_fields = {
             V1_PARAMETERS_LIST.DESCRIPTION: 'match',
             V1_PARAMETERS_LIST.ADDRESS: 'match',
-            V1_PARAMETERS_LIST.NAME: 'terms',
+            V1_PARAMETERS_LIST.NAME: 'match',
             V1_PARAMETERS_LIST.OS_ID: 'terms',
-            V1_PARAMETERS_LIST.NAME_LOCAL: 'terms',
+            V1_PARAMETERS_LIST.NAME_LOCAL: 'match',
             V1_PARAMETERS_LIST.COUNTRY: 'terms',
             V1_PARAMETERS_LIST.SECTOR: 'terms',
             V1_PARAMETERS_LIST.PRODUCT_TYPE: 'terms',


### PR DESCRIPTION
[OSDEV-1103](https://opensupplyhub.atlassian.net/browse/OSDEV-1103) - API v1/production-locations. Enable accent-insensitive search in OpenSearch for the production location name and address.

Change query_type for `name` and `name_local` fields from `terms` to `match`.

[OSDEV-1103]: https://opensupplyhub.atlassian.net/browse/OSDEV-1103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ