### PR TITLE
[OSDEV-1533] Moderation Decision Date should be N/A if "status_change_date" is absent in object

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Bugfix
 * [OSDEV-1492](https://opensupplyhub.atlassian.net/browse/OSDEV-1492) - Fixed an issue where invalid manually entered dates were not validated on the UI, resulting in API errors with message “The request query is invalid.” on `Moderation Queue` page. Invalid dates are now trimmed and properly handled.
 * [OSDEV-1493](https://opensupplyhub.atlassian.net/browse/OSDEV-1493) - Fixed an issue where the backend sorts countries not by `name` but by their `alpha-2 codes` in `GET /api/v1/moderation-events/` endpoint.
+* [OSDEV-1533](https://opensupplyhub.atlassian.net/browse/OSDEV-1533) - The presentation of the `Moderation Decision Date` in the `Moderation Queue` table has been corrected. If the "status_change_date" is missing in the object, it now displays as "N/A".
 
 ### What's new
 * [OSDEV-1376](https://opensupplyhub.atlassian.net/browse/OSDEV-1376) - Updated automated emails for closure reports (report_result) to remove the term "Rejected" for an improved user experience. Added link to Closure Policy and instructions for submitting a Reopening Report to make the process easier to understand for users.

--- a/src/react/src/__tests__/components/DashboardModerationQueueListTable.test.js
+++ b/src/react/src/__tests__/components/DashboardModerationQueueListTable.test.js
@@ -6,8 +6,6 @@ import renderWithProviders from '../../util/testUtils/renderWithProviders';
 import { EMPTY_PLACEHOLDER, DATE_FORMATS } from '../../util/constants';
 import { formatUTCDate } from '../../util/util';
 
-const isEqual = require('lodash/isEqual');
-
 describe('DashboardModerationQueueListTable component', () => {
     const sampleModerationEventsWithoutStatusChangeDate =[        {
         moderation_id: 188,

--- a/src/react/src/__tests__/components/DashboardModerationQueueListTable.test.js
+++ b/src/react/src/__tests__/components/DashboardModerationQueueListTable.test.js
@@ -5,6 +5,7 @@ import DashboardModerationQueueListTable from '../../components/Dashboard/Dashbo
 import renderWithProviders from '../../util/testUtils/renderWithProviders';
 import { EMPTY_PLACEHOLDER, DATE_FORMATS } from '../../util/constants';
 import { formatUTCDate } from '../../util/util';
+
 const isEqual = require('lodash/isEqual');
 
 describe('DashboardModerationQueueListTable component', () => {

--- a/src/react/src/__tests__/components/DashboardModerationQueueListTable.test.js
+++ b/src/react/src/__tests__/components/DashboardModerationQueueListTable.test.js
@@ -9,37 +9,37 @@ const isEqual = require('lodash/isEqual');
 
 describe('DashboardModerationQueueListTable component', () => {
     const sampleModerationEventsWithoutStatusChangeDate =[        {
-        moderation_id: 11,
-        created_at: '2024-10-17T11:30:20.287Z',
+        moderation_id: 188,
+        created_at: '2023-09-16T11:32:20.297Z',
         cleaned_data: {
-            name: 'Eco Friendly Plastics',
+            name: 'Plastic Test Eco',
             country: {
-                name: 'Germany',
-                alpha_2: 'DE',
-                alpha_3: 'DEU',
-                numeric: '276',
+                name: 'Greece',
+                alpha_2: 'GR',
+                alpha_3: 'GRC',
+                numeric: '300',
             }
         },
         contributor_name: 'Green Solutions Corp',
         status: 'PENDING',
-        updated_at: '2024-10-18T11:30:20.287Z',
+        updated_at: '2024-10-17T11:31:20.287Z',
         source: 'SLC',
     },
     {
-        moderation_id: 12,
-        created_at: '2024-10-10T12:45:30.297Z',
+        moderation_id: 189,
+        created_at: '2023-08-09T12:44:18.297Z',
         cleaned_data: {
-            name: 'Solar Energy Systems Ltd',
+            name: 'Winds Systems Energy Ltd',
             country: {
-                name: 'France',
-                alpha_2: 'FR',
-                alpha_3: 'FRA',
-                numeric: '250',
+                name: 'Greenland',
+                alpha_2: 'GL',
+                alpha_3: 'GRL',
+                numeric: '304',
             }
         },
-        contributor_name: 'Renewable Resources Inc',
+        contributor_name: 'New Resources Corp',
         status: 'PENDING',
-        updated_at: '2024-10-13T12:45:30.297Z',
+        updated_at: '2023-11-12T12:46:30.297Z',
         source: 'API',
     },];
     const sampleModerationEvents = [

--- a/src/react/src/__tests__/components/DashboardModerationQueueListTable.test.js
+++ b/src/react/src/__tests__/components/DashboardModerationQueueListTable.test.js
@@ -557,14 +557,6 @@ describe('DashboardModerationQueueListTable component', () => {
     test('if no status_change_date displays N/A', () => {
         const { getAllByText } = renderComponent({ events: sampleModerationEventsWithoutStatusChangeDate, count: 2});
 
-        sampleModerationEventsWithoutStatusChangeDate.forEach(event => {
-            expect(event.status_change_date).toBeUndefined();
-            const decisionDate = event.status_change_date
-            ? formatUTCDate(event.status_change_date, DATE_FORMATS.LONG)
-            : EMPTY_PLACEHOLDER;
-
-            expect(isEqual(decisionDate, EMPTY_PLACEHOLDER)).toBe(true);
-        });
         const elements = getAllByText(EMPTY_PLACEHOLDER);
         expect(elements).toHaveLength(2);
     });

--- a/src/react/src/__tests__/components/DashboardModerationQueueListTable.test.js
+++ b/src/react/src/__tests__/components/DashboardModerationQueueListTable.test.js
@@ -5,8 +5,43 @@ import DashboardModerationQueueListTable from '../../components/Dashboard/Dashbo
 import renderWithProviders from '../../util/testUtils/renderWithProviders';
 import { EMPTY_PLACEHOLDER, DATE_FORMATS } from '../../util/constants';
 import { formatUTCDate } from '../../util/util';
+const isEqual = require('lodash/isEqual');
 
 describe('DashboardModerationQueueListTable component', () => {
+    const sampleModerationEventsWithoutStatusChangeDate =[        {
+        moderation_id: 11,
+        created_at: '2024-10-17T11:30:20.287Z',
+        cleaned_data: {
+            name: 'Eco Friendly Plastics',
+            country: {
+                name: 'Germany',
+                alpha_2: 'DE',
+                alpha_3: 'DEU',
+                numeric: '276',
+            }
+        },
+        contributor_name: 'Green Solutions Corp',
+        status: 'PENDING',
+        updated_at: '2024-10-18T11:30:20.287Z',
+        source: 'SLC',
+    },
+    {
+        moderation_id: 12,
+        created_at: '2024-10-10T12:45:30.297Z',
+        cleaned_data: {
+            name: 'Solar Energy Systems Ltd',
+            country: {
+                name: 'France',
+                alpha_2: 'FR',
+                alpha_3: 'FRA',
+                numeric: '250',
+            }
+        },
+        contributor_name: 'Renewable Resources Inc',
+        status: 'PENDING',
+        updated_at: '2024-10-13T12:45:30.297Z',
+        source: 'API',
+    },];
     const sampleModerationEvents = [
         {
             moderation_id: 11,
@@ -22,7 +57,6 @@ describe('DashboardModerationQueueListTable component', () => {
             },
             contributor_name: 'Green Solutions Corp',
             status: 'PENDING',
-            status_change_date: null,
             updated_at: '2024-10-18T11:30:20.287Z',
             source: 'SLC',
         },
@@ -45,7 +79,7 @@ describe('DashboardModerationQueueListTable component', () => {
             source: 'API',
         },
     ];
-    
+
     const paginatedModerationEvents = [
         ...sampleModerationEvents,
         {
@@ -519,12 +553,27 @@ describe('DashboardModerationQueueListTable component', () => {
         });
     });
 
+    test('if no status_change_date displays N/A', () => {
+        const { getAllByText } = renderComponent({ events: sampleModerationEventsWithoutStatusChangeDate, count: 2});
+
+        sampleModerationEventsWithoutStatusChangeDate.forEach(event => {
+            expect(event.status_change_date).toBeUndefined();
+            const decisionDate = event.status_change_date
+            ? formatUTCDate(event.status_change_date, DATE_FORMATS.LONG)
+            : EMPTY_PLACEHOLDER;
+
+            expect(isEqual(decisionDate, EMPTY_PLACEHOLDER)).toBe(true);
+        });
+        const elements = getAllByText(EMPTY_PLACEHOLDER);
+        expect(elements).toHaveLength(2);
+    });
+
     test('handles rows per page change', () => {
         const { getByText, rerender } = renderComponent({ events: paginatedModerationEvents, count: 26 });
 
         expect(getByText(/1-25 of 26/)).toBeInTheDocument();
         expect(getByText(/rows per page/i)).toBeInTheDocument();
-        
+
         fireEvent.click(getByText('25'));
         fireEvent.click(getByText('50'));
 

--- a/src/react/src/components/Dashboard/DashboardModerationQueueListTable.jsx
+++ b/src/react/src/components/Dashboard/DashboardModerationQueueListTable.jsx
@@ -15,7 +15,7 @@ import {
     updateModerationEventsPage,
     updateModerationEventsOrder,
 } from '../../actions/dashboardModerationQueue';
-import { moderationEventsPropType } from '../../util/propTypes'; //
+import { moderationEventsPropType } from '../../util/propTypes';
 import {
     EMPTY_PLACEHOLDER,
     DATE_FORMATS,

--- a/src/react/src/components/Dashboard/DashboardModerationQueueListTable.jsx
+++ b/src/react/src/components/Dashboard/DashboardModerationQueueListTable.jsx
@@ -15,7 +15,7 @@ import {
     updateModerationEventsPage,
     updateModerationEventsOrder,
 } from '../../actions/dashboardModerationQueue';
-import { moderationEventsPropType } from '../../util/propTypes';
+import { moderationEventsPropType } from '../../util/propTypes'; //
 import {
     EMPTY_PLACEHOLDER,
     DATE_FORMATS,
@@ -185,7 +185,7 @@ function DashboardModerationQueueListTable({
                                                 {moderationStatus}
                                             </TableCell>
                                             <TableCell padding="dense">
-                                                {moderationDecisionDate !== null
+                                                {moderationDecisionDate
                                                     ? formatUTCDate(
                                                           moderationDecisionDate,
                                                           DATE_FORMATS.LONG,


### PR DESCRIPTION
[OSDEV-1533](https://opensupplyhub.atlassian.net/browse/OSDEV-1533) - The presentation of the `Moderation Decision Date` in the `Moderation Queue` table has been corrected. If the "status_change_date" is missing in the object, it now displays as "N/A".

<img width="400" alt="Screenshot 2024-12-20 at 17 10 07" src="https://github.com/user-attachments/assets/43202570-90bb-421d-aec9-2782da115081" />


[OSDEV-1533]: https://opensupplyhub.atlassian.net/browse/OSDEV-1533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ