### PR TITLE
Increased RDS storage space in Production, Test, and Pre-prod environments.

### DIFF
--- a/deployment/environments/terraform-preprod.tfvars
+++ b/deployment/environments/terraform-preprod.tfvars
@@ -13,7 +13,7 @@ cloudfront_price_class = "PriceClass_All"
 bastion_ami = "ami-0bb3fad3c0286ebd5"
 bastion_instance_type = "t3.nano"
 
-rds_allocated_storage = "128"
+rds_allocated_storage = "256"
 rds_engine_version = "12"
 rds_parameter_group_family = "postgres12"
 rds_instance_type = "db.m6in.8xlarge"

--- a/deployment/environments/terraform-production.tfvars
+++ b/deployment/environments/terraform-production.tfvars
@@ -12,7 +12,7 @@ cloudfront_price_class = "PriceClass_All"
 bastion_ami = "ami-0bb3fad3c0286ebd5"
 bastion_instance_type = "t3.nano"
 
-rds_allocated_storage = "128"
+rds_allocated_storage = "256"
 rds_engine_version = "12"
 rds_parameter_group_family = "postgres12"
 rds_instance_type = "db.m6in.8xlarge"

--- a/deployment/environments/terraform-test.tfvars
+++ b/deployment/environments/terraform-test.tfvars
@@ -13,7 +13,7 @@ cloudfront_price_class = "PriceClass_All"
 bastion_ami = "ami-0bb3fad3c0286ebd5"
 bastion_instance_type = "t3.nano"
 
-rds_allocated_storage = "128"
+rds_allocated_storage = "256"
 rds_engine_version = "12"
 rds_parameter_group_family = "postgres12"
 rds_instance_type = "db.t3.xlarge"

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -46,6 +46,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Architecture/Environment changes
 * [OSDEV-1170](https://opensupplyhub.atlassian.net/browse/OSDEV-1170) - Added the ability to automatically create a dump from the latest shared snapshot of the anonymized database from Production environment for use in the Test and Pre-Prod environments.
+* In light of recent instances(on 12/03/2024 UTC and 12/04/2024 UTC) where the current RDS disk storage space limit was reached in Production, the RDS storage size has been increased to `256 GB` in the Production, Test, and Pre-prod environments to accommodate the processing of larger volumes of data. The configurations for the Test and Pre-prod environments have also been updated to maintain parity with the Production environment.
 
 ### Bugfix
 * [OSDEV-1388](https://opensupplyhub.atlassian.net/browse/OSDEV-1388) - The waiter from boto3 cannot wait more than half an hour so we replaced it with our own.


### PR DESCRIPTION
In light of recent instances(on 12/03/2024 UTC and 12/04/2024 UTC) where the current RDS disk storage space limit was reached in Production, the RDS storage size has been increased to `256 GB` in the Production, Test, and Pre-prod environments to accommodate the processing of larger volumes of data. The configurations for the Test and Pre-prod environments have also been updated to maintain parity with the Production environment.