### PR TITLE
[OSDEV-1410] Fix processing of geocode results for POST /api/moderation-events/{moderation_id}/production-locations endpoint

### DIFF
--- a/src/django/api/moderation_event_actions/approval/add_production_location.py
+++ b/src/django/api/moderation_event_actions/approval/add_production_location.py
@@ -161,7 +161,8 @@ class AddProductionLocation(EventApprovalStrategy):
         item: FacilityListItem, geocode_result: Dict
     ) -> None:
         item.geocoded_point = Point(
-            geocode_result["longitude"], geocode_result["latitude"]
+            geocode_result["geocoded_point"]["lng"],
+            geocode_result["geocoded_point"]["lat"],
         )
         item.geocoded_address = geocode_result["geocoded_address"]
         item.processing_results.append(

--- a/src/django/api/tests/test_moderation_events_add_production_location.py
+++ b/src/django/api/tests/test_moderation_events_add_production_location.py
@@ -69,8 +69,10 @@ class ModerationEventsAddProductionLocationTest(APITestCase):
                 "errors": [],
             },
             geocode_result={
-                "latitude": self.latitude,
-                "longitude": self.longitude,
+                "geocoded_point": {
+                    "lat": self.latitude,
+                    "lng": self.longitude,
+                },
                 "geocoded_address": "Geocoded Address",
                 "full_response": {
                     "status": "OK",


### PR DESCRIPTION
[OSDEV-1410](https://opensupplyhub.atlassian.net/browse/OSDEV-1410) - Moderation. Implement POST /api/moderation-events/{moderation_id}/production-locations endpoint.

In this PR, a fix was added for the processing of geocode results during the creation of a new production location based on the moderation event.

[OSDEV-1410]: https://opensupplyhub.atlassian.net/browse/OSDEV-1410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ