### PR TITLE
[OSDEV-1388] fix sharing anonymized snapshots with another account.

### DIFF
--- a/deployment/terraform/database_anonymizer_sheduled_task/docker/database_anonymizer.py
+++ b/deployment/terraform/database_anonymizer_sheduled_task/docker/database_anonymizer.py
@@ -113,7 +113,13 @@ response = source.copy_db_snapshot(
 )
 
 waiters = source.get_waiter('db_snapshot_completed')
-waiters.wait(DBSnapshotIdentifier=shared_snapshot_identifier)
+waiters.wait(
+    DBSnapshotIdentifier=shared_snapshot_identifier,
+    WaiterConfig={
+        'Delay': 15,
+        'MaxAttempts': 100
+    }
+)
 
 print("Share snapshot " + shared_snapshot_identifier + " with " + destination_aws_account + " AWS account")
 source.modify_db_snapshot_attribute(

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -27,6 +27,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   * Always build a docker image for the amd64 platform so that the image in the local environment fully corresponds to the one in production.
 * [OSDEV-1172](https://opensupplyhub.atlassian.net/browse/OSDEV-1172)
   * Added the ability to restore a database from a snapshot.
+* [OSDEV-1388](https://opensupplyhub.atlassian.net/browse/OSDEV-1388)
+  * Increased timeout to wait for copying anonymized shared snapshot.
 
 ### Bugfix
 * Fixed a bug related to environment variable management:


### PR DESCRIPTION
This changes increase timeout for copying shared snapshot to avoid the problem
```
botocore.exceptions.WaiterError: Waiter DBSnapshotCompleted failed: Max attempts exceeded
```