### PR TITLE
Limit page number for api/facilities GET endpoint

### DIFF
--- a/src/django/api/views/facility/facilities_view_set.py
+++ b/src/django/api/views/facility/facilities_view_set.py
@@ -1727,4 +1727,3 @@ class FacilitiesViewSet(ListModelMixin,
 
         except Facility.DoesNotExist as exc:
             raise NotFound() from exc
-        

--- a/src/django/api/views/facility/facilities_view_set.py
+++ b/src/django/api/views/facility/facilities_view_set.py
@@ -226,6 +226,15 @@ class FacilitiesViewSet(ListModelMixin,
         if not params.is_valid():
             raise ValidationError(params.errors)
 
+        if ('page' in request.query_params
+                and int(request.query_params['page']) > 100):
+            return Response(
+                data={
+                    "detail": "API limit exceeded.",
+                },
+                status=status.HTTP_429_TOO_MANY_REQUESTS,
+            )
+
         queryset = (
                 FacilityIndex
                 .objects
@@ -1718,3 +1727,4 @@ class FacilitiesViewSet(ListModelMixin,
 
         except Facility.DoesNotExist as exc:
             raise NotFound() from exc
+        


### PR DESCRIPTION
Limit the page number to 100 for the API/facilities GET endpoint.