### PR TITLE
[OSDEV-1372] Always use linux/amd64 platform to build docker image

### DIFF
--- a/src/django/Dockerfile
+++ b/src/django/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-bullseye
+FROM --platform=linux/amd64 python:3.7-slim-bullseye
 # FROM python:3.7-slim
 
 RUN mkdir -p /usr/local/src/static/static


### PR DESCRIPTION
The fixed version of the linux/amd64 platform allows you to build an image on the arm64 platform identical to the production environment.