### PR TITLE
Right-sized ECS and RDS resources

### DIFF
--- a/deployment/environments/terraform-development.tfvars
+++ b/deployment/environments/terraform-development.tfvars
@@ -27,8 +27,8 @@ rds_deletion_protection = true
 app_ecs_desired_count = "1"
 app_ecs_deployment_min_percent = "100"
 app_ecs_deployment_max_percent = "400"
-app_fargate_cpu = "1024"
-app_fargate_memory = "8192"
+app_fargate_cpu = "512"
+app_fargate_memory = "1024"
 
 app_dd_fargate_cpu = "2048"
 app_dd_fargate_memory = "4096"

--- a/deployment/environments/terraform-preprod.tfvars
+++ b/deployment/environments/terraform-preprod.tfvars
@@ -16,17 +16,17 @@ bastion_instance_type = "t3.nano"
 rds_allocated_storage = "256"
 rds_engine_version = "12"
 rds_parameter_group_family = "postgres12"
-rds_instance_type = "db.m6in.8xlarge"
+rds_instance_type = "db.m6in.4xlarge"
 rds_database_identifier = "opensupplyhub-enc-pp"
 rds_database_name = "opensupplyhub"
 rds_multi_az = false
 rds_storage_encrypted = true
 
-app_ecs_desired_count = "12"
+app_ecs_desired_count = "10"
 app_ecs_deployment_min_percent = "100"
 app_ecs_deployment_max_percent = "400"
 app_fargate_cpu = "2048"
-app_fargate_memory = "8192"
+app_fargate_memory = "4096"
 
 cli_fargate_cpu = "2048"
 cli_fargate_memory = "8192"

--- a/deployment/environments/terraform-production.tfvars
+++ b/deployment/environments/terraform-production.tfvars
@@ -15,18 +15,18 @@ bastion_instance_type = "t3.nano"
 rds_allocated_storage = "256"
 rds_engine_version = "12"
 rds_parameter_group_family = "postgres12"
-rds_instance_type = "db.m6in.8xlarge"
+rds_instance_type = "db.m6in.4xlarge"
 rds_database_identifier = "opensupplyhub-enc-prd"
 rds_database_name = "opensupplyhub"
 rds_multi_az = false
 rds_storage_encrypted = true
 
-app_ecs_desired_count = "12"
+app_ecs_desired_count = "10"
 app_ecs_deployment_min_percent = "100"
 app_ecs_deployment_max_percent = "400"
 app_ecs_grace_period_seconds = "420"
 app_fargate_cpu = "2048"
-app_fargate_memory = "8192"
+app_fargate_memory = "4096"
 
 cli_fargate_cpu = "2048"
 cli_fargate_memory = "8192"

--- a/deployment/environments/terraform-staging.tfvars
+++ b/deployment/environments/terraform-staging.tfvars
@@ -24,7 +24,7 @@ app_ecs_desired_count = "4"
 app_ecs_deployment_min_percent = "100"
 app_ecs_deployment_max_percent = "400"
 app_fargate_cpu = "1024"
-app_fargate_memory = "8192"
+app_fargate_memory = "2048"
 
 cli_fargate_cpu = "1024"
 cli_fargate_memory = "8192"

--- a/deployment/environments/terraform-test.tfvars
+++ b/deployment/environments/terraform-test.tfvars
@@ -32,7 +32,7 @@ app_ecs_desired_count = "2"
 app_ecs_deployment_min_percent = "100"
 app_ecs_deployment_max_percent = "400"
 app_fargate_cpu = "2048"
-app_fargate_memory = "8192"
+app_fargate_memory = "4096"
 
 app_dd_fargate_cpu = "4096"
 app_dd_fargate_memory = "8192"

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -74,6 +74,20 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Architecture/Environment changes
 * [OSDEV-1170](https://opensupplyhub.atlassian.net/browse/OSDEV-1170) - Added the ability to automatically create a dump from the latest shared snapshot of the anonymized database from Production environment for use in the Test and Pre-Prod environments.
 * In light of recent instances(on 12/03/2024 UTC and 12/04/2024 UTC) where the current RDS disk storage space limit was reached in Production, the RDS storage size has been increased to `256 GB` in the Production, Test, and Pre-prod environments to accommodate the processing of larger volumes of data. The configurations for the Test and Pre-prod environments have also been updated to maintain parity with the Production environment.
+* Right-sized the resources for Django containers across all environments and the RDS instance in the Production and Preprod environments. This will result in a savings of approximately $2,481. The following changes have been made:
+    - Production:
+        - RDS instance type was changed from `db.m6in.8xlarge` to `db.m6in.4xlarge`.
+        - ECS tasks for Django containers: the number was reduced from `12` to `10`, and memory was reduced from `8GB` to `4GB`.
+    - Preprod:
+        - RDS instance type was changed from `db.m6in.8xlarge` to `db.m6in.4xlarge`.
+        - ECS tasks for Django containers: the number was reduced from `12` to `10`, and memory was reduced from `8GB` to `4GB`.
+        - These changes were made to maintain parity with the Production environment, as it is a copy of that environment.
+    - Staging:
+        - ECS tasks for Django containers: memory was reduced from `8GB` to `2GB`.
+    - Test:
+        - ECS tasks for Django containers: memory was reduced from `8GB` to `4GB`.
+    - Development:
+        - ECS tasks for Django containers: memory was reduced from `8GB` to `1GB`, and CPU was reduced from `1 vCPU` to `0.5 vCPU`.
 
 ### Bugfix
 * [OSDEV-1388](https://opensupplyhub.atlassian.net/browse/OSDEV-1388) - The waiter from boto3 cannot wait more than half an hour so we replaced it with our own.


### PR DESCRIPTION
Right-sized the resources for Django containers across all environments and the RDS instance in the Production and Preprod environments. This will result in a savings of approximately $2,481. The following changes have been made:

- Production:
     - RDS instance type was changed from `db.m6in.8xlarge` to `db.m6in.4xlarge`.
     - ECS tasks for Django containers: the number was reduced from `12` to `10`, and memory was reduced from `8GB` to `4GB`.
- Preprod:
   - RDS instance type was changed from `db.m6in.8xlarge` to `db.m6in.4xlarge`.
   - ECS tasks for Django containers: the number was reduced from `12` to `10`, and memory was reduced from `8GB` to `4GB`.
   - These changes were made to maintain parity with the Production environment, as it is a copy of that environment.
- Staging:
   - ECS tasks for Django containers: memory was reduced from `8GB` to `2GB`.
- Test:
   - ECS tasks for Django containers: memory was reduced from `8GB` to `4GB`.
- Development:
   - ECS tasks for Django containers: memory was reduced from `8GB` to `1GB`, and CPU was reduced from `1 vCPU` to `0.5 vCPU`.