### PR TITLE
[OSDEV-1127] Add country name to the "Search by OS ID" result screen.

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -34,7 +34,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### What's new
 * [OSDEV-1127](https://opensupplyhub.atlassian.net/browse/OSDEV-1127) - It was implemented the Production Location Search screen that has two tabs: "Search by OS ID" and "Search by Name and Address." Each tab adds a query parameter (`?tab=os-id` and `?tab=name-address`) to the URL when active, allowing for redirection to the selected tab. On the "Search by OS ID" tab, users see an input field where they can enter an OS ID. After entering the full OS ID (15 characters), the "Search By ID" button becomes clickable, allowing users to proceed to the results screen. There are two possible outcomes:
-    * Successful Search: If the search is successful, the results screen displays information about the production location, including its name, OS ID, previous OS ID (If they exist), and address. Users can then choose to either return to the search by name and address or add data and claim the location.
+    * Successful Search: If the search is successful, the results screen displays information about the production location, including its name, OS ID, previous OS ID (If they exist), address, and country name. Users can then choose to either return to the search by name and address or add data and claim the location.
     * Unsuccessful Search: If the search is unsuccessful, an explanation is provided, along with two options: return to the search by name and address or search for another OS ID.
 
     Each results screen also includes a "Back to ID search" button at the top.

--- a/src/react/src/__tests__/components/SearchByOsIdSuccessResult.test.js
+++ b/src/react/src/__tests__/components/SearchByOsIdSuccessResult.test.js
@@ -9,13 +9,15 @@ describe('SearchByOsIdSuccessResult component', () => {
     const name = 'Production Location Name';
     const osId = 'US2021250D1DTN7';
     const historicalOsIds = ['US2020053ZH1RY4', 'US2020053ZH1RY5'];
-    const address = '1234 Production Location St. United States';
+    const address = '1234 Production Location St, City, State, 12345';
+    const countryName = 'United States';
     const handleBackToSearchByNameAddress = jest.fn();
 
     const defaultProps = {
         name,
         osId,
         address,
+        countryName,
         handleBackToSearchByNameAddress
     };
 
@@ -27,6 +29,7 @@ describe('SearchByOsIdSuccessResult component', () => {
         expect(getByText(`OS ID: ${osId}`)).toBeInTheDocument();
         expect(queryByText('Previous OS ID:')).not.toBeInTheDocument();
         expect(getByText(address)).toBeInTheDocument();
+        expect(getByText(countryName)).toBeInTheDocument();
     });
 
     it('renders SearchByOsIdResultActions', () => {

--- a/src/react/src/components/Contribute/SearchByOsIdResult.jsx
+++ b/src/react/src/components/Contribute/SearchByOsIdResult.jsx
@@ -46,6 +46,7 @@ const SearchByOsIdResult = ({
         os_id: osId,
         historical_os_id: historicalOsIds,
         address,
+        country: { name: countryName } = {},
     } = locationData;
 
     const handleBackToSearchByNameAddress = () => {
@@ -83,6 +84,7 @@ const SearchByOsIdResult = ({
                         osId={osId}
                         historicalOsIds={historicalOsIds}
                         address={address}
+                        countryName={countryName}
                         handleBackToSearchByNameAddress={
                             handleBackToSearchByNameAddress
                         }

--- a/src/react/src/components/Contribute/SearchByOsIdSuccessResult.jsx
+++ b/src/react/src/components/Contribute/SearchByOsIdSuccessResult.jsx
@@ -17,7 +17,7 @@ const SearchByOsIdSuccessResult = ({
 }) => {
     const historicalOsIdsNotEmpty =
         Array.isArray(historicalOsIds) && historicalOsIds.length > 0;
-    console.log('countryName >>>', countryName);
+
     return (
         <>
             <Typography component="h2" className={classes.resultTitleStyles}>
@@ -75,7 +75,6 @@ SearchByOsIdSuccessResult.propTypes = {
     osId: string.isRequired,
     historicalOsIds: arrayOf(string),
     address: string.isRequired,
-    // country: object.isRequired,
     countryName: string.isRequired,
     handleBackToSearchByNameAddress: func.isRequired,
     classes: object.isRequired,

--- a/src/react/src/components/Contribute/SearchByOsIdSuccessResult.jsx
+++ b/src/react/src/components/Contribute/SearchByOsIdSuccessResult.jsx
@@ -11,12 +11,13 @@ const SearchByOsIdSuccessResult = ({
     osId,
     historicalOsIds,
     address,
+    countryName,
     handleBackToSearchByNameAddress,
     classes,
 }) => {
     const historicalOsIdsNotEmpty =
         Array.isArray(historicalOsIds) && historicalOsIds.length > 0;
-
+    console.log('countryName >>>', countryName);
     return (
         <>
             <Typography component="h2" className={classes.resultTitleStyles}>
@@ -46,10 +47,14 @@ const SearchByOsIdSuccessResult = ({
                             <PreviousOsIdTooltip />
                         </Typography>
                     ))}
-
-                <Typography className={classes.locationAddressStyles}>
-                    {address}
-                </Typography>
+                <div className={classes.locationAddressContainerStyles}>
+                    <Typography className={classes.locationAddressStyles}>
+                        {address}
+                    </Typography>
+                    <Typography className={classes.locationAddressStyles}>
+                        {countryName}
+                    </Typography>
+                </div>
             </div>
             <SearchByOsIdResultActions
                 defaultButtonLabel="No, search by name and address"
@@ -70,6 +75,8 @@ SearchByOsIdSuccessResult.propTypes = {
     osId: string.isRequired,
     historicalOsIds: arrayOf(string),
     address: string.isRequired,
+    // country: object.isRequired,
+    countryName: string.isRequired,
     handleBackToSearchByNameAddress: func.isRequired,
     classes: object.isRequired,
 };

--- a/src/react/src/util/propTypes.js
+++ b/src/react/src/util/propTypes.js
@@ -469,5 +469,11 @@ export const productionLocationPropType = shape({
     os_id: string,
     name: string,
     address: string,
+    country: shape({
+        alpha_2: string,
+        alpha_3: string,
+        name: string,
+        numeric: string,
+    }),
     historical_os_id: arrayOf(string),
 });

--- a/src/react/src/util/styles.js
+++ b/src/react/src/util/styles.js
@@ -435,8 +435,6 @@ export const makeSearchByOsIdResultStyles = theme =>
             margin: '8px 0 24px 0',
         }),
         locationDetailsStyles: Object.freeze({
-            fontSize: '18px',
-            fontWeight: theme.typography.fontWeightSemiBold,
             margin: '24px 0',
         }),
         locationNameStyles: Object.freeze({
@@ -448,19 +446,24 @@ export const makeSearchByOsIdResultStyles = theme =>
             fontSize: '16px',
             lineHeight: '20px',
             fontWeight: theme.typography.fontWeightBold,
-            margin: '8px 0',
+            marginTop: '8px',
         }),
         locationHistoricalOsIdStyles: Object.freeze({
             fontSize: '14px',
             lineHeight: '20px',
             fontWeight: theme.typography.fontWeightBold,
             color: COLOURS.DARK_GREY,
+            marginTop: '8px',
+        }),
+        locationAddressContainerStyles: Object.freeze({
+            display: 'flex',
+            flexDirection: 'column',
+            marginTop: '12px',
         }),
         locationAddressStyles: Object.freeze({
             fontSize: '16px',
             lineHeight: '20px',
             fontWeight: theme.typography.fontWeightSemiBold,
-            marginTop: '12px',
         }),
     });
 


### PR DESCRIPTION
[OSDEV-1127](https://opensupplyhub.atlassian.net/browse/OSDEV-1127) - SLC. Implement OS ID search. 

This PR adds a country name to the "Search by OS ID" result screen to provide users with a clearer geographical context for production location.

Changes:

- Modified Components:
   - `SearchByOsIdResult.jsx`: Updated logic to pass the country name to the result display.
   - `SearchByOsIdSuccessResult.jsx`:  Updated to render the country name field as part of the result view.

- Prop Types:
   - Extended `productionLocationPropType` to include a `country` object for ensuring correct data type validation.

- Styling:
   - Updated styles in `makeSearchByOsIdResultStyles` to ensure the country name is properly displayed and aligned with the rest of the layout.

- Tests:
   - Updated unit tests for the `SearchByOsIdSuccessResult` component to verify that the country name is correctly rendered in the result view.




[OSDEV-1127]: https://opensupplyhub.atlassian.net/browse/OSDEV-1127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ