### PR TITLE
[OSDEV-1372] Use a new base docker image for Django

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -23,7 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-1325](https://opensupplyhub.atlassian.net/browse/OSDEV-1325)
   * __Deploy to AWS__ pipeline will init from __[Release] Deploy__ pipeline and get deployment parameters, such as cleaning OpenSearch indexes, by trigger.
 * [OSDEV-1372](https://opensupplyhub.atlassian.net/browse/OSDEV-1372)
-  * Updating Dockerfile with newer Debian version as PostgreSQL repository support for Debian 10 has ended
+  * Changed the base image in the Django app Dockerfile to use a Debian 11 instead of Debian 10 as the PostgreSQL 13 repository support for Debian 10 has been ended.
 
 ### Bugfix
 * *Describe bugfix here.*

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -22,6 +22,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Architecture/Environment changes
 * [OSDEV-1325](https://opensupplyhub.atlassian.net/browse/OSDEV-1325)
   * __Deploy to AWS__ pipeline will init from __[Release] Deploy__ pipeline and get deployment parameters, such as cleaning OpenSearch indexes, by trigger.
+* [OSDEV-1372](https://opensupplyhub.atlassian.net/browse/OSDEV-1372)
+  * Updating Dockerfile with newer Debian version as PostgreSQL repository support for Debian 10 has ended
 
 ### Bugfix
 * *Describe bugfix here.*

--- a/src/django/Dockerfile
+++ b/src/django/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/azavea/django:3.2-python3.7-slim
+FROM python:3.7-slim-bullseye
 # FROM python:3.7-slim
 
 RUN mkdir -p /usr/local/src/static/static
@@ -8,13 +8,17 @@ COPY requirements.txt /usr/local/src/
 RUN set -ex \
     && buildDeps=" \
     build-essential \
+    libpq-dev \
     " \
     && deps=" \
+    gdal-bin \
+    gettext \
     postgresql-client-13 \
     " \
     && apt-get update && apt-get install -y $buildDeps $deps --no-install-recommends \
     && pip install --no-cache-dir -r requirements.txt \
-    && apt-get purge -y --auto-remove $buildDeps
+    && apt-get purge -y --auto-remove $buildDeps \
+    && rm -rf  /usr/local/src/requirements.txt /var/lib/apt/lists/*
 
 COPY . /usr/local/src
 
@@ -24,6 +28,8 @@ RUN GOOGLE_SERVER_SIDE_API_KEY="" \
     HUBSPOT_SUBSCRIPTION_ID="" \
     EXTERNAL_DOMAIN="" \
     python manage.py collectstatic --no-input
+
+ENTRYPOINT ["/usr/local/bin/gunicorn"]
 
 CMD ["-b :8080", \
     "--workers=1", \

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -37,3 +37,7 @@ Unidecode==1.0.23
 django-slowtests
 django-allauth==0.54.0
 opensearch-py==2.5.0
+gunicorn==20.1.0
+django==3.2.17
+psycopg2==2.9.4
+gevent==22.8.0


### PR DESCRIPTION
Changed the base image in the Django app Dockerfile to use a Debian 11 instead of Debian 10 as the PostgreSQL 13 repository support for Debian 10 has been ended.