### PR TITLE
Remove calling of `index_facilities_new` command from the `post_deployment` command

### DIFF
--- a/src/django/api/management/commands/post_deployment.py
+++ b/src/django/api/management/commands/post_deployment.py
@@ -9,4 +9,3 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         call_command('migrate')
-        call_command('index_facilities_new')


### PR DESCRIPTION
Remove the calling of the `index_facilities_new` command from the `post_deployment` command after release 1.20.