### PR TITLE
Decreased the OpenSearch version to 2.15, the latest version supported by AWS.

### DIFF
--- a/deployment/terraform/opensearch.tf
+++ b/deployment/terraform/opensearch.tf
@@ -15,7 +15,7 @@ resource "aws_cloudwatch_log_group" "opensearch" {
 
 resource "aws_opensearch_domain" "opensearch" {
   domain_name    = local.opensearch_domain_name
-  engine_version = "OpenSearch_2.17"
+  engine_version = "OpenSearch_2.15"
 
   cluster_config {
     instance_type          = var.opensearch_instance_type

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -10,8 +10,28 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * Product name: Open Supply Hub
 * Release date: November 16, 2024
 
+### Database changes
+#### Migrations:
+* *Describe migrations here.*
+
+#### Scheme changes
+* *Describe scheme changes here.*
+
+### Code/API changes
+* *Describe code/API changes here.*
+
 ### Architecture/Environment changes
-* Open Search versoion has been increased to 2.15
+* The OpenSearch version has been increased to 2.15.
+
+### Bugfix
+* *Describe bugfix here.*
+
+### What's new
+* *Describe what's new here. The changes that can impact user experience should be listed in this section.*
+
+### Release instructions:
+* Run the `[Release] Deploy` pipeline for the Staging or Production environment with the flag 'Clear OpenSearch indexes' set to true. This will allow Logstash to refill OpenSearch since the OpenSearch instance will be recreated due to the version increase.
+
 
 ## Release 1.23.0
 
@@ -36,7 +56,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Release instructions:
 * Ensure that the following commands are included in the `post_deployment` command:
     * `migrate`
-* Run `Deploy to AWS` pipeline for an existing environment with the flag clear OpenSearch set to true - to let the tokenizer parse full text into words with new configurations.
+* Run `[Release] Deploy` pipeline for an existing environment with the flag 'Clear OpenSearch indexes' set to true - to let the tokenizer parse full text into words with new configurations.
 
 
 ## Release 1.22.0

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * Release date: November 16, 2024
 
 ### Architecture/Environment changes
-* Open Search versoion has been increased to 2.17
+* Open Search versoion has been increased to 2.15
 
 ## Release 1.23.0
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,7 +184,7 @@ services:
       - proxynet
 
   opensearch-single-node:
-    image: opensearchproject/opensearch:2.17.0
+    image: opensearchproject/opensearch:2.15.0
     environment:
       - cluster.name=opensearch-cluster # Name the cluster.
       - node.name=opensearch-single-node # Name the node that will run in this container.


### PR DESCRIPTION
Right now, the deployment to AWS is failing because version 2.17 isn't supported yet. See the logs here: https://github.com/opensupplyhub/open-supply-hub/actions/runs/11579269192/job/32235103967.
That's why the version was decreased to 2.15, the latest version supported by AWS.