### PR TITLE
Create POST request for v1/production-locations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,6 +121,7 @@ services:
       kafka-topics --bootstrap-server kafka:9092 --list
       echo -e 'Creating kafka topics'
       kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic dedupe.hub.topic --replication-factor 1 --partitions 1
+      kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic moderation-events --replication-factor 1 --partitions 1
 
       echo -e 'Successfully created the following topics:'
       kafka-topics --bootstrap-server kafka:9092 --list
@@ -196,7 +197,7 @@ services:
       - POSTGRES_USER=opensupplyhub
       - POSTGRES_PASSWORD=opensupplyhub
       - POSTGRES_DB=opensupplyhub
-      - LOGSTASH_UPDATE_INTERVAL_MINUTES=2
+      - LOGSTASH_UPDATE_INTERVAL_MINUTES=10
 
     depends_on:
       - opensearch-single-node

--- a/src/dedupe-hub/api/app/main.py
+++ b/src/dedupe-hub/api/app/main.py
@@ -132,6 +132,18 @@ async def handle(value):
         log.info(f'[Matching] Start processing!')
         result = matcher(value)
         log.info(f'[Matching] Result: {result}')
+
+        # Emit the message to Kafka moderation-events topic
+        producer = AIOKafkaProducer(
+            bootstrap_servers=settings.bootstrap_servers
+        )
+        await producer.start()
+        try:
+            await producer.send("moderation-events", json.dumps(result).encode())
+            log.info(f'[Kafka] Sent message to moderation-events topic: {result}')
+        finally:
+            await producer.stop()
+
     except Exception as error:
         log.error(f'[Matching] Error: {error}')
     return

--- a/src/django/api/views/v1/production_locations.py
+++ b/src/django/api/views/v1/production_locations.py
@@ -1,11 +1,24 @@
+import logging
 from django.http import QueryDict
+from django.utils import timezone
+from django.db import transaction
+from waffle import flag_is_active
 from rest_framework import status
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
+from rest_framework.exceptions import (
+    PermissionDenied,
+    APIException
+)
+from api.facility_actions.processing_facility_api import ProcessingFacilityAPI
+from api.facility_actions.processing_facility_executor import (
+    ProcessingFacilityExecutor
+)
 from api.views.v1.utils import (
     serialize_params,
     handle_errors_decorator
 )
+from ...permissions import IsRegisteredAndConfirmed, IsSuperuser
 from api.services.search import OpenSearchService
 from api.views.v1.opensearch_query_builder.opensearch_query_builder \
     import OpenSearchQueryBuilder
@@ -15,9 +28,26 @@ from api.serializers.v1.production_locations_serializer \
     import ProductionLocationsSerializer
 from api.views.v1.index_names import OpenSearchIndexNames
 
+from ...sector_product_type_parser import SectorCache
+from ...constants import (
+    FeatureGroups,
+    FacilityCreateQueryParams
+)
+
+from contricleaner.lib.contri_cleaner import ContriCleaner
+from contricleaner.lib.exceptions.handler_not_set_error \
+    import HandlerNotSetError
+
+from ...serializers import (
+    FacilityCreateQueryParamsSerializer,
+)
+
+# Initialize logger.
+log = logging.getLogger(__name__)
+
 
 class ProductionLocations(ViewSet):
-    swagger_schema = None
+    # swagger_schema = None
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -59,3 +89,50 @@ class ProductionLocations(ViewSet):
             query_body
         )
         return Response(response)
+
+    @transaction.non_atomic_requests
+    def create(self, request):
+        if not IsRegisteredAndConfirmed().has_permission(request, self):
+            return Response(status=status.HTTP_401_UNAUTHORIZED)
+        if not flag_is_active(request._request,
+                              FeatureGroups.CAN_SUBMIT_FACILITY):
+            raise PermissionDenied()
+
+        log.info(f'[API Upload] Uploading data: {request.data}')
+
+        parsing_started = str(timezone.now())
+        log.info('[API Upload] Started CC Parse process!')
+
+        params_serializer = FacilityCreateQueryParamsSerializer(
+            data=request.query_params)
+        params_serializer.is_valid(raise_exception=True)
+        should_create = params_serializer.validated_data[
+            FacilityCreateQueryParams.CREATE]
+        public_submission = params_serializer.validated_data[
+            FacilityCreateQueryParams.PUBLIC]
+        private_allowed = flag_is_active(
+            request._request, FeatureGroups.CAN_SUBMIT_PRIVATE_FACILITY)
+        if not public_submission and not private_allowed:
+            raise PermissionDenied('Cannot submit a private facility')
+
+        contri_cleaner = ContriCleaner(request.data, SectorCache())
+        try:
+            contri_cleaner_processed_data = contri_cleaner.process_data()
+        except HandlerNotSetError as err:
+            log.error(f'[API Upload] Internal ContriCleaner Error: {err}')
+            raise APIException('Internal System Error. '
+                               'Please contact support.')
+
+        processing_input = {
+            'request': request,
+            'contri_cleaner_processed_data': contri_cleaner_processed_data,
+            'public_submission': public_submission,
+            'should_create': should_create,
+            'parsing_started': parsing_started,
+        }
+
+        processing_facility_executor = ProcessingFacilityExecutor(
+            ProcessingFacilityAPI(processing_input)
+        )
+
+        return processing_facility_executor.run_processing()

--- a/src/logstash/pipeline/sync_moderation_events.conf
+++ b/src/logstash/pipeline/sync_moderation_events.conf
@@ -1,0 +1,72 @@
+input{
+  kafka {
+    bootstrap_servers => "kafka:9092" # TODO: works only locally now
+    topics => ["moderation-events"]
+    codec => "json"
+  }
+}
+
+'''
+TODO: These data should come from the microservice
+Filter above does nott work as expected since it receives data in
+format like this (other formats should be addressed as well 
+for each case depending on match_type):
+[
+  {
+    "facility_list_item_id": 2407352,
+    "facility_id": "PT20242369XF62M", 
+    "status": "AUTOMATIC", 
+    "results": {
+        "match_type": "single_exact_match"
+    }, 
+    "confidence": 1
+  }
+]
+'''
+
+filter {
+  # Transform the incoming event data to match the OpenSearch schema
+  mutate {
+    rename => { 
+      "[facility_id]" => "[os_id]" 
+    }
+    rename => {
+      "[country][alpha_2]" => "[country][alpha_2]"
+    }
+    rename => {
+      "[claim_status]" => "[claim_status]"
+    }
+    # Add any additional fields that are missing or set default values
+    add_field => {
+      "name" => "Default Name" # Example placeholder, replace as needed
+      "description" => "Default Description" # Example placeholder, replace as needed
+    }
+  }
+
+  # Remove any fields not required by the OpenSearch schema
+  prune {
+    whitelist_names => ["os_id", "country.alpha_2", "claim_status", "name", "description"]
+  }
+}
+
+output {
+  '''
+  stdout {
+    codec => rubydebug
+  }
+  '''
+  opensearch {
+    hosts => ["${OPENSEARCH_HOST}:${OPENSEARCH_PORT}"]
+    auth_type => {
+      type => "${OPENSEARCH_AUTH_TYPE}"
+      region => "${AWS_REGION}"
+    }
+    ssl => "${OPENSEARCH_SSL}"
+    ssl_certificate_verification => "${OPENSEARCH_SSL_CERT_VERIFICATION}"
+    index => "production-locations"
+    document_id => "%{[@metadata][_id]}"
+    template_name => "production_locations_template"
+    template => "/usr/share/logstash/indexes/production_locations.json"
+    legacy_template => false
+  }
+}

--- a/src/logstash/sql/sync_single_production_location.sql
+++ b/src/logstash/sql/sync_single_production_location.sql
@@ -1,0 +1,1 @@
+-- TODO: get single facility and ingest it to the OpenSearch --


### PR DESCRIPTION
1. Add Django view for POST api/v1/production-locations.
2. Created new moderation-events topic using init-kafka (localhost only).
3. Emit event (facility id and it's status) from Dedupe Hub to the moderation-events topic.
4. Created a separate pipeline for the Logstash to intercept Kafka events from moderation-events topic (localhost only).
5. TODO: implement rihgt ingesting of this data into the OpenSearch.