### PR TITLE
[OSDEV-1493] Moderation. Moderation Queue Page (integration) - sorting issue and 500 error for localization

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -3,6 +3,31 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). The format is based on the `RELEASE-NOTES-TEMPLATE.md` file.
 
+## Release 1.27.0
+
+## Introduction
+* Product name: Open Supply Hub
+* Release date: December 28, 2024
+
+### Database changes
+#### Migrations:
+
+#### Scheme changes
+
+### Code/API changes
+
+### Architecture/Environment changes
+
+### Bugfix
+* [OSDEV-1493](https://opensupplyhub.atlassian.net/browse/OSDEV-1493) - Fixed an issue where the backend sorts countries not by `name` but by their `alpha-2 codes` in `GET /api/v1/moderation-events/` endpoint.
+
+### What's new
+
+### Release instructions:
+* Ensure that the following commands are included in the `post_deployment` command:
+    * `migrate`
+    * `reindex_database`
+
 
 ## Release 1.26.0
 

--- a/src/django/api/tests/test_moderation_events_query_builder.py
+++ b/src/django/api/tests/test_moderation_events_query_builder.py
@@ -87,6 +87,11 @@ class TestModerationEventsQueryBuilder(TestCase):
         self.builder.add_sort('created_at', 'asc')
         expected = {'created_at': {'order': 'asc'}}
         self.assertIn(expected, self.builder.query_body['sort'])
+    
+    def test_add_sort_country(self):
+        self.builder.add_sort('country', 'asc')
+        expected = {'cleaned_data.country.name': {'order': 'asc'}}
+        self.assertIn(expected, self.builder.query_body['sort'])
 
     def test_add_search_after(self):
         search_after_value = '2023-11-21T10:00:00'

--- a/src/django/api/tests/test_moderation_events_query_builder.py
+++ b/src/django/api/tests/test_moderation_events_query_builder.py
@@ -87,7 +87,7 @@ class TestModerationEventsQueryBuilder(TestCase):
         self.builder.add_sort('created_at', 'asc')
         expected = {'created_at': {'order': 'asc'}}
         self.assertIn(expected, self.builder.query_body['sort'])
-    
+
     def test_add_sort_country(self):
         self.builder.add_sort('country', 'asc')
         expected = {'cleaned_data.country.name': {'order': 'asc'}}

--- a/src/django/api/views/v1/opensearch_query_builder/moderation_events_query_builder.py
+++ b/src/django/api/views/v1/opensearch_query_builder/moderation_events_query_builder.py
@@ -55,7 +55,7 @@ class ModerationEventsQueryBuilder(OpenSearchQueryBuilder):
                 {
                     'cleaned_data.' +
                     field +
-                    '.alpha_2': {'order': order_by}
+                    '.name': {'order': order_by}
                 }
             )
         else:


### PR DESCRIPTION
[OSDEV-1493](https://opensupplyhub.atlassian.net/browse/OSDEV-1493) Moderation. Moderation Queue Page (integration) - sorting issue and 500 error for localization
- Fixed an issue where the backend sorts countries not by `name` but by their `alpha-2 codes` in `GET /api/v1/moderation-events/` endpoint.

[OSDEV-1493]: https://opensupplyhub.atlassian.net/browse/OSDEV-1493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ