### PR TITLE
[OSDEV-1039] Fix DB reset

### DIFF
--- a/.github/workflows/deploy_to_aws.yml
+++ b/.github/workflows/deploy_to_aws.yml
@@ -318,7 +318,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: "eu-west-1"
-          LIST_S3_BUCKET: opensupplyhub-${{ steps.get_env_name.outputs.lowercase }}-files-${{ env.AWS_DEFAULT_REGION }}
+          LIST_S3_BUCKET: opensupplyhub-${{ steps.get_env_name.outputs.lowercase }}-files-eu-west-1
           RESET_LISTS_FOLDER: "api/fixtures/list_files/"
 
   update_services:

--- a/.github/workflows/deploy_to_aws.yml
+++ b/.github/workflows/deploy_to_aws.yml
@@ -308,7 +308,7 @@ jobs:
         if: ${{ vars.ENV_NAME == 'Development' && inputs.restore-db == true}}
         run: |
           echo "Creating an S3 folder with production location lists to reset DB if it doesn't exist."
-          aws s3api put-object --bucket ${{ env.LIST_S3_BUCKET }} --key ${{ env.RESET_LISTS_S3_FOLDER }}
+          aws s3api put-object --bucket ${{ env.LIST_S3_BUCKET }} --key ${{ env.RESET_LISTS_FOLDER }}
           echo "Coping all production location files from the repo to S3 to ensure consistency between local and environment resets."
           aws s3 cp ./src/django/${{ env.RESET_LISTS_FOLDER }} s3://${{ env.LIST_S3_BUCKET }}/${{ env.RESET_LISTS_FOLDER }} --recursive
           echo "Triggering reset commands."

--- a/.github/workflows/deploy_to_aws.yml
+++ b/.github/workflows/deploy_to_aws.yml
@@ -307,12 +307,19 @@ jobs:
       - name: Reset database for ${{ vars.ENV_NAME }}
         if: ${{ vars.ENV_NAME == 'Development' && inputs.restore-db == true}}
         run: |
+          echo "Creating an S3 folder with production location lists to reset DB if it doesn't exist."
+          aws s3api put-object --bucket ${{ env.LIST_S3_BUCKET }} --key ${{ env.RESET_LISTS_S3_FOLDER }}
+          echo "Coping all production location files from the repo to S3 to ensure consistency between local and environment resets."
+          aws s3 cp ./src/django/${{ env.RESET_LISTS_FOLDER }} s3://${{ env.LIST_S3_BUCKET }}/${{ env.RESET_LISTS_FOLDER }} --recursive
+          echo "Triggering reset commands."
           ./deployment/run_cli_task ${{ vars.ENV_NAME }} "reset_database"
           ./deployment/run_cli_task ${{ vars.ENV_NAME }} "matchfixtures"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: "eu-west-1"
+          LIST_S3_BUCKET: opensupplyhub-${{ steps.get_env_name.outputs.lowercase }}-files-${{ env.AWS_DEFAULT_REGION }}
+          RESET_LISTS_FOLDER: "api/fixtures/list_files/"
 
   update_services:
     needs: restore_database

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -19,7 +19,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Code/API changes
 * [OSDEV-1102](https://opensupplyhub.atlassian.net/browse/OSDEV-1102) - API. Propagate production location updates to OpenSearch data source via refreshing `updated_at` field in `api_facility` table. Triggered updated_at field in such actions: transfer to alternate facility, claim facility, approve, reject and deny claim, claim details, merge facilities, match facility (promote, split).
-* [OSDEV-1039](https://opensupplyhub.atlassian.net/browse/OSDEV-1039) - Deleted the `facility_list_items.json` fixture from the Django app since it is no longer needed because it has been replaced with real CSV files. Adjusted all the code that used the `facility_list_items.json` fixture, and deleted the unused matching logic from the Django app since it isn't necessary and was connected to that fixture.
+* [OSDEV-1039](https://opensupplyhub.atlassian.net/browse/OSDEV-1039) - Deleted the `facility_list_items.json` fixture from the Django app since it is no longer needed, having been replaced with real CSV files. Additionally, other important changes have been implemented in the Django app and deployment:
+    * Adjusted all code that used the `facility_list_items.json` fixture and removed the unused matching logic from the Django app, as it is no longer necessary and was connected to that fixture.
+    * Updated the reset database step in the `restore_database` job of the Deploy to AWS GitHub workflow to upload CSV location list files to S3 for parsing during the DB reset.
 
 ### Architecture/Environment changes
 * [OSDEV-1325](https://opensupplyhub.atlassian.net/browse/OSDEV-1325)


### PR DESCRIPTION
Updated the reset database step in the `restore_database` job of the Deploy to AWS GitHub workflow to upload CSV location list files to S3 for parsing during the DB reset.