### PR TITLE
Osdev 1376 closure report. updating auto email response to remove the word 'rejected'

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -27,7 +27,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-1383](https://opensupplyhub.atlassian.net/browse/OSDEV-1383) - Edited text of the automated email that notifies a contributor when one of their facilities has been claimed. The new text provides more information to the contributor to understand the claim process and how they can encourage more of their facilities to claim their profile.
 * [OSDEV-1474](https://opensupplyhub.atlassian.net/browse/OSDEV-1474) - Added contributor type value to response of `/api/contributors/` endpoint.
 
-
 ### Release instructions:
 * Ensure that the following commands are included in the `post_deployment` command:
     * `migrate`

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-1493](https://opensupplyhub.atlassian.net/browse/OSDEV-1493) - Fixed an issue where the backend sorts countries not by `name` but by their `alpha-2 codes` in `GET /api/v1/moderation-events/` endpoint.
 
 ### What's new
+* [OSDEV-1376](https://opensupplyhub.atlassian.net/browse/OSDEV-1376) - Updated automated emails for closure reports (report_result) to remove the term "Rejected" for an improved user experience. Added link to Closure Policy and instructions for submitting a Reopening Report to make the process easier to understand for users.
 
 ### Release instructions:
 * Ensure that the following commands are included in the `post_deployment` command:

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -24,7 +24,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### What's new
 * [OSDEV-1376](https://opensupplyhub.atlassian.net/browse/OSDEV-1376) - Updated automated emails for closure reports (report_result) to remove the term "Rejected" for an improved user experience. Added link to Closure Policy and instructions for submitting a Reopening Report to make the process easier to understand for users.
-
 * [OSDEV-1383](https://opensupplyhub.atlassian.net/browse/OSDEV-1383) - Edited text of the automated email that notifies a contributor when one of their facilities has been claimed. The new text provides more information to the contributor to understand the claim process and how they can encourage more of their facilities to claim their profile.
 * [OSDEV-1474](https://opensupplyhub.atlassian.net/browse/OSDEV-1474) - Added contributor type value to response of `/api/contributors/` endpoint.
 

--- a/src/django/api/templates/mail/report_result_body.html
+++ b/src/django/api/templates/mail/report_result_body.html
@@ -7,11 +7,14 @@
     </head>
     <body>
         <p>
-            Hi there,
+            Hello,
         </p>
         <p>
-            Thanks for reporting {{ facility_name }} facility as {{ closure_state|lower }}.
-            {% if is_closure and is_rejected %}We have rejected this report and the facility's profile in OS Hub has not been changed.{% endif %}{% if is_closure and is_confirmed %}The facility profile in Open Supply Hub has now been updated and the facility is marked as closed.{% endif %}{% if is_reopening and is_rejected %}We have rejected this report and the facility's profile in OS Hub has not been changed.{% endif %}{% if is_reopening and is_confirmed %}The facility profile in Open Supply Hub has now been updated and the facility is no longer marked as closed.{% endif %}
+            Thank you for reporting the facility {{ facility_name }} as {{ closure_state|lower }}.
+            {% if is_closure and is_rejected %}We did not approve this report and the facility's profile on OS Hub has not been changed. For more details, view our <a href="https://info.opensupplyhub.org/governance-policies">Facility Closure Policy</a>.{% endif %}
+            {% if is_closure and is_confirmed %}The facility profile on OS Hub has now been updated and the facility is marked as closed.{% endif %}
+            {% if is_reopening and is_rejected %}We did not approve this report and the facility's profile on OS Hub has not been changed.{% endif %}
+            {% if is_reopening and is_confirmed %}The facility profile on OS Hub has now been updated and the facility is no longer marked as closed.{% endif %}
         </p>
         {% if status_change_reason|length %}
         <p>
@@ -20,17 +23,17 @@
         {% endif %}
         {% if is_rejected %}
         <p>
-            If you have additional evidence that can be used to verify the facility has {{ closure_state|lower }}, this can be shared with: data@opensupplyhub.org
+            If you have additional evidence that can be used to verify that the facility is {{ closure_state|lower }}, email the relevant documents to: data@opensupplyhub.org
         </p>
         {% endif %}
         {% if is_closure and is_confirmed %}
         <p>
-            Should you receive reports that the facility is re-opened in the future, you can share this update with the OS Hub Team.
+            Should you receive reports that the facility is re-opened in the future, please send us an report clicking the “Report” button (flag icon) on the facility profile and choosing “Report as Reopened”
         </p>
         {% endif %}
 
         <p>
-            Best wishes,
+            Best Regards,
         </p>
         {% include "mail/signature_block.html" %}
     </body>

--- a/src/django/api/templates/mail/report_result_body.txt
+++ b/src/django/api/templates/mail/report_result_body.txt
@@ -1,15 +1,15 @@
 {% block content %}
-Hi there,
+Hello,
 
-Thanks for reporting {{ facility_name }} facility as {{ closure_state|lower }}.
+Thank you for reporting the facility {{ facility_name }} as {{ closure_state|lower }} on Open Supply Hub (OS Hub).
 
-{% if is_closure and is_rejected %}We have rejected this report and the facility's profile in OS Hub has not been changed.{% endif %}{% if is_closure and is_confirmed %}The facility profile in the Open Supply Hub has now been updated and the facility is marked as closed.{% endif %}{% if is_reopening and is_rejected %}We have rejected this report and the facility's profile in OS Hub has not been changed.{% endif %}{% if is_reopening and is_confirmed %}The facility profile in the Open Supply Hub has now been updated and the facility is no longer marked as closed.{% endif %}
+{% if is_closure and is_rejected %}We did not approve this report and the facility's profile in OS Hub has not been changed. For more details, view our Facility Closure Policy: https://info.opensupplyhub.org/governance-policies.{% endif %}{% if is_closure and is_confirmed %}The facility profile on OS Hub has now been updated and the facility is marked as closed.{% endif %}{% if is_reopening and is_rejected %}We did not approve this report and the facility's profile on OS Hub has not been changed.{% endif %}{% if is_reopening and is_confirmed %}The facility profile on OS Hub has now been updated and the facility is no longer marked as closed.{% endif %}
 
 {% if status_change_reason|length %}OS Hub Team review notes: {{ status_change_reason }}{% endif %}
 
-{% if is_rejected %}If you have additional evidence that can be used to verify the facility has {{ closure_state|lower }}, this can be shared with: data@opensupplyhub.org{% endif %}{% if is_closure and is_confirmed %}Should you receive reports that the facility is re-opened in the future, you can share this update with the OS Hub Team.{% endif %}
+{% if is_rejected %}If you have additional evidence that can be used to verify that the facility is {{ closure_state|lower }}, email the relevant documents to: data@opensupplyhub.org{% endif %}{% if is_closure and is_confirmed %}Should you receive reports that the facility is re-opened in the future, please send us an report clicking the “Report” button (flag icon) on the facility profile and choosing “Report as Reopened”.{% endif %}
 
-Best wishes,
+Best Regards,
 
 {% include "mail/signature_block.txt" %}
 {% endblock content %}


### PR DESCRIPTION
Updated the automated email for closure reports (report_result( to remove the term "Rejected" for an improved user experience. Added link to Closure Report policy and instructions to submit a reopening report to provide users with more information on the process.