### PR TITLE
[OSDEV-1467] Releases. Block API create facility endpoint if "disable_list_uploading" switch is enabled in Admin panel

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -50,12 +50,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Code/API changes
 * [OSDEV-1346](https://opensupplyhub.atlassian.net/browse/OSDEV-1346) - Create GET request for `v1/moderation-events` endpoint.
 * [OSDEV-1429](https://opensupplyhub.atlassian.net/browse/OSDEV-1429) - The list upload switcher has been created to disable the `Submit` button on the List Contribute page through the Switch page in the Django admin panel during the release process. Implemented a check on the list upload endpoint.
-* [OSDEV-1467](https://opensupplyhub.atlassian.net/browse/OSDEV-1467) - Implemented disabling endpoint `POST /api/facilities/?public=true&create=true` during the release process . It is raising error message with status code 503.
 * [OSDEV-1332](https://opensupplyhub.atlassian.net/browse/OSDEV-1332) - Introduced new `PATCH api/v1/moderation-events/{moderation_id}` endpoint
 to modify moderation event `status`.
 * [OSDEV-1347](https://opensupplyhub.atlassian.net/browse/OSDEV-1347) - Create GET request for `v1/moderation-events/{moderation_id}` endpoint.
 * Update `/v1/production-locations/{os_id}` endpoint to return a single object instead of multiple objects. Also, add unit tests for the `ProductionLocationsViewSet`.
 * The RDS instance has been upgraded as follows: for `production` and `preprod`, it is now `db.m6in.8xlarge`, and for `test`, it has been upgraded to `db.t3.xlarge`.
+* [OSDEV-1467](https://opensupplyhub.atlassian.net/browse/OSDEV-1467) - Implemented disabling endpoint `POST /api/facilities/` during the release process. It is raising an error message with status code 503.
 
 ### Architecture/Environment changes
 * Increased the memory for the Dedupe Hub instance from 8GB to 12GB in the `production` and `pre-prod` environments to reduce the risk of container overload and minimize the need for reindexing in the future.

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -50,6 +50,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Code/API changes
 * [OSDEV-1346](https://opensupplyhub.atlassian.net/browse/OSDEV-1346) - Create GET request for `v1/moderation-events` endpoint.
 * [OSDEV-1429](https://opensupplyhub.atlassian.net/browse/OSDEV-1429) - The list upload switcher has been created to disable the `Submit` button on the List Contribute page through the Switch page in the Django admin panel during the release process. Implemented a check on the list upload endpoint.
+* [OSDEV-1467](https://opensupplyhub.atlassian.net/browse/OSDEV-1467) - Implemented disabling endpoint `POST /api/facilities/?public=true&create=true` during the release process . It is raising error message with status code 503.
 * [OSDEV-1332](https://opensupplyhub.atlassian.net/browse/OSDEV-1332) - Introduced new `PATCH api/v1/moderation-events/{moderation_id}` endpoint
 to modify moderation event `status`.
 * [OSDEV-1347](https://opensupplyhub.atlassian.net/browse/OSDEV-1347) - Create GET request for `v1/moderation-events/{moderation_id}` endpoint.

--- a/src/django/api/views/facility/facilities_view_set.py
+++ b/src/django/api/views/facility/facilities_view_set.py
@@ -11,6 +11,7 @@ from contricleaner.lib.contri_cleaner import ContriCleaner
 from contricleaner.lib.exceptions.handler_not_set_error \
     import HandlerNotSetError
 
+from api.exceptions import ServiceUnavailableException
 from api.helpers.helpers import validate_workers_count
 from oar.settings import (
     MAX_ATTACHMENT_SIZE_IN_BYTES,
@@ -576,6 +577,11 @@ class FacilitiesViewSet(ListModelMixin,
         """  # noqa
         # Adding the @permission_classes decorator was not working so we
         # explicitly invoke our custom permission class.
+        if switch_is_active('disable_list_uploading'):
+            block_message = ('Open Supply Hub is undergoing maintenance and '
+                             'not accepting new data at the moment. Please '
+                             'try again in a few minutes.')
+            raise ServiceUnavailableException(block_message)
         if not IsRegisteredAndConfirmed().has_permission(request, self):
             return Response(status=status.HTTP_401_UNAUTHORIZED)
         if not flag_is_active(request._request,


### PR DESCRIPTION
[OSDEV-1467](https://opensupplyhub.atlassian.net/browse/OSDEV-1467) Implemented disabling endpoint `POST /api/facilities/` during the release process. It is raising an error message with status code 503.

<img width="400" alt="Screenshot 2024-11-26 at 14 38 20" src="https://github.com/user-attachments/assets/363e2bfe-40ec-417e-bd7e-f0be9f9ca2ff">

<img width="400" alt="Screenshot 2024-11-26 at 14 38 33" src="https://github.com/user-attachments/assets/ec62655d-b91c-49e6-8d70-8f4002d2f080">


[OSDEV-1467]: https://opensupplyhub.atlassian.net/browse/OSDEV-1467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ