### PR TITLE
[OSDEV-1102] Propagate production location updates to OpenSearch

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -17,7 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * *Describe scheme changes here.*
 
 ### Code/API changes
-* *Describe code/API changes here.*
+* [OSDEV-1102](https://opensupplyhub.atlassian.net/browse/OSDEV-1102) - API. Propagate production location updates to OpenSearch data source via refresh `updated_at` field in `api_facility` table.
 
 ### Architecture/Environment changes
 * *Describe architecture/environment changes here.*

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -17,7 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * *Describe scheme changes here.*
 
 ### Code/API changes
-* [OSDEV-1102](https://opensupplyhub.atlassian.net/browse/OSDEV-1102) - API. Propagate production location updates to OpenSearch data source via refresh `updated_at` field in `api_facility` table.
+* [OSDEV-1102](https://opensupplyhub.atlassian.net/browse/OSDEV-1102) - API. Propagate production location updates to OpenSearch data source via refreshing `updated_at` field in `api_facility` table.
 
 ### Architecture/Environment changes
 * *Describe architecture/environment changes here.*

--- a/src/django/api/management/commands/post_deployment.py
+++ b/src/django/api/management/commands/post_deployment.py
@@ -9,4 +9,3 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         call_command('migrate')
-        call_command('index_facilities_new')

--- a/src/django/api/models/facility/facility.py
+++ b/src/django/api/models/facility/facility.py
@@ -1,5 +1,4 @@
 from itertools import groupby
-from django.utils import timezone
 
 from api.constants import FacilityClaimStatuses
 from api.models.facility.facility_manager import FacilityManager
@@ -298,5 +297,4 @@ class Facility(models.Model):
     @staticmethod
     def update_facility_updated_at_field(facility_id):
         facility = Facility.objects.get(pk=facility_id)
-        facility.updated_at = timezone.now()
-        facility.save()
+        facility.save(update_fields=['updated_at'])

--- a/src/django/api/models/facility/facility.py
+++ b/src/django/api/models/facility/facility.py
@@ -295,6 +295,7 @@ class Facility(models.Model):
 
         return f'{timestamp}-{tile_version}'
 
+    @staticmethod
     def update_facility_updated_at_field(facility_id):
         facility = Facility.objects.get(pk=facility_id)
         facility.updated_at = timezone.now()

--- a/src/django/api/models/facility/facility.py
+++ b/src/django/api/models/facility/facility.py
@@ -1,4 +1,5 @@
 from itertools import groupby
+from django.utils import timezone
 
 from api.constants import FacilityClaimStatuses
 from api.models.facility.facility_manager import FacilityManager
@@ -293,3 +294,8 @@ class Facility(models.Model):
             tile_version = 0
 
         return f'{timestamp}-{tile_version}'
+
+    def update_facility_updated_at_field(facility_id):
+        facility = Facility.objects.get(pk=facility_id)
+        facility.updated_at = timezone.now()
+        facility.save()

--- a/src/django/api/tests/test_facility_history_endpoint.py
+++ b/src/django/api/tests/test_facility_history_endpoint.py
@@ -299,7 +299,7 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
 
         self.assertEqual(
             len(data),
-            4,
+            5,
         )
 
     @override_flag("can_get_facility_history", active=True)
@@ -353,7 +353,7 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
 
         self.assertEqual(
             len(data),
-            4,
+            5,
         )
 
     @override_flag("can_get_facility_history", active=True)
@@ -771,13 +771,13 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
         data = json.loads(history_response.content)
 
         self.assertEqual(
-            data[0]["action"],
+            data[1]["action"],
             "CLAIM",
         )
 
         self.assertEqual(
             len(data),
-            3,
+            5,
         )
 
     @override_flag("can_get_facility_history", active=True)
@@ -868,13 +868,13 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
         data = json.loads(history_response.content)
 
         self.assertEqual(
-            data[0]["action"],
+            data[2]["action"],
             "ASSOCIATE",
         )
 
         self.assertEqual(
             len(data),
-            2,
+            4,
         )
 
     @override_flag("can_get_facility_history", active=True)
@@ -947,13 +947,13 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
         data = json.loads(history_response.content)
 
         self.assertEqual(
-            data[0]["action"],
+            data[1]["action"],
             "CLAIM_REVOKE",
         )
 
         self.assertEqual(
             len(data),
-            4,
+            7,
         )
 
     @override_flag("can_get_facility_history", active=True)
@@ -1054,13 +1054,13 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
         data = json.loads(history_response.content)
 
         self.assertEqual(
-            data[0]["action"],
+            data[1]["action"],
             "CLAIM_UPDATE",
         )
 
         self.assertEqual(
             len(data),
-            4,
+            7,
         )
 
         non_public_keys = [

--- a/src/django/api/tests/test_opensearch_relevant_data.py
+++ b/src/django/api/tests/test_opensearch_relevant_data.py
@@ -1,0 +1,79 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from django.utils import timezone
+from api.services.search import \
+    OpenSearchService
+from api.models import (
+    Contributor,
+    Facility,
+    FacilityList,
+    FacilityListItem,
+    Source,
+    User,
+)
+from django.contrib.gis.geos import Point
+
+
+class TestPrepareOpenSearchResponse(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_client = MagicMock()
+        self.service = OpenSearchService(client=self.mock_client)
+
+        self.email = "user@example.com"
+        self.password = "password"
+        self.user = User.objects.create(email=self.email)
+        self.user.set_password(self.password)
+        self.user.save()
+
+        self.contributor = Contributor(name="Contributor", admin=self.user)
+        self.contributor.save()
+
+        self.list_one = FacilityList.objects.create(
+            header="header", file_name="one", name="list"
+        )
+
+        self.source_one = Source.objects.create(
+            facility_list=self.list_one,
+            source_type=Source.LIST,
+            is_active=True,
+            is_public=True,
+            contributor=self.contributor,
+        )
+
+        self.list_item_one = FacilityListItem.objects.create(
+            name="name",
+            address="address",
+            country_code="US",
+            sector=["Apparel"],
+            source=self.source_one,
+            row_index=1,
+            status=FacilityListItem.CONFIRMED_MATCH,
+        )
+
+        self.facility = Facility.objects.create(
+            name="name",
+            address="address",
+            country_code="US",
+            location=Point(0, 0),
+            created_from=self.list_item_one,
+        )
+
+        self.old_updated_at = '2019-03-24 02:23:22.195 +0100'
+
+        self.facility.updated_at = self.old_updated_at
+        self.facility.save()
+
+    @patch('api.services.search.logger')
+    def test_update_facility_updated_at_field(self, mock_logger):
+        current_time = timezone.now()
+        Facility.update_facility_updated_at_field(self.facility.id)
+        new_updated_at = self.facility.updated_at
+        self.assertEqual(current_time.replace(microsecond=0),
+                         new_updated_at.replace(microsecond=0))
+        self.assertNotEqual(self.old_updated_at, new_updated_at)
+        mock_logger.warning.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/django/api/views/facility/facilities_view_set.py
+++ b/src/django/api/views/facility/facilities_view_set.py
@@ -929,6 +929,8 @@ class FacilitiesViewSet(ListModelMixin,
                 )
 
             send_claim_facility_confirmation_email(request, facility_claim)
+            facility.updated_at = timezone.now()
+            facility.save()
 
             approved = (
                 FacilityClaim
@@ -1110,6 +1112,8 @@ class FacilitiesViewSet(ListModelMixin,
         merge.delete()
 
         target.refresh_from_db()
+        target.updated_at = timezone.now()
+        target.save()
         context = {'request': request}
         facility_index = FacilityIndex.objects.get(id=target.id)
         response_data = FacilityIndexDetailsSerializer(

--- a/src/django/api/views/facility/facilities_view_set.py
+++ b/src/django/api/views/facility/facilities_view_set.py
@@ -929,8 +929,7 @@ class FacilitiesViewSet(ListModelMixin,
                 )
 
             send_claim_facility_confirmation_email(request, facility_claim)
-            facility.updated_at = timezone.now()
-            facility.save()
+            Facility.update_facility_updated_at_field(facility.id)
 
             approved = (
                 FacilityClaim
@@ -1112,8 +1111,8 @@ class FacilitiesViewSet(ListModelMixin,
         merge.delete()
 
         target.refresh_from_db()
-        target.updated_at = timezone.now()
-        target.save()
+        Facility.update_facility_updated_at_field(target.id)
+
         context = {'request': request}
         facility_index = FacilityIndex.objects.get(id=target.id)
         response_data = FacilityIndexDetailsSerializer(

--- a/src/django/api/views/facility/facility_claim_view_set.py
+++ b/src/django/api/views/facility/facility_claim_view_set.py
@@ -1,7 +1,6 @@
 import json
 from api.models.transactions.index_facilities_new import index_facilities_new
 
-from api.helpers.helpers import validate_workers_count
 from rest_framework.decorators import action
 from rest_framework.exceptions import (
     NotFound,
@@ -33,6 +32,7 @@ from ...models.facility.facility_claim import FacilityClaim
 from ...models.facility.facility_claim_review_note import (
     FacilityClaimReviewNote
 )
+from ...models.facility.facility import Facility
 from ...permissions import (
     IsRegisteredAndConfirmed,
     IsSuperuser
@@ -158,6 +158,7 @@ class FacilityClaimViewSet(ModelViewSet):
             claim.status_change_date = timezone.now()
             claim.status = FacilityClaimStatuses.APPROVED
             claim.save()
+            Facility.update_facility_updated_at_field(claim.facility_id)
 
             note = (
                 f'Status was updated to {FacilityClaimStatuses.APPROVED} '
@@ -208,6 +209,7 @@ class FacilityClaimViewSet(ModelViewSet):
             claim.status_change_date = timezone.now()
             claim.status = FacilityClaimStatuses.DENIED
             claim.save()
+            Facility.update_facility_updated_at_field(claim.facility_id)
 
             note = (
                 f'Status was updated to {FacilityClaimStatuses.DENIED} '
@@ -251,6 +253,7 @@ class FacilityClaimViewSet(ModelViewSet):
             claim.status_change_date = timezone.now()
             claim.status = FacilityClaimStatuses.REVOKED
             claim.save()
+            Facility.update_facility_updated_at_field(claim.facility_id)
 
             note = (
                 f'Status was updated to {FacilityClaimStatuses.REVOKED} '
@@ -428,6 +431,7 @@ class FacilityClaimViewSet(ModelViewSet):
                 setattr(claim, field_name, request.data.get(field_name))
 
             claim.save()
+            Facility.update_facility_updated_at_field(claim.facility_id)
 
             create_extendedfields_for_claim(claim)
 

--- a/src/django/api/views/facility/facility_claim_view_set.py
+++ b/src/django/api/views/facility/facility_claim_view_set.py
@@ -1,6 +1,7 @@
 import json
 from api.models.transactions.index_facilities_new import index_facilities_new
 
+from api.helpers.helpers import validate_workers_count
 from rest_framework.decorators import action
 from rest_framework.exceptions import (
     NotFound,


### PR DESCRIPTION
[OSDEV-1102](https://opensupplyhub.atlassian.net/browse/OSDEV-1102) - API. Propagate production location updates to OpenSearch data source via refreshing `updated_at` field in `api_facility` table.

List of cases where updated data should appear in OpenSearch:
 - Claim process: approve, reject, deny, claim
 - Claim details 
 - Merge facilities (Dashboard)
 
 Fixed the tests for the facility history, as the save operation increases the number of actions saved to the facility history with the status FacilityHistoryActions.OTHER.

[OSDEV-1102]: https://opensupplyhub.atlassian.net/browse/OSDEV-1102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ