### PR TITLE
Updated RELEASE-NOTES.md file for 1.24 version

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -30,7 +30,17 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * *Describe what's new here. The changes that can impact user experience should be listed in this section.*
 
 ### Release instructions:
-* Run the `[Release] Deploy` pipeline for the Staging or Production environment with the flag 'Clear OpenSearch indexes' set to true. This will allow Logstash to refill OpenSearch since the OpenSearch instance will be recreated due to the version increase.
+* The following steps should be completed while deploying to Staging or Production:
+    1. Run the `[Release] Deploy` pipeline for these environments with the flag 'Clear OpenSearch indexes' set to true. This will allow Logstash to refill OpenSearch since the OpenSearch instance will be recreated due to the version increase.
+    2. Open the triggered `Deploy to AWS` workflow and ensure that the `apply` job is completed. **Right after** finishing the `apply` job, follow these instructions, which should be the last steps in setting up the recreated OpenSearch instance:
+        - Copy the ARN of the `terraform_ci` user from the AWS IAM console.
+            - Navigate to the AWS console's search input, type "IAM", and open the IAM console.
+            - In the IAM console, find and click on the "Users" tab.
+            - In the list of available users, locate the `terraform_ci` user, click on it, and on that page, you will find its ARN.
+        - After copying this value, go to the AWS OpenSearch console in the same way you accessed the IAM console.
+        - Open the available domains and locate the domain for the corresponding environment. Open it, then navigate to the security configuration and click "Edit".
+        - Find the section titled "Fine-grained access control", and under this section, you will find an "IAM ARN" input field. Paste the copied ARN into this field and save the changes. It may take several minutes to apply. Make sure that the "Configuration change status" field has green status.
+    3. Then, return to the running `Deploy to AWS` workflow and ensure that the logs for `clear_opensearch` job do not contain errors related to access for deleting the OpenSearch index or lock files in EFS storage. In case of **an access error**, simply rerun the `Deploy to AWS` workflow manually from the appropriate release Git tag.
 
 
 ## Release 1.23.0


### PR DESCRIPTION
Right now, to enable access from EC2 to OpenSearch, the IAM ARN of the special Terraform user needs to be added to the master user settings associated with the OpenSearch instance. Since it’s not possible to set multiple master users via Terraform, you will need to add one more manually through the AWS console, as this is permitted.

As the OpenSearch instance will be recreated during the release of version 1.24, the necessary instructions have been provided in the corresponding release notes 1.24 to reestablish access from EC2 to OpenSearch for clearing OpenSearch indexes.