### PR TITLE
[OSDEV-1346] - Refactor index mapping and sorting for name and address of moderation event

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Code/API changes
 * [OSDEV-1453](https://opensupplyhub.atlassian.net/browse/OSDEV-1453) - The `detail` keyword instead of `message` has been applied in error response objects for V1 endpoints.
-* [OSDEV-1346](https://opensupplyhub.atlassian.net/browse/OSDEV-1346) - Disabled null values from the response of the OpenSearch. Disabled possible null `os_id`, `claim_id` and `source` from `PATCH api/v1/moderation-events/{moderation_id}` response. Updated index mapping for `cleaned_data.name` and `cleaned_data.address` for `GET api/v1/moderation-events`.
+* [OSDEV-1346](https://opensupplyhub.atlassian.net/browse/OSDEV-1346) - Disabled null values from the response of the OpenSearch. Disabled possible null `os_id`, `claim_id` and `source` from `PATCH api/v1/moderation-events/{moderation_id}` response. Updated index mapping for `cleaned_data.name` and `cleaned_data.address` for `GET api/v1/moderation-events`. This change fixes the OpenSearch error while sorting by `cleaned_data.name` and `cleaned_data.address`: `Text fields are not optimised for operations that require per-document field data like aggregations and sorting, so these operations are disabled by default. Please use a keyword field instead.`.
 * [OSDEV-1410](https://opensupplyhub.atlassian.net/browse/OSDEV-1410) - Introduced new POST `/api/moderation-events/{moderation_id}/production-locations` endpoint
 * [OSDEV-1449](https://opensupplyhub.atlassian.net/browse/OSDEV-1449) - **Breaking changes** to the following endpoints:
   - GET `v1/moderation-events`

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Code/API changes
 * [OSDEV-1453](https://opensupplyhub.atlassian.net/browse/OSDEV-1453) - The `detail` keyword instead of `message` has been applied in error response objects for V1 endpoints.
-* [OSDEV-1346](https://opensupplyhub.atlassian.net/browse/OSDEV-1346) - Disabled null values from the response of the OpenSearch. Disabled possible null `os_id`, `claim_id` and `source` from `PATCH api/v1/moderation-events/{moderation_id}` response.
+* [OSDEV-1346](https://opensupplyhub.atlassian.net/browse/OSDEV-1346) - Disabled null values from the response of the OpenSearch. Disabled possible null `os_id`, `claim_id` and `source` from `PATCH api/v1/moderation-events/{moderation_id}` response. Updated index mapping for `cleaned_data.name` and `cleaned_data.address` for `GET api/v1/moderation-events`.
 * [OSDEV-1410](https://opensupplyhub.atlassian.net/browse/OSDEV-1410) - Introduced new POST `/api/moderation-events/{moderation_id}/production-locations` endpoint
 * [OSDEV-1449](https://opensupplyhub.atlassian.net/browse/OSDEV-1449) - **Breaking changes** to the following endpoints:
   - GET `v1/moderation-events`

--- a/src/django/api/views/v1/opensearch_query_builder/moderation_events_query_builder.py
+++ b/src/django/api/views/v1/opensearch_query_builder/moderation_events_query_builder.py
@@ -48,14 +48,12 @@ class ModerationEventsQueryBuilder(OpenSearchQueryBuilder):
             or field == V1_PARAMETERS_LIST.ADDRESS
         ):
             self.query_body['sort'].append({
-                'cleaned_data.' + field: {'order': order_by}
+                f'cleaned_data.{field}.keyword': {'order': order_by}
             })
         elif field == V1_PARAMETERS_LIST.COUNTRY:
             self.query_body['sort'].append(
                 {
-                    'cleaned_data.' +
-                    field +
-                    '.alpha_2': {'order': order_by}
+                    f'cleaned_data.{field}.alpha_2': {'order': order_by}
                 }
             )
         else:

--- a/src/logstash/indexes/moderation_events.json
+++ b/src/logstash/indexes/moderation_events.json
@@ -45,10 +45,20 @@
         "cleaned_data": {
           "properties": {
             "name": {
-              "type": "keyword"
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword"
+                }
+              }
             },
             "address": {
-              "type": "keyword"
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword"
+                }
+              }
             },
             "country": {
               "properties": {


### PR DESCRIPTION
Follow-up PR for [OSDEV-1346](https://opensupplyhub.atlassian.net/browse/OSDEV-1346)
Refactor index mapping and sorting for `cleaned_data.name` and `cleaned_data.address` of moderation event to prevent error:

```
'search_phase_execution_exception', 'Text fields are not optimised for operations that require per-document field data like aggregations and sorting, so these operations are disabled by default. Please use a keyword field instead.
```

[OSDEV-1346]: https://opensupplyhub.atlassian.net/browse/OSDEV-1346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ