### PR TITLE
[OSDEV-1474] Add contributor type to /api/contributors/ endpoint

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-1493](https://opensupplyhub.atlassian.net/browse/OSDEV-1493) - Fixed an issue where the backend sorts countries not by `name` but by their `alpha-2 codes` in `GET /api/v1/moderation-events/` endpoint.
 
 ### What's new
+* [OSDEV-1474](https://opensupplyhub.atlassian.net/browse/OSDEV-1474) - Added contributor type value to response of `/api/contributors/` endpoint.
 
 ### Release instructions:
 * Ensure that the following commands are included in the `post_deployment` command:

--- a/src/django/api/tests/test_contributors_list_api_endpoint.py
+++ b/src/django/api/tests/test_contributors_list_api_endpoint.py
@@ -37,6 +37,14 @@ class ContributorsListAPIEndpointTest(TestCase):
         self.contrib_six_name = "contributor with one good and one error item"
         self.contrib_seven_name = "contributor with create=False API source"
 
+        self.contrib_one_type = "Brand / Retailer"
+        self.contrib_two_type = "Multi-Stakeholder Initiative"
+        self.contrib_three_type = "Union"
+        self.contrib_four_type = "Brand / Retailer"
+        self.contrib_five_type = "Multi-Stakeholder Initiative"
+        self.contrib_six_type = "Test"
+        self.contrib_seven_type = "Union"
+
         self.country_code = "US"
         self.list_one_name = "one"
         self.list_one_b_name = "one-b"
@@ -57,43 +65,44 @@ class ContributorsListAPIEndpointTest(TestCase):
         self.contrib_one = Contributor.objects.create(
             admin=self.user_one,
             name=self.contrib_one_name,
-            contrib_type=Contributor.OTHER_CONTRIB_TYPE,
+            contrib_type=self.contrib_one_type,
         )
 
         self.contrib_two = Contributor.objects.create(
             admin=self.user_two,
             name=self.contrib_two_name,
-            contrib_type=Contributor.OTHER_CONTRIB_TYPE,
+            contrib_type=self.contrib_two_type,
         )
 
         self.contrib_three = Contributor.objects.create(
             admin=self.user_three,
             name=self.contrib_three_name,
-            contrib_type=Contributor.OTHER_CONTRIB_TYPE,
+            contrib_type=self.contrib_three_type,
         )
 
         self.contrib_four = Contributor.objects.create(
             admin=self.user_four,
             name=self.contrib_four_name,
-            contrib_type=Contributor.OTHER_CONTRIB_TYPE,
+            contrib_type=self.contrib_four_type,
         )
 
         self.contrib_five = Contributor.objects.create(
             admin=self.user_five,
             name=self.contrib_five_name,
-            contrib_type=Contributor.OTHER_CONTRIB_TYPE,
+            contrib_type=self.contrib_five_type,
         )
 
         self.contrib_six = Contributor.objects.create(
             admin=self.user_six,
             name=self.contrib_six_name,
             contrib_type=Contributor.OTHER_CONTRIB_TYPE,
+            other_contrib_type=self.contrib_six_type,
         )
 
         self.contrib_seven = Contributor.objects.create(
             admin=self.user_seven,
             name=self.contrib_seven_name,
-            contrib_type=Contributor.OTHER_CONTRIB_TYPE,
+            contrib_type=self.contrib_seven_type,
         )
 
         self.list_one = FacilityList.objects.create(
@@ -216,10 +225,16 @@ class ContributorsListAPIEndpointTest(TestCase):
         response = self.client.get("/api/contributors/")
         response_data = response.json()
         contributor_names = list(zip(*response_data))[1]
+        contributor_types = list(zip(*response_data))[2]
 
         self.assertIn(
             self.contrib_one_name,
             contributor_names,
+        )
+
+        self.assertIn(
+            self.contrib_one_type,
+            contributor_types,
         )
 
         self.assertNotIn(
@@ -245,6 +260,11 @@ class ContributorsListAPIEndpointTest(TestCase):
         self.assertIn(
             self.contrib_six_name,
             contributor_names,
+        )
+
+        self.assertIn(
+            self.contrib_six_type,
+            contributor_types,
         )
 
         self.assertEqual(

--- a/src/django/api/views/contributor/all_contributors.py
+++ b/src/django/api/views/contributor/all_contributors.py
@@ -8,7 +8,8 @@ from .active_contributors import active_contributors
 @throttle_classes([])
 def all_contributors(_):
     """
-    Returns list contributors as a list of tuples of contributor IDs, names and types.
+    Returns list contributors as a list of tuples of 
+    contributor IDs, names and types.
 
     ## Sample Response
 
@@ -21,8 +22,8 @@ def all_contributors(_):
         (
             contributor.id,
             contributor.name,
-            contributor.other_contrib_type 
-            if contributor.contrib_type == "Other" 
+            contributor.other_contrib_type
+            if contributor.contrib_type == "Other"
             else contributor.contrib_type
         )
         for contributor in active_contributors().order_by('name')

--- a/src/django/api/views/contributor/all_contributors.py
+++ b/src/django/api/views/contributor/all_contributors.py
@@ -8,7 +8,7 @@ from .active_contributors import active_contributors
 @throttle_classes([])
 def all_contributors(_):
     """
-    Returns list contributors as a list of tuples of 
+    Returns list contributors as a list of tuples of
     contributor IDs, names and types.
 
     ## Sample Response

--- a/src/django/api/views/contributor/all_contributors.py
+++ b/src/django/api/views/contributor/all_contributors.py
@@ -8,19 +8,24 @@ from .active_contributors import active_contributors
 @throttle_classes([])
 def all_contributors(_):
     """
-    Returns list contributors as a list of tuples of contributor IDs and names.
+    Returns list contributors as a list of tuples of contributor IDs, names and types.
 
     ## Sample Response
 
         [
-            [1, "Contributor One"]
-            [2, "Contributor Two"]
+            [1, "Contributor One", "Brand/Retailer"]
+            [2, "Contributor Two", "Service Provider"]
         ]
     """
     response_data = [
-        (contributor.id, contributor.name)
-        for contributor
-        in active_contributors().order_by('name')
+        (
+            contributor.id,
+            contributor.name,
+            contributor.other_contrib_type 
+            if contributor.contrib_type == "Other" 
+            else contributor.contrib_type
+        )
+        for contributor in active_contributors().order_by('name')
     ]
 
     return Response(response_data)


### PR DESCRIPTION
[OSDEV-1474](https://opensupplyhub.atlassian.net/browse/OSDEV-1474) Add contributor type to /api/contributors/ endpoint

- Added contributor type value to response of `/api/contributors/` endpoint
- Updated unit test

[OSDEV-1474]: https://opensupplyhub.atlassian.net/browse/OSDEV-1474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ