### PR TITLE
[OSDEV-1336] SLC. Implement PATCH api/v1/production-locations/{os_id}/

### DIFF
--- a/deployment/clear_opensearch/clear_opensearch.sh.tpl
+++ b/deployment/clear_opensearch/clear_opensearch.sh.tpl
@@ -12,15 +12,12 @@
 # This can help speed up the deployment process of new changes.
 
 echo -e "\nDelete the custom OpenSearch indexes\n"
-curl -X DELETE https://$OPENSEARCH_DOMAIN/production-locations --aws-sigv4 "aws:amz:eu-west-1:es" --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY"
 curl -X DELETE https://$OPENSEARCH_DOMAIN/moderation-events --aws-sigv4 "aws:amz:eu-west-1:es" --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY"
 
 echo -e "\nDelete the custom OpenSearch templates\n"
-curl -X DELETE https://$OPENSEARCH_DOMAIN/_index_template/production_locations_template --aws-sigv4 "aws:amz:eu-west-1:es" --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY"
 curl -X DELETE https://$OPENSEARCH_DOMAIN/_index_template/moderation_events_template --aws-sigv4 "aws:amz:eu-west-1:es" --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY"
 
 echo -e "\nRemove the JDBC input lock files from the EFS storage connected to Logstash\n"
 sudo mount -t efs -o tls,accesspoint=$EFS_AP_ID $EFS_ID:/ /mnt
-sudo rm /mnt/production_locations_jdbc_last_run
 sudo rm /mnt/moderation_events_jdbc_last_run
 sudo umount /mnt

--- a/deployment/clear_opensearch/clear_opensearch.sh.tpl
+++ b/deployment/clear_opensearch/clear_opensearch.sh.tpl
@@ -5,19 +5,17 @@
 # new index mappings or to refresh the OpenSearch cluster after
 # restarting Logstash, with the lock files deleted from EFS
 # storage for each pipeline.
-#
-# The script can be modified to delete only specific templates,
-# indexes, and Logstash pipeline lock files, allowing for a more
-# targeted refresh without affecting the entire OpenSearch cluster.
-# This can help speed up the deployment process of new changes.
 
 echo -e "\nDelete the custom OpenSearch indexes\n"
+curl -X DELETE https://$OPENSEARCH_DOMAIN/production-locations --aws-sigv4 "aws:amz:eu-west-1:es" --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY"
 curl -X DELETE https://$OPENSEARCH_DOMAIN/moderation-events --aws-sigv4 "aws:amz:eu-west-1:es" --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY"
 
 echo -e "\nDelete the custom OpenSearch templates\n"
+curl -X DELETE https://$OPENSEARCH_DOMAIN/_index_template/production_locations_template --aws-sigv4 "aws:amz:eu-west-1:es" --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY"
 curl -X DELETE https://$OPENSEARCH_DOMAIN/_index_template/moderation_events_template --aws-sigv4 "aws:amz:eu-west-1:es" --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY"
 
 echo -e "\nRemove the JDBC input lock files from the EFS storage connected to Logstash\n"
 sudo mount -t efs -o tls,accesspoint=$EFS_AP_ID $EFS_ID:/ /mnt
+sudo rm /mnt/production_locations_jdbc_last_run
 sudo rm /mnt/moderation_events_jdbc_last_run
 sudo umount /mnt

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -16,7 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Code/API changes
 * [OSDEV-1336](https://opensupplyhub.atlassian.net/browse/OSDEV-1336) - Introduced a new PATCH `/api/v1/production-locations/{os_id}/` endpoint based on the API v1 specification. This endpoint allows the creation of a new moderation event for updating the production location with the given details. Basically, the endpoint can be used to contribute to an existing location.
-* [OSDEV-1336](https://opensupplyhub.atlassian.net/browse/OSDEV-1336) - Dynamic mapping for the new fields in the `moderation-events` index has been disabled for those that don't have an explicit mapping defined. This change helps avoid indexing conflicts, such as when a field is initially indexed with one data type (e.g., long), but later an entry with a different data type for the same field is indexed, causing the entire entry to fail indexing. After this change, fields with an explicit mapping will be indexed, while other fields will not be indexed or searchable, but will still be displayed in the document. The `clear_opensearch.sh.tpl` script has been edited to clear only resources related to the `moderation-events` index, so there will be no need to wait for the production-locations index to be refilled during deployment, as it will not be deleted.
+* [OSDEV-1336](https://opensupplyhub.atlassian.net/browse/OSDEV-1336) - Dynamic mapping for the new fields in the `moderation-events` index has been disabled for those that don't have an explicit mapping defined. This change helps avoid indexing conflicts, such as when a field is initially indexed with one data type (e.g., long), but later an entry with a different data type for the same field is indexed, causing the entire entry to fail indexing. After this change, fields with an explicit mapping will be indexed, while other fields will not be indexed or searchable, but will still be displayed in the document.
 
 ### Architecture/Environment changes
 
@@ -33,7 +33,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * Ensure that the following commands are included in the `post_deployment` command:
     * `migrate`
     * `reindex_database`
-* Run `[Release] Deploy` pipeline for the target environment with the flag `Clear the custom OpenSearch indexes and templates` set to true - to refresh the index mappings for the `moderation-events` index after disabling dynamic mapping for the new fields that don't have an explicit mapping defined. Note that the `clear_opensearch.sh.tpl` script has been edited to clear only resources related to the `moderation-events` index, so there will be no need to wait for the `production-locations` index to be refilled, as it will not be deleted.
+* Run `[Release] Deploy` pipeline for the target environment with the flag `Clear the custom OpenSearch indexes and templates` set to true - to refresh the index mappings for the `moderation-events` index after disabling dynamic mapping for the new fields that don't have an explicit mapping defined.
 
 
 ## Release 1.26.0

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -33,7 +33,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * Ensure that the following commands are included in the `post_deployment` command:
     * `migrate`
     * `reindex_database`
-* Run `[Release] Deploy` pipeline for the target environment with the flag `Clear the custom OpenSearch indexes and templates` set to true - to refresh the index mappings for the `moderation-events` index after disabling dynamic mapping for the new fields that don't have an explicit mapping defined.
+* Run `[Release] Deploy` pipeline for the target environment with the flag `Clear the custom OpenSearch indexes and templates` set to true - to refresh the index mappings for the `moderation-events` index after disabling dynamic mapping for the new fields that don't have an explicit mapping defined. The `production-locations` will also be affected since it will clean all of our custom indexes and templates within the OpenSearch cluster
 
 
 ## Release 1.26.0
@@ -111,7 +111,7 @@ This issue has been fixed by adding additional requests to delete the appropriat
 * Ensure that the following commands are included in the `post_deployment` command:
     * `migrate`
     * `reindex_database`
-* Run `[Release] Deploy` pipeline for the target environment with the flag `Clear the custom OpenSearch indexes and templates` set to true - to refresh the index mappings for the `production-locations` and `moderation-events` indexes after fixing the process of clearing the custom OpenSearch indexes.
+* Run `[Release] Deploy` pipeline for the target environment with the flag `Clear the custom OpenSearch indexes and templates` set to true - to refresh the index mappings for the `production-locations` and `moderation-events` indexes after fixing the process of clearing the custom OpenSearch indexes. It will clean all of our custom indexes and templates within the OpenSearch cluster.
 
 
 ## Release 1.25.0

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 #### Scheme changes
 
 ### Code/API changes
+* [OSDEV-1336](https://opensupplyhub.atlassian.net/browse/OSDEV-1336) - Introduced a new PATCH `/api/v1/production-locations/{os_id}/` endpoint based on the API v1 specification. This endpoint allows the creation of a new moderation event for updating the production location with the given details. Basically, the endpoint can be used to contribute to an existing location.
+* [OSDEV-1336](https://opensupplyhub.atlassian.net/browse/OSDEV-1336) - Dynamic mapping for the new fields in the `moderation-events` index has been disabled for those that don't have an explicit mapping defined. This change helps avoid indexing conflicts, such as when a field is initially indexed with one data type (e.g., long), but later an entry with a different data type for the same field is indexed, causing the entire entry to fail indexing. After this change, fields with an explicit mapping will be indexed, while other fields will not be indexed or searchable, but will still be displayed in the document. The `clear_opensearch.sh.tpl` script has been edited to clear only resources related to the `moderation-events` index, so there will be no need to wait for the production-locations index to be refilled during deployment, as it will not be deleted.
 
 ### Architecture/Environment changes
 
@@ -28,6 +30,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * Ensure that the following commands are included in the `post_deployment` command:
     * `migrate`
     * `reindex_database`
+* Run `[Release] Deploy` pipeline for the target environment with the flag `Clear the custom OpenSearch indexes and templates` set to true - to refresh the index mappings for the `moderation-events` index after disabling dynamic mapping for the new fields that don't have an explicit mapping defined. Note that the `clear_opensearch.sh.tpl` script has been edited to clear only resources related to the `moderation-events` index, so there will be no need to wait for the `production-locations` index to be refilled, as it will not be deleted.
 
 
 ## Release 1.26.0
@@ -105,7 +108,7 @@ This issue has been fixed by adding additional requests to delete the appropriat
 * Ensure that the following commands are included in the `post_deployment` command:
     * `migrate`
     * `reindex_database`
-* Run `[Release] Deploy` pipeline for the target environment with the flag `Clear custom OpenSearch indexes and templates` set to true - to refresh the index mappings for the `production-locations` and `moderation-events` indexes after fixing the process of clearing the custom OpenSearch indexes.
+* Run `[Release] Deploy` pipeline for the target environment with the flag `Clear the custom OpenSearch indexes and templates` set to true - to refresh the index mappings for the `production-locations` and `moderation-events` indexes after fixing the process of clearing the custom OpenSearch indexes.
 
 
 ## Release 1.25.0

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -226,7 +226,7 @@ class APIV1LocationContributionErrorMessages:
         'address. This may be due to incorrect, incomplete, or ambiguous '
         'information. Please verify and try again.'
     )
-    LOCATION_NOT_FOUND = ('The location with the given ID was not found.')
+    LOCATION_NOT_FOUND = ('The location with the given id was not found.')
 
     @staticmethod
     def invalid_data_type_error(data_type: str) -> str:

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -226,6 +226,7 @@ class APIV1LocationContributionErrorMessages:
         'address. This may be due to incorrect, incomplete, or ambiguous '
         'information. Please verify and try again.'
     )
+    LOCATION_NOT_FOUND = ('The location with the given ID was not found.')
 
     @staticmethod
     def invalid_data_type_error(data_type: str) -> str:

--- a/src/django/api/moderation_event_actions/creation/dtos/create_moderation_event_dto.py
+++ b/src/django/api/moderation_event_actions/creation/dtos/create_moderation_event_dto.py
@@ -4,13 +4,16 @@ from typing import Dict
 from rest_framework import status
 
 from api.models.moderation_event import ModerationEvent
+from api.models.contributor.contributor import Contributor
+from api.models.facility.facility import Facility
 
 
 @dataclass
 class CreateModerationEventDTO:
-    contributor_id: int
+    contributor: Contributor
     raw_data: Dict
     request_type: str
+    os: Facility = None
     cleaned_data: Dict = field(default_factory=dict)
     source: str = ''
     geocode_result: Dict = field(default_factory=dict)

--- a/src/django/api/moderation_event_actions/creation/moderation_event_creator.py
+++ b/src/django/api/moderation_event_actions/creation/moderation_event_creator.py
@@ -20,12 +20,13 @@ class ModerationEventCreator:
             return event_dto
 
         event_dto.moderation_event = ModerationEvent.objects.create(
-            contributor=processed_event.contributor_id,
+            contributor=processed_event.contributor,
             request_type=processed_event.request_type,
             raw_data=processed_event.raw_data,
             cleaned_data=processed_event.cleaned_data,
             geocode_result=processed_event.geocode_result,
-            source=processed_event.source
+            source=processed_event.source,
+            os=processed_event.os
         )
 
         return event_dto

--- a/src/django/api/tests/test_location_contribution_strategy.py
+++ b/src/django/api/tests/test_location_contribution_strategy.py
@@ -70,7 +70,7 @@ class TestLocationContributionStrategy(APITestCase):
         self.assertNotIn('source', self.common_valid_input_data)
 
         event_dto = CreateModerationEventDTO(
-            contributor_id=self.contributor,
+            contributor=self.contributor,
             raw_data=self.common_valid_input_data,
             request_type=ModerationEvent.RequestType.CREATE.value
         )
@@ -137,7 +137,7 @@ class TestLocationContributionStrategy(APITestCase):
 
         # Check the length validation.
         event_dto_1 = CreateModerationEventDTO(
-            contributor_id=self.contributor,
+            contributor=self.contributor,
             raw_data=invalid_input_data_1,
             request_type=ModerationEvent.RequestType.CREATE.value
         )
@@ -150,7 +150,7 @@ class TestLocationContributionStrategy(APITestCase):
 
         # Check validation of accepted values.
         event_dto_2 = CreateModerationEventDTO(
-            contributor_id=self.contributor,
+            contributor=self.contributor,
             raw_data=invalid_input_data_2,
             request_type=ModerationEvent.RequestType.CREATE.value
         )
@@ -163,7 +163,7 @@ class TestLocationContributionStrategy(APITestCase):
 
         # Check the accepted data type validation for the source field.
         event_dto_3 = CreateModerationEventDTO(
-            contributor_id=self.contributor,
+            contributor=self.contributor,
             raw_data=invalid_input_data_3,
             request_type=ModerationEvent.RequestType.CREATE.value
         )
@@ -189,7 +189,7 @@ class TestLocationContributionStrategy(APITestCase):
         }
 
         event_dto = CreateModerationEventDTO(
-            contributor_id=self.contributor,
+            contributor=self.contributor,
             raw_data=input_data,
             request_type=ModerationEvent.RequestType.CREATE.value
         )
@@ -256,7 +256,7 @@ class TestLocationContributionStrategy(APITestCase):
         }
 
         event_dto = CreateModerationEventDTO(
-            contributor_id=self.contributor,
+            contributor=self.contributor,
             raw_data=input_data,
             request_type=ModerationEvent.RequestType.CREATE.value
         )
@@ -289,7 +289,7 @@ class TestLocationContributionStrategy(APITestCase):
         }
 
         event_dto = CreateModerationEventDTO(
-            contributor_id=self.contributor,
+            contributor=self.contributor,
             raw_data=input_data,
             request_type=ModerationEvent.RequestType.CREATE.value
         )
@@ -332,7 +332,7 @@ class TestLocationContributionStrategy(APITestCase):
         }
 
         event_dto = CreateModerationEventDTO(
-            contributor_id=self.contributor,
+            contributor=self.contributor,
             raw_data=input_data,
             request_type=ModerationEvent.RequestType.CREATE.value
         )
@@ -368,7 +368,7 @@ class TestLocationContributionStrategy(APITestCase):
         }
 
         event_dto = CreateModerationEventDTO(
-            contributor_id=self.contributor,
+            contributor=self.contributor,
             raw_data=input_data,
             request_type=ModerationEvent.RequestType.CREATE.value
         )
@@ -397,7 +397,7 @@ class TestLocationContributionStrategy(APITestCase):
         }
 
         event_dto = CreateModerationEventDTO(
-            contributor_id=self.contributor,
+            contributor=self.contributor,
             raw_data=input_data,
             request_type=ModerationEvent.RequestType.CREATE.value
         )
@@ -454,7 +454,7 @@ class TestLocationContributionStrategy(APITestCase):
         }
 
         event_dto = CreateModerationEventDTO(
-            contributor_id=self.contributor,
+            contributor=self.contributor,
             raw_data=input_data,
             request_type=ModerationEvent.RequestType.CREATE.value
         )
@@ -629,7 +629,7 @@ class TestLocationContributionStrategy(APITestCase):
         }
 
         event_dto = CreateModerationEventDTO(
-            contributor_id=self.contributor,
+            contributor=self.contributor,
             raw_data=input_data,
             request_type=ModerationEvent.RequestType.CREATE.value
         )

--- a/src/django/api/tests/test_production_locations_partial_update.py
+++ b/src/django/api/tests/test_production_locations_partial_update.py
@@ -40,7 +40,7 @@ class TestProductionLocationsPartialUpdate(APITestCase):
         self.login(user_email, user_password)
 
         # Create a valid Facility entry specifically for this test, to be used
-        # for making PATCH requests for it.
+        # for making PATCH requests for this production location.
         list = FacilityList.objects.create(
             header='header', file_name='one', name='New List Test'
         )

--- a/src/django/api/tests/test_production_locations_partial_update.py
+++ b/src/django/api/tests/test_production_locations_partial_update.py
@@ -1,0 +1,336 @@
+import json
+
+from unittest.mock import Mock, patch
+from rest_framework.test import APITestCase
+from django.urls import reverse
+from allauth.account.models import EmailAddress
+from waffle.testutils import override_switch
+from django.contrib.gis.geos import Point
+
+from api.models.moderation_event import ModerationEvent
+from api.models.contributor.contributor import Contributor
+from api.models.facility.facility_list import FacilityList
+from api.models.facility.facility_list_item import FacilityListItem
+from api.models.source import Source
+from api.models.user import User
+from api.models.facility.facility import Facility
+from api.views.v1.url_names import URLNames
+from api.tests.test_data import geocoding_data
+
+
+class TestProductionLocationsPartialUpdate(APITestCase):
+    def setUp(self):
+        # Create a valid Contributor specifically for this test.
+        user_email = 'test@example.com'
+        user_password = 'example123'
+        self.user = User.objects.create(email=user_email)
+        self.user.set_password(user_password)
+        self.user.save()
+
+        EmailAddress.objects.create(
+            user=self.user, email=user_email, verified=True, primary=True
+        )
+
+        contributor = Contributor.objects.create(
+            admin=self.user,
+            name='test contributor 1',
+            contrib_type=Contributor.OTHER_CONTRIB_TYPE
+        )
+
+        self.login(user_email, user_password)
+
+        # Create a valid Facility entry specifically for this test, to be used
+        # for making PATCH requests for it.
+        list = FacilityList.objects.create(
+            header='header', file_name='one', name='New List Test'
+        )
+        source = Source.objects.create(
+            source_type=Source.LIST,
+            facility_list=list,
+            contributor=contributor
+        )
+        list_item = FacilityListItem.objects.create(
+            name='Gamma Tech Manufacturing Plant',
+            address='1574 Quantum Avenue, Building 4B, Technopolis',
+            country_code='YT',
+            sector=['Apparel'],
+            row_index=1,
+            status=FacilityListItem.CONFIRMED_MATCH,
+            source=source
+        )
+        self.production_location = Facility.objects.create(
+            name=list_item.name,
+            address=list_item.address,
+            country_code=list_item.country_code,
+            location=Point(0, 0),
+            created_from=list_item
+        )
+
+        self.url = reverse(
+            URLNames.PRODUCTION_LOCATIONS + '-detail',
+            args=[self.production_location.id])
+        self.common_valid_req_body = json.dumps({
+            'name': 'Blue Horizon Facility',
+            'address': '990 Spring Garden St., Philadelphia PA 19123',
+            'country': 'US'
+        })
+
+    def login(self, email: str, password: str) -> None:
+        self.client.logout()
+        self.client.login(email=email, password=password)
+
+    def test_only_registered_and_confirmed_has_access(self):
+        expected_response_body = {
+            'detail': (
+                'User must be registered and have confirmed their email to '
+                'access.'
+            )
+        }
+
+        saved_email_address = EmailAddress.objects.get_primary(self.user)
+        # Purposely make the email address unverified to trigger a permission
+        # error.
+        saved_email_address.verified = False
+        saved_email_address.save()
+
+        response = self.client.patch(
+            self.url,
+            self.common_valid_req_body,
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            json.loads(response.content),
+            expected_response_body
+        )
+
+    @patch('api.geocoding.requests.get')
+    def test_default_throttling_is_applied(self, mock_get):
+        mock_get.return_value = Mock(ok=True, status_code=200)
+        mock_get.return_value.json.return_value = geocoding_data
+
+        # Simulate 30 requests.
+        for _ in range(30):
+            response = self.client.patch(
+                self.url,
+                self.common_valid_req_body,
+                content_type='application/json'
+            )
+            self.assertEqual(response.status_code, 202)
+
+            response_body_dict = json.loads(response.content)
+            response_moderation_id = response_body_dict.get('moderation_id')
+            moderation_event = ModerationEvent.objects.get(
+                pk=response_moderation_id
+            )
+            stringified_created_at = moderation_event.created_at.strftime(
+                '%Y-%m-%dT%H:%M:%S.%f'
+            ) + 'Z'
+
+            self.assertEqual(
+                response_body_dict.get('moderation_status'),
+                'PENDING'
+            )
+            self.assertEqual(
+                response_body_dict.get('created_at'),
+                stringified_created_at
+            )
+            self.assertEqual(
+                response_body_dict.get('os_id'),
+                self.production_location.id
+            )
+            self.assertEqual(len(response_body_dict), 4)
+
+        # Now simulate the 31st request, which should be throttled.
+        throttled_response = self.client.patch(
+            self.url,
+            self.common_valid_req_body,
+            content_type='application/json'
+        )
+        throttled_response_body_dict = json.loads(throttled_response.content)
+        self.assertEqual(throttled_response.status_code, 429)
+        self.assertEqual(len(throttled_response_body_dict), 1)
+
+    @override_switch('disable_list_uploading', active=True)
+    def test_client_cannot_patch_when_upload_is_blocked(self):
+        expected_error = (
+            'Open Supply Hub is undergoing maintenance and not accepting new '
+            'data at the moment. Please try again in a few minutes.'
+        )
+
+        response = self.client.patch(
+            self.url,
+            self.common_valid_req_body,
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 503)
+
+        response_body_dict = json.loads(response.content)
+        error = response_body_dict.get('detail')
+        self.assertEqual(error, expected_error)
+        self.assertEqual(len(response_body_dict), 1)
+
+    def test_location_not_found(self):
+        expected_error = 'The location with the given id was not found.'
+        url_with_nonexistent_id = reverse(
+            URLNames.PRODUCTION_LOCATIONS + '-detail',
+            args=['TT11111111111TT']
+        )
+
+        response = self.client.patch(
+            url_with_nonexistent_id,
+            self.common_valid_req_body,
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 404)
+
+        response_body_dict = json.loads(response.content)
+        error = response_body_dict.get('detail')
+        self.assertEqual(error, expected_error)
+        self.assertEqual(len(response_body_dict), 1)
+
+    def test_endpoint_supports_only_dictionary_structure(self):
+        expected_general_error = (
+            'The request body is invalid.'
+        )
+        expected_specific_error = (
+            'Invalid data. Expected a dictionary (object), but got list.'
+        )
+        expected_error_field = 'non_field_errors'
+
+        response = self.client.patch(
+            self.url,
+            [1, 2, 3],
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 400)
+
+        response_body_dict = json.loads(response.content)
+        self.assertEqual(len(response_body_dict), 2)
+
+        general_error = response_body_dict['detail']
+        errors_list_length = len(response_body_dict['errors'])
+        specific_error = response_body_dict['errors'][0]['detail']
+        error_field = response_body_dict['errors'][0]['field']
+        self.assertEqual(general_error, expected_general_error)
+        self.assertEqual(errors_list_length, 1)
+        self.assertEqual(specific_error, expected_specific_error)
+        self.assertEqual(error_field, expected_error_field)
+
+    @patch('api.geocoding.requests.get')
+    def test_moderation_event_created_with_valid_data(
+            self,
+            mock_get):
+        mock_get.return_value = Mock(ok=True, status_code=200)
+        mock_get.return_value.json.return_value = geocoding_data
+
+        valid_req_body = json.dumps({
+            'source': 'SLC',
+            'name': 'Blue Horizon Facility',
+            'address': '990 Spring Garden St., Philadelphia PA 19123',
+            'country': 'US',
+            'location_type': 'Coating',
+            'coordinates': {
+                'lat': 51.078389,
+                'lng': 16.978477
+            }
+        })
+
+        response = self.client.patch(
+            self.url,
+            valid_req_body,
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 202)
+
+        response_body_dict = json.loads(response.content)
+        response_moderation_id = response_body_dict.get('moderation_id')
+        moderation_event = ModerationEvent.objects.get(
+            pk=response_moderation_id
+        )
+        stringified_created_at = moderation_event.created_at.strftime(
+            '%Y-%m-%dT%H:%M:%S.%f'
+        ) + 'Z'
+
+        # Check the response.
+        self.assertEqual(
+            response_body_dict.get('moderation_status'),
+            'PENDING'
+        )
+        self.assertEqual(
+            response_body_dict.get('created_at'),
+            stringified_created_at
+        )
+        self.assertEqual(
+            response_moderation_id,
+            str(moderation_event.uuid)
+        )
+        self.assertEqual(
+            response_body_dict.get('os_id'),
+            self.production_location.id
+        )
+        self.assertEqual(len(response_body_dict), 4)
+
+    @patch('api.geocoding.requests.get')
+    def test_moderation_event_not_created_with_invalid_data(
+            self,
+            mock_get):
+        mock_get.return_value = Mock(ok=True, status_code=200)
+        mock_get.return_value.json.return_value = geocoding_data
+
+        expected_response_body = {
+            'detail': 'The request body is invalid.',
+            'errors': [
+                {
+                    'field': 'sector',
+                    'detail': ('Expected value for sector to be a string or a '
+                               "list of strings but got {'some_key': 1135}.")
+                },
+                {
+                    'field': 'location_type',
+                    'detail': (
+                        'Expected value for location_type to be a '
+                        'string or a list of strings but got '
+                        "{'some_key': 1135}."
+                    )
+                }
+            ]
+        }
+        initial_moderation_event_count = ModerationEvent.objects.count()
+
+        invalid_req_body = json.dumps({
+            'source': 'API',
+            'name': 'Blue Horizon Facility',
+            'address': '990 Spring Garden St., Philadelphia PA 19123',
+            'country': 'US',
+            'sector': {'some_key': 1135},
+            'parent_company': 'string',
+            'product_type': [
+                'string'
+            ],
+            'location_type': {'some_key': 1135},
+            'processing_type': [
+                'string'
+            ],
+            'number_of_workers': {
+                'min': 0,
+                'max': 0
+            },
+            'coordinates': {
+                'lat': 10,
+                'lng': 20
+            }
+        })
+
+        response = self.client.patch(
+            self.url,
+            invalid_req_body,
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 422)
+
+        response_body_dict = json.loads(response.content)
+        self.assertEqual(response_body_dict, expected_response_body)
+        # Ensure that no ModerationEvent record has been created.
+        self.assertEqual(ModerationEvent.objects.count(),
+                         initial_moderation_event_count)

--- a/src/django/api/views/v1/production_locations.py
+++ b/src/django/api/views/v1/production_locations.py
@@ -236,6 +236,7 @@ class ProductionLocations(ViewSet):
 
         return Response(
             {
+                'os_id': result.os.id,
                 'moderation_id': result.moderation_event.uuid,
                 'moderation_status': result.moderation_event.status,
                 'created_at': result.moderation_event.created_at

--- a/src/logstash/indexes/moderation_events.json
+++ b/src/logstash/indexes/moderation_events.json
@@ -8,6 +8,7 @@
       "number_of_replicas": 1
     },
     "mappings": {
+      "dynamic": false,
       "properties": {
         "moderation_id": {
           "type": "keyword"


### PR DESCRIPTION
[[OSDEV-1336](https://opensupplyhub.atlassian.net/browse/OSDEV-1336)]
- Introduced a new PATCH `/api/v1/production-locations/{os_id}/` endpoint based on the API v1 specification. This endpoint allows the creation of a new moderation event for updating the production location with the given details. Basically, the endpoint can be used to contribute to an existing location.
- Dynamic mapping for the new fields in the `moderation-events` index has been disabled for those that don't have an explicit mapping defined. This change helps avoid indexing conflicts, such as when a field is initially indexed with one data type (e.g., long), but later an entry with a different data type for the same field is indexed, causing the entire entry to fail indexing. After this change, fields with an explicit mapping will be indexed, while other fields will not be indexed or searchable, but will still be displayed in the document.

[OSDEV-1336]: https://opensupplyhub.atlassian.net/browse/OSDEV-1336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ