### PR TITLE
[OSDEV-1025] Add the claim badge to C/R moderation screen

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * Release date: September 7, 2024
 
 ### Code/API changes
+* [OSDEV-1025](https://opensupplyhub.atlassian.net/browse/OSDEV-1025) - Added the `get_is_claimed` method to the `FacilityMatchSerializer` that returns a boolean value depending on whether the matched facility has an approved claim or not.
 
 ### Architecture/Environment changes
 * [OSDEV-1153](https://opensupplyhub.atlassian.net/browse/OSDEV-1153) - Created integration tests for the OpenSearch and for new `/api/v1/production-locations/` API endpoint.
@@ -17,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Bugfix
 
 ### What's new
+* [OSDEV-1025](https://opensupplyhub.atlassian.net/browse/OSDEV-1025) - Added the claim badge to the facility details on the C/R moderation screen when the facility has an approved claim.
 
 ### Release instructions:
 

--- a/src/django/api/serializers/facility/facility_match_serializer.py
+++ b/src/django/api/serializers/facility/facility_match_serializer.py
@@ -21,7 +21,6 @@ class FacilityMatchSerializer(ModelSerializer):
                   'is_active', 'is_claimed')
 
     def get_os_id(self, match):
-        print('match >>>', match)
         return match.facility.id
 
     def get_name(self, match):

--- a/src/django/api/serializers/facility/facility_match_serializer.py
+++ b/src/django/api/serializers/facility/facility_match_serializer.py
@@ -1,8 +1,10 @@
+from api.constants import FacilityClaimStatuses
+from api.models.facility.facility_claim import FacilityClaim
+from api.models.facility.facility_match import FacilityMatch
 from rest_framework.serializers import (
     SerializerMethodField,
     ModelSerializer,
 )
-from ...models import FacilityMatch
 
 
 class FacilityMatchSerializer(ModelSerializer):
@@ -10,14 +12,16 @@ class FacilityMatchSerializer(ModelSerializer):
     name = SerializerMethodField()
     address = SerializerMethodField()
     location = SerializerMethodField()
+    is_claimed = SerializerMethodField()
 
     class Meta:
         model = FacilityMatch
         fields = ('id', 'status', 'confidence', 'results',
                   'os_id', 'name', 'address', 'location',
-                  'is_active')
+                  'is_active', 'is_claimed')
 
     def get_os_id(self, match):
+        print('match >>>', match)
         return match.facility.id
 
     def get_name(self, match):
@@ -30,3 +34,9 @@ class FacilityMatchSerializer(ModelSerializer):
         [lng, lat] = match.facility.location
 
         return {"lat": lat, "lng": lng}
+
+    def get_is_claimed(self, match):
+        return FacilityClaim.objects.filter(
+            facility=match.facility,
+            status=FacilityClaimStatuses.APPROVED
+        ).exists()

--- a/src/django/api/tests/test_facility_match_serializer.py
+++ b/src/django/api/tests/test_facility_match_serializer.py
@@ -1,0 +1,95 @@
+from django.test import TestCase
+from django.contrib.gis.geos import Point
+
+from api.constants import FacilityClaimStatuses
+from api.models.facility.facility import Facility
+from api.models.facility.facility_claim import FacilityClaim
+from api.models.facility.facility_list_item import FacilityListItem
+from api.models.facility.facility_match import FacilityMatch
+from api.models.source import Source
+from api.models.user import User
+from api.models.contributor.contributor import Contributor
+from api.models.facility.facility_list import FacilityList
+from api.serializers.facility.facility_match_serializer \
+    import FacilityMatchSerializer
+
+
+class FacilityMatchSerializerTest(TestCase):
+    def setUp(self):
+        self.user_email = "test@example.com"
+        self.user_password = "example123"
+        self.user = User.objects.create(email=self.user_email)
+        self.user.set_password(self.user_password)
+        self.user.save()
+
+        self.contributor = Contributor.objects.create(
+            admin=self.user,
+            name="test contributor 1",
+            contrib_type=Contributor.OTHER_CONTRIB_TYPE,
+        )
+
+        self.list = FacilityList.objects.create(
+            header="header", file_name="one", name="First List"
+        )
+
+        self.source = Source.objects.create(
+            facility_list=self.list,
+            source_type=Source.LIST,
+            is_active=True,
+            is_public=True,
+            contributor=self.contributor,
+        )
+
+        self.list_item = FacilityListItem.objects.create(
+            name="Item",
+            address="Address",
+            country_code="US",
+            sector=["Apparel"],
+            row_index=1,
+            geocoded_point=Point(0, 0),
+            status=FacilityListItem.CONFIRMED_MATCH,
+            source=self.source,
+        )
+
+        self.facility = Facility.objects.create(
+            name="Name",
+            address="Address",
+            country_code="US",
+            location=Point(0, 0),
+            created_from=self.list_item,
+        )
+
+        self.facility_match = FacilityMatch.objects.create(
+            status=FacilityMatch.AUTOMATIC,
+            facility=self.facility,
+            facility_list_item=self.list_item,
+            confidence=0.85,
+            results="",
+        )
+
+    def test_facility_match_serializer_fields(self):
+        serializer = FacilityMatchSerializer(self.facility_match)
+        data = serializer.data
+
+        self.assertEqual(data['os_id'], self.facility.id)
+
+        self.assertEqual(data['name'], self.facility.name)
+
+        self.assertEqual(data['address'], self.facility.address)
+
+        expected_location = {"lat": 0.0, "lng": 0.0}
+        self.assertEqual(data['location'], expected_location)
+
+        self.assertFalse(data['is_claimed'])
+
+    def test_is_claimed_field_with_claim(self):
+        FacilityClaim.objects.create(
+            facility=self.facility,
+            contributor=self.contributor,
+            status=FacilityClaimStatuses.APPROVED
+        )
+
+        serializer = FacilityMatchSerializer(self.facility_match)
+        data = serializer.data
+
+        self.assertTrue(data['is_claimed'])

--- a/src/react/src/__tests__/components/FacilityListItemsConfirmationTableRowItem.test.js
+++ b/src/react/src/__tests__/components/FacilityListItemsConfirmationTableRowItem.test.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
+import { fireEvent } from '@testing-library/react';
 import renderWithProviders from '../../util/testUtils/renderWithProviders';
 import FacilityListItemsConfirmationTableRowItem from '../../components/FacilityListItemsConfirmationTableRowItem';
+import { facilityMatchStatusChoicesEnum, CONFIRM_ACTION } from '../../util/constants';
 
 describe('FacilityListItemsConfirmationTableRowItem component', () => {
-    
     const defaultProps = {
         id: 1,
         os_id: 'UA2019096H785YM',
@@ -21,53 +22,41 @@ describe('FacilityListItemsConfirmationTableRowItem component', () => {
         is_claimed: false,
     };
 
-    it('renders without crashing', () => {
+    const renderComponent = (props = {}) =>
         renderWithProviders(
             <Router>
-                <FacilityListItemsConfirmationTableRowItem {...defaultProps} />
+                <table>
+                    <tbody>
+                        <FacilityListItemsConfirmationTableRowItem {...defaultProps} {...props} />
+                    </tbody>
+                </table>
             </Router>
-        )
+        );
+
+    it('renders without crashing', () => {
+        renderComponent();
     });
 
     it('renders the facility name', () => {
-        const { getByText } = renderWithProviders(
-            <Router>
-                <FacilityListItemsConfirmationTableRowItem {...defaultProps} />
-            </Router>
-        );
+        const { getByText } = renderComponent();
 
         expect(getByText('Test Facility')).toBeInTheDocument();
     });
 
     it('renders the facility address', () => {
-        const { getByText } = renderWithProviders(
-            <Router>
-                <FacilityListItemsConfirmationTableRowItem {...defaultProps} />
-            </Router>
-        );
+        const { getByText } = renderComponent();
 
         expect(getByText('123 Main St')).toBeInTheDocument();
     });
 
     it('renders the facility confidence', () => {
-        const { getByText } = renderWithProviders(
-            <Router>
-                <FacilityListItemsConfirmationTableRowItem {...defaultProps} />
-            </Router>
-        );
+        const { getByText } = renderComponent();
 
         expect(getByText('0.7')).toBeInTheDocument();
     });
 
     it('renders BadgeVerified when is_claimed is true', () => {
-        const { getByTestId } = renderWithProviders(
-            <Router>
-                <FacilityListItemsConfirmationTableRowItem
-                    {...defaultProps}
-                    is_claimed={true}
-                />
-            </Router>
-        );
+        const { getByTestId } = renderComponent({ is_claimed: true });
 
         const badgeIcon = getByTestId('badge-verified');
 
@@ -75,15 +64,77 @@ describe('FacilityListItemsConfirmationTableRowItem component', () => {
     });
 
     it('does not render BadgeVerified when is_claimed is false', () => {
-        const { queryByTestId } = renderWithProviders(
-            <Router>
-                <FacilityListItemsConfirmationTableRowItem {...defaultProps} />
-            </Router>
-        );
-        
+        const { queryByTestId } = renderComponent();
+
         const badgeIcon = queryByTestId('badge-verified');
 
         expect(badgeIcon).not.toBeInTheDocument();
     });
-});
 
+    it('renders a Checkbox when status is PENDING and readOnly is false', () => {
+        const { getByRole } = renderComponent();
+
+        const checkbox = getByRole('checkbox');
+        expect(checkbox).toBeInTheDocument();
+    });
+
+    it('does not render a Checkbox when status is not PENDING', () => {
+        const { queryByRole } = renderComponent({
+            status: facilityMatchStatusChoicesEnum.CONFIRMED,
+        });
+
+        const checkbox = queryByRole('checkbox');
+        expect(checkbox).not.toBeInTheDocument();
+    });
+
+    it('does not render a Checkbox when readOnly is true', () => {
+        const { queryByRole } = renderComponent({ readOnly: true });
+
+        const checkbox = queryByRole('checkbox');
+        expect(checkbox).not.toBeInTheDocument();
+    });
+
+    it('renders the status text when status is not PENDING', () => {
+        const { getByText } = renderComponent({
+            status: facilityMatchStatusChoicesEnum.CONFIRMED,
+        });
+
+        expect(getByText(facilityMatchStatusChoicesEnum.CONFIRMED)).toBeInTheDocument();
+    });
+
+    it('calls toggleCheckbox when Checkbox is clicked', () => {
+        const toggleCheckbox = jest.fn();
+
+        const { getByRole } = renderComponent({ toggleCheckbox });
+
+        const checkbox = getByRole('checkbox');
+        fireEvent.click(checkbox);
+
+        expect(toggleCheckbox).toHaveBeenCalledWith({
+            id: 1,
+            os_id: 'UA2019096H785YM',
+            address: '123 Main St',
+            name: 'Test Facility',
+            confidence: '0.7',
+        });
+    });
+
+    it('checks the Checkbox when action is CONFIRM_ACTION and activeCheckboxes contains the item', () => {
+        const { getByRole } = renderComponent({
+            action: CONFIRM_ACTION,
+            activeCheckboxes: [{ id: 1 }],
+        });
+
+        const checkbox = getByRole('checkbox');
+        expect(checkbox).toBeChecked();
+    });
+
+    it('disables the Checkbox based on isCheckboxDisabled', () => {
+        const isCheckboxDisabled = jest.fn().mockReturnValue(true);
+
+        const { getByRole } = renderComponent({ isCheckboxDisabled });
+
+        const checkbox = getByRole('checkbox');
+        expect(checkbox).toBeDisabled();
+    });
+});

--- a/src/react/src/__tests__/components/FacilityListItemsConfirmationTableRowItem.test.js
+++ b/src/react/src/__tests__/components/FacilityListItemsConfirmationTableRowItem.test.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
+import renderWithProviders from '../../util/testUtils/renderWithProviders';
+import FacilityListItemsConfirmationTableRowItem from '../../components/FacilityListItemsConfirmationTableRowItem';
+
+describe('FacilityListItemsConfirmationTableRowItem component', () => {
+    
+    const defaultProps = {
+        id: 1,
+        os_id: 'UA2019096H785YM',
+        name: 'Test Facility',
+        status: 'PENDING',
+        className: '',
+        activeCheckboxes: [],
+        address: '123 Main St',
+        isCheckboxDisabled: jest.fn(),
+        confidence: '0.7',
+        readOnly: false,
+        toggleCheckbox: jest.fn(),
+        action: '',
+        is_claimed: false,
+    };
+
+    it('renders without crashing', () => {
+        renderWithProviders(
+            <Router>
+                <FacilityListItemsConfirmationTableRowItem {...defaultProps} />
+            </Router>
+        )
+    });
+
+    it('renders the facility name', () => {
+        const { getByText } = renderWithProviders(
+            <Router>
+                <FacilityListItemsConfirmationTableRowItem {...defaultProps} />
+            </Router>
+        );
+
+        expect(getByText('Test Facility')).toBeInTheDocument();
+    });
+
+    it('renders the facility address', () => {
+        const { getByText } = renderWithProviders(
+            <Router>
+                <FacilityListItemsConfirmationTableRowItem {...defaultProps} />
+            </Router>
+        );
+
+        expect(getByText('123 Main St')).toBeInTheDocument();
+    });
+
+    it('renders the facility confidence', () => {
+        const { getByText } = renderWithProviders(
+            <Router>
+                <FacilityListItemsConfirmationTableRowItem {...defaultProps} />
+            </Router>
+        );
+
+        expect(getByText('0.7')).toBeInTheDocument();
+    });
+
+    it('renders BadgeVerified when is_claimed is true', () => {
+        const { getByTestId } = renderWithProviders(
+            <Router>
+                <FacilityListItemsConfirmationTableRowItem
+                    {...defaultProps}
+                    is_claimed={true}
+                />
+            </Router>
+        );
+
+        const badgeIcon = getByTestId('badge-verified');
+
+        expect(badgeIcon).toBeInTheDocument();
+    });
+
+    it('does not render BadgeVerified when is_claimed is false', () => {
+        const { queryByTestId } = renderWithProviders(
+            <Router>
+                <FacilityListItemsConfirmationTableRowItem {...defaultProps} />
+            </Router>
+        );
+        
+        const badgeIcon = queryByTestId('badge-verified');
+
+        expect(badgeIcon).not.toBeInTheDocument();
+    });
+});
+

--- a/src/react/src/components/BadgeVerified.jsx
+++ b/src/react/src/components/BadgeVerified.jsx
@@ -4,7 +4,12 @@ import SvgIcon from '@material-ui/core/SvgIcon';
 
 export default function BadgeVerified({ color, style, ...props }) {
     return (
-        <SvgIcon viewBox="0 0 16 20" style={style} {...props}>
+        <SvgIcon
+            viewBox="0 0 16 20"
+            style={style}
+            {...props}
+            data-testid="badge-verified"
+        >
             <path
                 fill={color}
                 d="M6.95 13.55L12.6 7.9L11.175 6.475L6.95 10.7L4.85 8.6L3.425 10.025L6.95 13.55ZM8 20C5.68333 19.4167 3.771 18.0873 2.263 16.012C0.754333 13.9373 0 11.6333 0 9.1V3L8 0L16 3V9.1C16 11.6333 15.246 13.9373 13.738 16.012C12.2293 18.0873 10.3167 19.4167 8 20ZM8 17.9C9.73333 17.35 11.1667 16.25 12.3 14.6C13.4333 12.95 14 11.1167 14 9.1V4.375L8 2.125L2 4.375V9.1C2 11.1167 2.56667 12.95 3.7 14.6C4.83333 16.25 6.26667 17.35 8 17.9Z"

--- a/src/react/src/components/FacilityListItemsConfirmationTableRow.jsx
+++ b/src/react/src/components/FacilityListItemsConfirmationTableRow.jsx
@@ -71,7 +71,6 @@ function FacilityListItemsConfirmationTableRow({
     fetchToMergeFacility,
     fetchTargetFacility,
 }) {
-    // console.log('item >>>', item);
     const {
         action,
         activeCheckboxes,
@@ -90,7 +89,6 @@ function FacilityListItemsConfirmationTableRow({
     const isSideBarSearch = false;
 
     const [matches, setMatches] = useState([]);
-    // console.log('matches >>>', matches);
 
     const filterUniqueMatches = matchList => {
         const uniqueOsIdItems = matchList.reduce((acc, matchItem) => {

--- a/src/react/src/components/FacilityListItemsConfirmationTableRow.jsx
+++ b/src/react/src/components/FacilityListItemsConfirmationTableRow.jsx
@@ -71,6 +71,7 @@ function FacilityListItemsConfirmationTableRow({
     fetchToMergeFacility,
     fetchTargetFacility,
 }) {
+    // console.log('item >>>', item);
     const {
         action,
         activeCheckboxes,
@@ -89,6 +90,7 @@ function FacilityListItemsConfirmationTableRow({
     const isSideBarSearch = false;
 
     const [matches, setMatches] = useState([]);
+    // console.log('matches >>>', matches);
 
     const filterUniqueMatches = matchList => {
         const uniqueOsIdItems = matchList.reduce((acc, matchItem) => {
@@ -273,25 +275,36 @@ function FacilityListItemsConfirmationTableRow({
                     className={className}
                 />
             ) : (
-                matches.map((
-                    { id, status, address, os_id, name, confidence }, // eslint-disable-line camelcase
-                ) => (
-                    <FacilityListItemsConfirmationTableRowItem
-                        key={id}
-                        id={id}
-                        os_id={os_id} // eslint-disable-line camelcase
-                        name={name}
-                        status={status}
-                        className={className}
-                        activeCheckboxes={activeCheckboxes}
-                        address={address}
-                        isCheckboxDisabled={isCheckboxDisabled}
-                        confidence={confidence}
-                        readOnly={readOnly}
-                        toggleCheckbox={toggleCheckbox}
-                        action={action}
-                    />
-                ))
+                matches.map(
+                    ({
+                        id,
+                        status,
+                        address,
+                        os_id, // eslint-disable-line camelcase
+                        name,
+                        confidence,
+                        is_claimed, // eslint-disable-line camelcase
+                    }) => {
+                        return (
+                            <FacilityListItemsConfirmationTableRowItem
+                                key={id}
+                                id={id}
+                                os_id={os_id} // eslint-disable-line camelcase
+                                name={name}
+                                status={status}
+                                className={className}
+                                activeCheckboxes={activeCheckboxes}
+                                address={address}
+                                isCheckboxDisabled={isCheckboxDisabled}
+                                confidence={confidence}
+                                readOnly={readOnly}
+                                toggleCheckbox={toggleCheckbox}
+                                action={action}
+                                is_claimed={is_claimed} // eslint-disable-line camelcase
+                            />
+                        );
+                    },
+                )
             )}
         </>
     );

--- a/src/react/src/components/FacilityListItemsConfirmationTableRow.jsx
+++ b/src/react/src/components/FacilityListItemsConfirmationTableRow.jsx
@@ -282,26 +282,24 @@ function FacilityListItemsConfirmationTableRow({
                         name,
                         confidence,
                         is_claimed, // eslint-disable-line camelcase
-                    }) => {
-                        return (
-                            <FacilityListItemsConfirmationTableRowItem
-                                key={id}
-                                id={id}
-                                os_id={os_id} // eslint-disable-line camelcase
-                                name={name}
-                                status={status}
-                                className={className}
-                                activeCheckboxes={activeCheckboxes}
-                                address={address}
-                                isCheckboxDisabled={isCheckboxDisabled}
-                                confidence={confidence}
-                                readOnly={readOnly}
-                                toggleCheckbox={toggleCheckbox}
-                                action={action}
-                                is_claimed={is_claimed} // eslint-disable-line camelcase
-                            />
-                        );
-                    },
+                    }) => (
+                        <FacilityListItemsConfirmationTableRowItem
+                            key={id}
+                            id={id}
+                            os_id={os_id} // eslint-disable-line camelcase
+                            name={name}
+                            status={status}
+                            className={className}
+                            activeCheckboxes={activeCheckboxes}
+                            address={address}
+                            isCheckboxDisabled={isCheckboxDisabled}
+                            confidence={confidence}
+                            readOnly={readOnly}
+                            toggleCheckbox={toggleCheckbox}
+                            action={action}
+                            is_claimed={is_claimed} // eslint-disable-line camelcase
+                        />
+                    ),
                 )
             )}
         </>

--- a/src/react/src/components/FacilityListItemsConfirmationTableRowItem.jsx
+++ b/src/react/src/components/FacilityListItemsConfirmationTableRowItem.jsx
@@ -3,6 +3,7 @@ import { bool, number, func, string, shape, arrayOf } from 'prop-types';
 import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
 import Checkbox from '@material-ui/core/Checkbox';
+import BadgeVerified from './BadgeVerified';
 import CellElement from './CellElement';
 import ShowOnly from './ShowOnly';
 
@@ -30,6 +31,7 @@ const FacilityListItemsConfirmationTableRowItem = ({
     readOnly,
     toggleCheckbox,
     action,
+    is_claimed, // eslint-disable-line camelcase
 }) => (
     <TableRow
         hover={false}
@@ -40,7 +42,13 @@ const FacilityListItemsConfirmationTableRowItem = ({
         className={className}
         key={id}
     >
-        <TableCell padding="default" variant="head" colSpan={2} />
+        <TableCell style={listTableCellStyles.badgeCellStyles} colSpan={2}>
+            {/* eslint-disable camelcase */}
+            <ShowOnly when={is_claimed}>
+                <BadgeVerified />
+            </ShowOnly>
+        </TableCell>
+
         <TableCell padding="default" style={listTableCellStyles.nameCellStyles}>
             <CellElement item={name} linkURL={makeFacilityDetailLink(os_id)} />
         </TableCell>
@@ -130,6 +138,7 @@ FacilityListItemsConfirmationTableRowItem.propTypes = {
     readOnly: bool.isRequired,
     toggleCheckbox: func.isRequired,
     action: string.isRequired,
+    is_claimed: bool.isRequired, // eslint-disable-line camelcase
 };
 
 export default FacilityListItemsConfirmationTableRowItem;

--- a/src/react/src/util/styles.js
+++ b/src/react/src/util/styles.js
@@ -50,6 +50,10 @@ export const listTableCellStyles = Object.freeze({
         padding: '10px 24px',
         borderColor: '#f3f3f3',
     }),
+    badgeCellStyles: Object.freeze({
+        padding: '15px 0',
+        textAlign: 'right',
+    }),
 });
 
 export const confirmRejectMatchRowStyles = Object.freeze({


### PR DESCRIPTION
[OSDEV-1025](https://opensupplyhub.atlassian.net/browse/OSDEV-1025) - Data Moderation. Add the claim badge to C/R moderation screen.

   - Added the claim badge to the facility details on the C/R moderation screen when the facility has an approved claim.
   - Added the `get_is_claimed` method to the `FacilityMatchSerializer` that returns a boolean value depending on whether the matched facility has an approved claim or not.

[OSDEV-1025]: https://opensupplyhub.atlassian.net/browse/OSDEV-1025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ