### PR TITLE
[OSDEV-1127] Update the helper text for the OS ID input 

### DIFF
--- a/src/react/src/__tests__/components/SearchByOsIdTab.test.js
+++ b/src/react/src/__tests__/components/SearchByOsIdTab.test.js
@@ -25,7 +25,7 @@ describe('SearchByOsIdTab component', () => {
         ).toBeInTheDocument();
         expect(getByPlaceholderText('Enter the OS ID')).toBeInTheDocument();
         expect(getByText(
-            'To search you need to enter the full ID production location'
+            'To search by ID, you need to enter the full OS ID of the production location.'
         )).toBeInTheDocument();
         
         const button = getByRole('button', { name: /Search by ID/i });

--- a/src/react/src/components/Contribute/SearchByOsIdTab.jsx
+++ b/src/react/src/components/Contribute/SearchByOsIdTab.jsx
@@ -14,7 +14,8 @@ const HelperText = ({ classes }) => (
     <span className={classes.helperTextContainerStyles}>
         <InfoOutlinedIcon className={classes.infoIconStyles} />
         <Typography component="span" className={classes.helperTextStyles}>
-            To search you need to enter the full ID production location
+            To search by ID, you need to enter the full OS ID of the production
+            location.
         </Typography>
     </span>
 );


### PR DESCRIPTION
[OSDEV-1127](https://opensupplyhub.atlassian.net/browse/OSDEV-1127) - SLC. Implement OS ID search.

In this PR, the helper text for the OS ID input was updated to match the layouts.

[OSDEV-1127]: https://opensupplyhub.atlassian.net/browse/OSDEV-1127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ