### PR TITLE
Fixed a bug related to environment variable management

### DIFF
--- a/deployment/environments/terraform-development.tfvars
+++ b/deployment/environments/terraform-development.tfvars
@@ -1,6 +1,5 @@
 project = "OpenSupplyHub"
 environment = "Development"
-py_environment = "Staging"
 
 aws_region = "eu-west-1"
 aws_availability_zones = ["eu-west-1a", "eu-west-1b"]

--- a/deployment/environments/terraform-preprod.tfvars
+++ b/deployment/environments/terraform-preprod.tfvars
@@ -1,57 +1,56 @@
-project = "OpenSupplyHub" # secure
-environment = "Preprod" # secure
-py_environment = "Staging" # secure
+project = "OpenSupplyHub"
+environment = "Preprod"
 
-aws_region = "eu-west-1" # secure
-aws_availability_zones = ["eu-west-1a", "eu-west-1b"] # secure
+aws_region = "eu-west-1"
+aws_availability_zones = ["eu-west-1a", "eu-west-1b"]
 
-r53_private_hosted_zone = "osh.internal" # secure
-r53_service_discovery_zone = "pp.internal" # secure
-r53_public_hosted_zone = "os-hub.net" # secure
+r53_private_hosted_zone = "osh.internal"
+r53_service_discovery_zone = "pp.internal"
+r53_public_hosted_zone = "os-hub.net"
 
-cloudfront_price_class = "PriceClass_All" # secure
+cloudfront_price_class = "PriceClass_All"
 
-bastion_ami = "ami-0bb3fad3c0286ebd5" # secure
-bastion_instance_type = "t3.nano" # secure
+bastion_ami = "ami-0bb3fad3c0286ebd5"
+bastion_instance_type = "t3.nano"
 
-rds_allocated_storage = "128" # secure
-rds_engine_version = "12" # secure
-rds_parameter_group_family = "postgres12" # secure
-rds_instance_type = "db.t3.2xlarge" # secure
-rds_database_identifier = "opensupplyhub-enc-pp" # secure
-rds_database_name = "opensupplyhub" # secure
-rds_multi_az = false # secure
-rds_storage_encrypted = true # secure
+rds_allocated_storage = "128"
+rds_engine_version = "12"
+rds_parameter_group_family = "postgres12"
+rds_instance_type = "db.t3.2xlarge"
+rds_database_identifier = "opensupplyhub-enc-pp"
+rds_database_name = "opensupplyhub"
+rds_multi_az = false
+rds_storage_encrypted = true
 
-app_ecs_desired_count = "12" # secure
-app_ecs_deployment_min_percent = "100" # secure
-app_ecs_deployment_max_percent = "400" # secure
-app_fargate_cpu = "2048" # secure
-app_fargate_memory = "8192" # secure
+app_ecs_desired_count = "12"
+app_ecs_deployment_min_percent = "100"
+app_ecs_deployment_max_percent = "400"
+app_fargate_cpu = "2048"
+app_fargate_memory = "8192"
 
-cli_fargate_cpu = "2048" # secure
-cli_fargate_memory = "8192" # secure
+cli_fargate_cpu = "2048"
+cli_fargate_memory = "8192"
 
-gunicorn_worker_timeout = "240" # secure
+gunicorn_worker_timeout = "240"
 
-batch_default_ce_spot_fleet_bid_percentage = 60 # secure
-batch_ami_id = "ami-002e2fef4b94f8fd0" # secure
+batch_default_ce_spot_fleet_bid_percentage = 60
+batch_ami_id = "ami-002e2fef4b94f8fd0"
 
-batch_default_ce_min_vcpus = 0 # secure
-batch_default_ce_max_vcpus = 128 # secure
-batch_default_job_memory = 8192 # secure
+batch_default_ce_min_vcpus = 0
+batch_default_ce_max_vcpus = 128
+batch_default_job_memory = 8192
 
-batch_default_ce_instance_types = ["c5", "m5"] # secure
+batch_default_ce_instance_types = ["c5", "m5"]
 
-app_ecs_grace_period_seconds = 300 # secure
+app_ecs_grace_period_seconds = 300
 
-ec_memcached_identifier = "opensupplyhub-pp" # secure
-rds_final_snapshot_identifier = "opensupplyhub-rds-pp" # secure
-topic_dedup_basic_name = "basic-name" # secure
-dedupe_hub_live = true # secure
-dedupe_hub_name = "deduplicate" # secure
-dedupe_hub_version = 1 # secure
-app_cc_ecs_desired_count = 0 # secure
+ec_memcached_identifier = "opensupplyhub-pp"
+rds_final_snapshot_identifier = "opensupplyhub-rds-pp"
+topic_dedup_basic_name = "basic-name"
+dedupe_hub_live = true
+dedupe_hub_name = "deduplicate"
+dedupe_hub_version = 1
+app_cc_ecs_desired_count = 0
 app_dd_fargate_cpu = 4096
 app_dd_fargate_memory = 8192
 app_dd_ecs_desired_count = 1

--- a/deployment/environments/terraform-production.tfvars
+++ b/deployment/environments/terraform-production.tfvars
@@ -1,6 +1,5 @@
 project = "OpenSupplyHub"
 environment = "Production"
-py_environment = "Production"
 
 aws_region = "eu-west-1"
 aws_availability_zones = ["eu-west-1a", "eu-west-1b"]

--- a/deployment/environments/terraform-staging.tfvars
+++ b/deployment/environments/terraform-staging.tfvars
@@ -1,6 +1,5 @@
 project = "OpenSupplyHub"
 environment = "Staging"
-py_environment = "Staging"
 aws_region = "eu-west-1"
 aws_availability_zones = ["eu-west-1a", "eu-west-1b"]
 

--- a/deployment/environments/terraform-test.tfvars
+++ b/deployment/environments/terraform-test.tfvars
@@ -1,6 +1,5 @@
 project = "OpenSupplyHub"
 environment = "Test"
-py_environment = "Test"
 
 aws_region = "eu-west-1"
 aws_availability_zones = ["eu-west-1a", "eu-west-1b"]

--- a/deployment/terraform/container_service.tf
+++ b/deployment/terraform/container_service.tf
@@ -231,7 +231,6 @@ data "template_file" "app" {
     aws_region                       = var.aws_region
     project                          = var.project
     environment                      = var.environment
-    py_environment                   = var.py_environment
     CORS_ALLOWED_ORIGIN_REGEXES      = var.CORS_ALLOWED_ORIGIN_REGEXES
     batch_job_queue_name             = local.batch_job_queue_name
     batch_job_def_name               = local.batch_job_def_name

--- a/deployment/terraform/task-definitions/app.json
+++ b/deployment/terraform/task-definitions/app.json
@@ -21,7 +21,7 @@
         { "name": "POSTGRES_USER", "value": "${postgres_user}" },
         { "name": "POSTGRES_PASSWORD", "value": "${postgres_password}" },
         { "name": "POSTGRES_DB", "value": "${postgres_db}" },
-        { "name": "DJANGO_ENV", "value": "${py_environment}" },
+        { "name": "DJANGO_ENV", "value": "${environment}" },
         { "name": "BATCH_JOB_QUEUE_NAME", "value": "${batch_job_queue_name}" },
         { "name": "BATCH_JOB_DEF_NAME", "value": "${batch_job_def_name}" },
         { "name": "DJANGO_SECRET_KEY", "value": "${django_secret_key}" },

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -470,9 +470,6 @@ variable "ec_memcached_max_item_size" {
   default = "1048576"
 }
 
-variable "py_environment" {
-  default = "Staging"
-}
 variable "CORS_ALLOWED_ORIGIN_REGEXES" {
   type = string
   default = "http://localhost, https://127.0.0.1"

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -24,7 +24,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   * __Deploy to AWS__ pipeline will init from __[Release] Deploy__ pipeline and get deployment parameters, such as cleaning OpenSearch indexes, by trigger.
 
 ### Bugfix
-* *Describe bugfix here.*
+* Fixed a bug related to environment variable management:
+    * Removed the `py_environment` Terraform variable, as it appeared to be a duplicate of the `environment` variable.
+    * Passed the correct environment values to the ECS task definition for the Django containers in all environments, especially in the Preprod and Development environments, to avoid misunderstandings and incorrect interpretations of the values previously passed via `py_environment`.
+    * Introduced a *Local* environment specifically for local development to avoid duplicating variable values with the AWS-hosted *Development* environment.
 
 ### What's new
 * *Describe what's new here. The changes that can impact user experience should be listed in this section.*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - POSTGRES_DB=opensupplyhub
       - CACHE_HOST=memcached
       - CACHE_PORT=11211
-      - DJANGO_ENV=Development
+      - DJANGO_ENV=Local
       - DJANGO_SECRET_KEY=secret
       - DJANGO_LOG_LEVEL=INFO
       - AWS_PROFILE=${AWS_PROFILE:-default}
@@ -171,7 +171,7 @@ services:
       - CONSUMER_GROUP_ID=dedupe.hub.grp-0
       - CONSUMER_CLIENT_ID=dedupe.hub
       - TOPIC_DEDUPE_BASIC_NAME=dedupe.hub.topic
-      - ENV="Development"
+      - ENV="Local"
       - ROLLBAR_SERVER_SIDE_ACCESS_TOKEN=""
       - POSTGRES_HOST=database
       - POSTGRES_PORT=5432

--- a/src/dedupe-hub/api/app/utils/constants.py
+++ b/src/dedupe-hub/api/app/utils/constants.py
@@ -4,7 +4,7 @@ from app.config import settings
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = (settings.env == 'Development')
+DEBUG = (settings.env == 'Local')
 # Rollbar config
 ROLLBAR = {
     'access_token': settings.rollbar_server_side_access_token,

--- a/src/django/api/adapters.py
+++ b/src/django/api/adapters.py
@@ -10,9 +10,7 @@ class OARUserAccountAdapter(DefaultAccountAdapter):
         return settings.DEFAULT_FROM_EMAIL
 
     def get_email_confirmation_url(self, request, emailconfirmation):
-        is_development = settings.ENVIRONMENT == 'Development'
-
-        if is_development:
+        if settings.DEBUG:
             protocol = 'http'
             domain = 'localhost:6543'
         else:

--- a/src/django/api/mail.py
+++ b/src/django/api/mail.py
@@ -7,7 +7,7 @@ from countries.lib.countries import COUNTRY_NAMES
 
 
 def make_oar_url(request):
-    if settings.ENVIRONMENT == 'Development':
+    if settings.DEBUG:
         protocol = 'http'
         host = 'localhost:6543'
     else:

--- a/src/django/api/management/commands/reprocess_geocode_failures.py
+++ b/src/django/api/management/commands/reprocess_geocode_failures.py
@@ -4,7 +4,7 @@ from django.db.models import Count
 
 from api.models import FacilityList, FacilityListItem
 
-from oar.settings import ENVIRONMENT
+from oar.settings import DEBUG
 
 from api.aws_batch import submit_jobs
 
@@ -48,8 +48,7 @@ class Command(BaseCommand):
 
         self.stdout.write('Reprocessing {} lists'.format(str(lists.count())))
         for facility_list in lists:
-            if ENVIRONMENT in ('Test', 'Staging',
-                               'Production', 'Preprod'):
+            if not DEBUG:
                 job_ids = submit_jobs(facility_list)
                 self.stdout.write('{} {}'.format(facility_list.id, job_ids))
             else:

--- a/src/django/api/serializers/user/user_password_reset_serializer.py
+++ b/src/django/api/serializers/user/user_password_reset_serializer.py
@@ -26,13 +26,13 @@ class UserPasswordResetSerializer(PasswordResetSerializer):
         request = self.context.get('request')
         # Set some values to trigger the send_email method.
 
-        if settings.ENVIRONMENT == 'Development':
+        if settings.DEBUG:
             domain_override = 'localhost:6543'
         else:
             domain_override = request.get_host()
 
         opts = {
-            'use_https': settings.ENVIRONMENT != 'Development',
+            'use_https': not settings.DEBUG,
             'domain_override': domain_override,
             'from_email': getattr(settings, 'DEFAULT_FROM_EMAIL'),
             'request': request,

--- a/src/django/api/views/facility/facility_list_view_set.py
+++ b/src/django/api/views/facility/facility_list_view_set.py
@@ -16,7 +16,7 @@ from api.helpers.helpers import (
 )
 from oar.settings import (
     MAX_UPLOADED_FILE_SIZE_IN_BYTES,
-    ENVIRONMENT,
+    DEBUG
 )
 from oar.rollbar import report_error_to_rollbar
 from rest_framework.decorators import action
@@ -240,7 +240,7 @@ class FacilityListViewSet(ModelViewSet):
                  for idx, row in enumerate(rows)]
         FacilityListItem.objects.bulk_create(items)
 
-        if ENVIRONMENT in ('Test', 'Staging', 'Production', 'Preprod'):
+        if not DEBUG:
             submit_parse_job(new_list)
 
         serializer = self.get_serializer(new_list)
@@ -470,7 +470,7 @@ class FacilityListViewSet(ModelViewSet):
         facility_list.status = FacilityList.APPROVED
         facility_list.save()
 
-        if ENVIRONMENT in ('Test', 'Staging', 'Production', 'Preprod'):
+        if not DEBUG:
             submit_jobs(facility_list)
 
         return Response(

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -26,25 +26,30 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = os.getenv('DJANGO_SECRET_KEY', 'secret')
 
 # Set environment
-ENVIRONMENT = os.getenv('DJANGO_ENV', 'Development')
-VALID_ENVIRONMENTS = ('Production', 'Staging', 'Development', 'Test', 'Preprod')
+ENVIRONMENT = os.getenv('DJANGO_ENV', 'Local')
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = (ENVIRONMENT == 'Local')
+
+VALID_ENVIRONMENTS = ('Production', 'Staging', 'Development', 'Test',
+                      'Preprod', 'Local')
 if ENVIRONMENT not in VALID_ENVIRONMENTS:
     raise ImproperlyConfigured(
         'Invalid ENVIRONMENT provided, must be one of {}'
         .format(VALID_ENVIRONMENTS))
 
 BATCH_JOB_QUEUE_NAME = os.getenv('BATCH_JOB_QUEUE_NAME')
-if BATCH_JOB_QUEUE_NAME is None and ENVIRONMENT != 'Development':
+if BATCH_JOB_QUEUE_NAME is None and not DEBUG:
     raise ImproperlyConfigured(
         'Invalid BATCH_JOB_QUEU_NAME provided, must be set')
 
 BATCH_JOB_DEF_NAME = os.getenv('BATCH_JOB_DEF_NAME')
-if BATCH_JOB_DEF_NAME is None and ENVIRONMENT != 'Development':
+if BATCH_JOB_DEF_NAME is None and not DEBUG:
     raise ImproperlyConfigured(
         'Invalid BATCH_JOB_DEF_NAME provided, must be set')
 
 EXTERNAL_DOMAIN = os.getenv('EXTERNAL_DOMAIN')
-if EXTERNAL_DOMAIN is None and ENVIRONMENT != 'Development':
+if EXTERNAL_DOMAIN is None and not DEBUG:
     raise ImproperlyConfigured(
         'Invalid EXTERNAL_DOMAIN provided, must be set')
 
@@ -56,22 +61,19 @@ LOGLEVEL = os.getenv('DJANGO_LOG_LEVEL', 'INFO')
 
 GIT_COMMIT = os.getenv('GIT_COMMIT', 'UNKNOWN')
 
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = (ENVIRONMENT == 'Development')
-
 ALLOWED_HOSTS = [
     '.openapparel.org',
     '.opensupplyhub.org',
     '.os-hub.net',
 ]
 
-if ENVIRONMENT == 'Development':
+if DEBUG:
     ALLOWED_HOSTS.append('localhost')
     ALLOWED_HOSTS.append('django')
     ALLOWED_HOSTS.append('app')
     ALLOWED_HOSTS.append('contricleaner')
 
-if ENVIRONMENT in ['Production', 'Staging', 'Test'] and BATCH_MODE == '':
+if not DEBUG and BATCH_MODE == '':
     # Within EC2, the Elastic Load Balancer HTTP health check will use the
     # target instance's private IP address for the Host header.
     #


### PR DESCRIPTION
- Removed the `py_environment` Terraform variable, as it appeared to be a duplicate of the `environment` variable.
- Passed the correct environment values to the ECS task definition for the Django containers in all environments, especially in the Preprod and Development environments, to avoid misunderstandings and incorrect interpretations of the values previously passed via `py_environment`.
- Introduced a *Local* environment specifically for local development to avoid duplicating variable values with the AWS-hosted *Development* environment.