### PR TITLE
Increased memory for the Dedupe Hub

### DIFF
--- a/deployment/environments/terraform-preprod.tfvars
+++ b/deployment/environments/terraform-preprod.tfvars
@@ -52,7 +52,7 @@ dedupe_hub_name = "deduplicate"
 dedupe_hub_version = 1
 app_cc_ecs_desired_count = 0
 app_dd_fargate_cpu = 4096
-app_dd_fargate_memory = 8192
+app_dd_fargate_memory = 12288
 app_dd_ecs_desired_count = 1
 
 opensearch_instance_type = "m6g.large.search"

--- a/deployment/environments/terraform-production.tfvars
+++ b/deployment/environments/terraform-production.tfvars
@@ -51,7 +51,7 @@ dedupe_hub_name = "deduplicate"
 dedupe_hub_version = 1
 app_cc_ecs_desired_count = 0
 app_dd_fargate_cpu = 4096
-app_dd_fargate_memory = 8192
+app_dd_fargate_memory = 12288
 app_dd_ecs_desired_count = 1
 django_log_level="DEBUG"
 

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -24,7 +24,7 @@ to modify moderation event `status`.
 * [OSDEV-1347](https://opensupplyhub.atlassian.net/browse/OSDEV-1347) - Create GET request for `v1/moderation-events/{moderation_id}` endpoint.
 
 ### Architecture/Environment changes
-* *Describe architecture/environment changes here.*
+* Increased memory for the Dedupe Hub instance from 8GB to 12GB in `production` & `pre-prod` environments.
 
 ### Bugfix
 * *Describe bugfix here.*

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -24,7 +24,7 @@ to modify moderation event `status`.
 * [OSDEV-1347](https://opensupplyhub.atlassian.net/browse/OSDEV-1347) - Create GET request for `v1/moderation-events/{moderation_id}` endpoint.
 
 ### Architecture/Environment changes
-* Increased memory for the Dedupe Hub instance from 8GB to 12GB in `production` & `pre-prod` environments.
+* Increased the memory for the Dedupe Hub instance from 8GB to 12GB in the `production` and `pre-prod` environments to reduce the risk of container overload and minimize the need for reindexing in the future.
 
 ### Bugfix
 * *Describe bugfix here.*


### PR DESCRIPTION
- Increased memory for the Dedupe Hub instance from 8GB to 12GB in `production` & `pre-prod` environments.