### PR TITLE
[OSDEV-1387] Make tile generation to be throttled 30/minutes

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -17,7 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-1229](https://opensupplyhub.atlassian.net/browse/OSDEV-1229) - Created Moderation Events Postgres table to track moderation events in the database.
 
 ### Code/API changes
-* Throttling has been introduced for tiles/* endpoints, limiting requests to 20 per minute. Class 
+* Throttling has been introduced for tiles/* endpoints, limiting requests to 30 per minute.
 * [OSDEV-1328](https://opensupplyhub.atlassian.net/browse/OSDEV-1328) The OpenSearch tokenizer has been changed to `lowercase` to get better search results when querying the GET /v1/production-locations/ endpoint.
 
 ### Architecture/Environment changes

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -17,11 +17,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-1229](https://opensupplyhub.atlassian.net/browse/OSDEV-1229) - Created Moderation Events Postgres table to track moderation events in the database.
 
 ### Code/API changes
-* Throttling has been introduced for tiles/* endpoints, limiting requests to 300 per minute.
+* Throttling has been introduced for tiles/* endpoints, limiting requests to 20 per minute. Class 
 * [OSDEV-1328](https://opensupplyhub.atlassian.net/browse/OSDEV-1328) The OpenSearch tokenizer has been changed to `lowercase` to get better search results when querying the GET /v1/production-locations/ endpoint.
 
 ### Architecture/Environment changes
 * Resource allocation has been optimized for the staging environment. The number of ECS tasks for the Django app has been reduced from 6 to 4, while maintaining system stability.
+
 
 ### Release instructions:
 * Ensure that the following commands are included in the `post_deployment` command:

--- a/src/django/api/throttles.py
+++ b/src/django/api/throttles.py
@@ -44,4 +44,4 @@ class TilesThrottle(SimpleRateThrottle):
         return 'tiles_rate'
 
     def get_rate(self):
-        return '45/minute'
+        return '30/minute'

--- a/src/django/api/throttles.py
+++ b/src/django/api/throttles.py
@@ -44,4 +44,4 @@ class TilesThrottle(SimpleRateThrottle):
         return 'tiles_rate'
 
     def get_rate(self):
-        return '20/minute'
+        return '45/minute'

--- a/src/django/api/throttles.py
+++ b/src/django/api/throttles.py
@@ -1,6 +1,6 @@
 from django.core.cache import caches
 from rest_framework.throttling import UserRateThrottle
-from rest_framework.throttling import ScopedRateThrottle
+from rest_framework.throttling import SimpleRateThrottle
 
 
 class UserCustomRateThrottle(UserRateThrottle):
@@ -36,6 +36,17 @@ class DataUploadThrottle(UserCustomRateThrottle):
     model_rate_field = 'data_upload_rate'
 
 
-class TilesThrottle(ScopedRateThrottle):
+class TilesThrottle(SimpleRateThrottle):
     scope = 'tiles'
     model_rate_field = 'tiles_rate'
+
+    def allow_request(self, request, view):
+        result = super(TilesThrottle, self).allow_request(request, view)
+        print(f'allow_request: {result} {self.scope}')
+        return result
+
+    def get_cache_key(self, request, view):
+        return 'tiles_rate'
+
+    def get_rate(self):
+        return '300/minute'

--- a/src/django/api/throttles.py
+++ b/src/django/api/throttles.py
@@ -49,4 +49,4 @@ class TilesThrottle(SimpleRateThrottle):
         return 'tiles_rate'
 
     def get_rate(self):
-        return '30/minute'
+        return '10/minute'

--- a/src/django/api/throttles.py
+++ b/src/django/api/throttles.py
@@ -49,4 +49,4 @@ class TilesThrottle(SimpleRateThrottle):
         return 'tiles_rate'
 
     def get_rate(self):
-        return '10/minute'
+        return '20/minute'

--- a/src/django/api/throttles.py
+++ b/src/django/api/throttles.py
@@ -40,11 +40,6 @@ class TilesThrottle(SimpleRateThrottle):
     scope = 'tiles'
     model_rate_field = 'tiles_rate'
 
-    def allow_request(self, request, view):
-        result = super(TilesThrottle, self).allow_request(request, view)
-        print(f'allow_request: {result} {self.scope}')
-        return result
-
     def get_cache_key(self, request, view):
         return 'tiles_rate'
 

--- a/src/django/api/throttles.py
+++ b/src/django/api/throttles.py
@@ -49,4 +49,4 @@ class TilesThrottle(SimpleRateThrottle):
         return 'tiles_rate'
 
     def get_rate(self):
-        return '300/minute'
+        return '30/minute'


### PR DESCRIPTION
In this PR, the tile generation request rate is throttled to 30 requests per minute. This solution aims to reduce the risk of outages in the production environment.

* Changed the parent class of TilesThrottle to SimpleRateThrottle.
* Introduced a minimal implementation of the TilesThrottle class