### PR TITLE
[OSDEV-1482] GET api/v1/moderation-events/{moderation_id} should return single response instead of array

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -49,7 +49,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Bugfix
 * [OSDEV-1388](https://opensupplyhub.atlassian.net/browse/OSDEV-1388) - The waiter from boto3 cannot wait more than half an hour so we replaced it with our own.
-* [OSDEV-1482](https://opensupplyhub.atlassian.net/browse/OSDEV-1482) - The `GET api/v1/moderation-events/{moderation_id}` endpoint return single response instead of array with one item.
+* [OSDEV-1482](https://opensupplyhub.atlassian.net/browse/OSDEV-1482) - The `GET api/v1/moderation-events/{moderation_id}` endpoint returns a single response instead of an array containing one item.
 
 ### What's new
 * [OSDEV-1175](https://opensupplyhub.atlassian.net/browse/OSDEV-1175) - New Moderation Queue Page was integrated with `GET api/v1/moderation-events/` endpoint that include pagination, sorting and filtering.

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -49,6 +49,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Bugfix
 * [OSDEV-1388](https://opensupplyhub.atlassian.net/browse/OSDEV-1388) - The waiter from boto3 cannot wait more than half an hour so we replaced it with our own.
+* [OSDEV-1482](https://opensupplyhub.atlassian.net/browse/OSDEV-1482) - The `GET api/v1/moderation-events/{moderation_id}` endpoint return single response instead of array with one item.
 
 ### What's new
 * [OSDEV-1175](https://opensupplyhub.atlassian.net/browse/OSDEV-1175) - New Moderation Queue Page was integrated with `GET api/v1/moderation-events/` endpoint that include pagination, sorting and filtering.

--- a/src/django/api/views/v1/moderation_events.py
+++ b/src/django/api/views/v1/moderation_events.py
@@ -88,7 +88,8 @@ class ModerationEvents(ViewSet):
         if len(events) == 0:
             return Response(
                 data={
-                    "detail": "The moderation event with the given uuid was not found.",
+                    "detail": 'The moderation event with the '
+                    'given uuid was not found.',
                 },
                 status=status.HTTP_404_NOT_FOUND,
             )

--- a/src/django/api/views/v1/moderation_events.py
+++ b/src/django/api/views/v1/moderation_events.py
@@ -83,7 +83,17 @@ class ModerationEvents(ViewSet):
             query_body
         )
 
-        return Response(response)
+        events = response.get("data", [])
+
+        if len(events) == 0:
+            return Response(
+                data={
+                    "detail": "The moderation event with the given uuid was not found.",
+                },
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        return Response(events[0])
 
     @handle_errors_decorator
     def partial_update(self, request, pk=None):

--- a/src/tests/v1/test_moderation_events.py
+++ b/src/tests/v1/test_moderation_events.py
@@ -12,8 +12,7 @@ class ModerationEventsTest(BaseAPITest):
                 headers=self.basic_headers,
             )
 
-        result = response.json()
-        self.assertEqual(result['count'], 0)
+        self.assertEqual(response.status_code, 404)
 
         moderation_id = '1f35a90f-70a0-4c3e-8e06-2ed8e1fc6800'
         response = requests.get(
@@ -22,8 +21,7 @@ class ModerationEventsTest(BaseAPITest):
             )
 
         result = response.json()
-        self.assertEqual(result['count'], 1)
-        self.assertEqual(result['data'][0]['moderation_id'], moderation_id)
+        self.assertEqual(result['moderation_id'], moderation_id)
 
     def test_moderation_events_status(self):
         response = requests.get(


### PR DESCRIPTION
[OSDEV-1482](https://opensupplyhub.atlassian.net/browse/OSDEV-1482) GET api/v1/moderation-events/{moderation_id} should return single response instead of array

- Updated response format and added handling for 404

[OSDEV-1482]: https://opensupplyhub.atlassian.net/browse/OSDEV-1482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ