### PR TITLE
Prevent automated deployment to AWS after creating tags for `sandbox` and `production`

### DIFF
--- a/.github/workflows/deploy_to_aws.yml
+++ b/.github/workflows/deploy_to_aws.yml
@@ -5,9 +5,9 @@ on:
     branches:
       - main
       - 'releases/**'
-    tags:
-      - 'sandbox-*'
-      - 'production-*'
+    # tags:
+    #   - 'sandbox-*'
+    #   - 'production-*'
   workflow_dispatch:
     inputs:
       deploy-env:

--- a/.github/workflows/deploy_to_aws.yml
+++ b/.github/workflows/deploy_to_aws.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
       - 'releases/**'
+    # TODO: Uncomment the following lines to enable deployment to production and sandbox environments
+    #       after the implementation of the OSDEV-1325 CI/CD. Trigger the 'Deploy to AWS' pipeline using the API.
+    #       https://opensupplyhub.atlassian.net/browse/OSDEV-1325
     # tags:
     #   - 'sandbox-*'
     #   - 'production-*'

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -38,7 +38,7 @@ Additionally, a `historical_os_id` filter was added to the `sync_production_loca
 ### Release instructions:
 * Ensure that the following commands are included in the `post_deployment` command:
     * `migrate`
-* After running the Release [Deploy] workflow for both the sandbox and production environments, the responsible person must manually run the Deploy to AWS workflow, ensuring that the Clear OpenSearch indexes option is checked for each environment.
+* After running the `Release [Deploy]` workflow for both the `sandbox` and `production` environments, the responsible person must manually run the `Deploy to AWS` workflow, ensuring that the `Clear OpenSearch indexes` option is checked for each environment.
 Note: This instruction updates item 3 of the ['Release to Production and Sandbox'](https://github.com/opensupplyhub/open-supply-hub/blob/main/doc/release/RELEASE-PROTOCOL.md#release-to-production-and-sandbox) section of the RELEASE-PROTOCOL.
 
 

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -36,7 +36,10 @@ Additionally, a `historical_os_id` filter was added to the `sync_production_loca
 * [OSDEV-1225](https://opensupplyhub.atlassian.net/browse/OSDEV-1225) - The auto email responses for `Approved` and `Rejected` statuses have been updated to improve user experience. A user receives an email updating them on the status of their list and the next steps they need to take.
 
 ### Release instructions:
-* Before deploying to an existing environment, manually delete the related EFS storage, OpenSearch domain, and stop all tasks of the Logstash service in the appropriate ECS cluster. This is necessary to apply the new mapping for the production-locations OpenSearch index.
+* Ensure that the following commands are included in the `post_deployment` command:
+    * `migrate`
+* After running the Release [Deploy] workflow for both the sandbox and production environments, the responsible person must manually run the Deploy to AWS workflow, ensuring that the Clear OpenSearch indexes option is checked for each environment.
+Note: This instruction updates item 3 of the ['Release to Production and Sandbox'](https://github.com/opensupplyhub/open-supply-hub/blob/main/doc/release/RELEASE-PROTOCOL.md#release-to-production-and-sandbox) section of the RELEASE-PROTOCOL.
 
 
 ## Release 1.20.0

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -26,7 +26,7 @@ Additionally, a `historical_os_id` filter was added to the `sync_production_loca
   * Improved OpenSearch indexes cleanup step in the `Deploy to AWS` and `DB - Apply Anonymized DB` pipelines to use script templates so that changes can be made in one place rather than in each pipeline separately
   * Stop/start Logstash and clearing OpenSearch indexes moved to separate jobs of `Deploy to AWS` and `DB - Apply Anonymized DB` pipelines.
   * Stop/start Logstash and clearing OpenSearch indexes now runs on ubuntu-latest runner.
-  * The automation deployment to AWS after creating tags for `sandbox` and `production` was temporarily prevented (until the implementation of [OSDEV-1325](https://opensupplyhub.atlassian.net/browse/OSDEV-1325)).
+  * The automated deployment to AWS after creating tags for `sandbox` and `production` was temporarily prevented (until the implementation of [OSDEV-1325](https://opensupplyhub.atlassian.net/browse/OSDEV-1325)).
 
 ### Bugfix
 * [OSDEV-1177](https://opensupplyhub.atlassian.net/browse/OSDEV-1177) - The following changes have been made:

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -23,9 +23,10 @@ Additionally, a `historical_os_id` filter was added to the `sync_production_loca
 
 ### Architecture/Environment changes
 * [OSDEV-1177](https://opensupplyhub.atlassian.net/browse/OSDEV-1177)
-  - Improved OpenSearch indexes cleanup step in the _Deploy to AWS_ and _DB - Apply Anonymized DB_ pipelines to use script templates so that changes can be made in one place rather than in each pipeline separately
-  - Stop/start Logstash and clearing OpenSearch indexes moved to separate jobs of _Deploy to AWS_ and _DB - Apply Anonymized DB_ pipelines.
-  - Stop/start Logstash and clearing OpenSearch indexes now runs on ubuntu-latest runner.
+  * Improved OpenSearch indexes cleanup step in the `Deploy to AWS` and `DB - Apply Anonymized DB` pipelines to use script templates so that changes can be made in one place rather than in each pipeline separately
+  * Stop/start Logstash and clearing OpenSearch indexes moved to separate jobs of `Deploy to AWS` and `DB - Apply Anonymized DB` pipelines.
+  * Stop/start Logstash and clearing OpenSearch indexes now runs on ubuntu-latest runner.
+  * The automation deployment to AWS after creating tags for `sandbox` and `production` was temporarily prevented (until the implementation of [OSDEV-1325](https://opensupplyhub.atlassian.net/browse/OSDEV-1325)).
 
 ### Bugfix
 * [OSDEV-1177](https://opensupplyhub.atlassian.net/browse/OSDEV-1177) - The following changes have been made:


### PR DESCRIPTION
Prevent automated deployment to AWS after creating tags for `sandbox` and `production`.

- The code responsible for triggering workflows on pushes to tags starting with `sandbox` or `production` was commented out to prevent automated deployment to AWS.
- The 'Release Instructions' section of the `RELEASE-NOTES.md` has been updated with a description of how to manually run the deployment to AWS.