### PR TITLE
[OSDEV-1532] Fix date filter on the Moderation Queue page

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Bugfix
 * [OSDEV-1492](https://opensupplyhub.atlassian.net/browse/OSDEV-1492) - Fixed an issue where invalid manually entered dates were not validated on the UI, resulting in API errors with message “The request query is invalid.” on `Moderation Queue` page. Invalid dates are now trimmed and properly handled.
 * [OSDEV-1493](https://opensupplyhub.atlassian.net/browse/OSDEV-1493) - Fixed an issue where the backend sorts countries not by `name` but by their `alpha-2 codes` in `GET /api/v1/moderation-events/` endpoint.
+* [OSDEV-1532](https://opensupplyhub.atlassian.net/browse/OSDEV-1532) - Fixed the date range picker on the `Moderation Queue` page. A Data Moderator can change the Before date even if an Error message is displayed.
 
 ### What's new
 * [OSDEV-1376](https://opensupplyhub.atlassian.net/browse/OSDEV-1376) - Updated automated emails for closure reports (report_result) to remove the term "Rejected" for an improved user experience. Added link to Closure Policy and instructions for submitting a Reopening Report to make the process easier to understand for users.

--- a/src/react/src/components/Dashboard/DashboardModerationQueue.jsx
+++ b/src/react/src/components/Dashboard/DashboardModerationQueue.jsx
@@ -85,7 +85,7 @@ const DashboardModerationQueue = ({
 
     useEffect(() => {
         /*
-         Fetch data if prev filters were not empty but 
+         Fetch data if prev filters were not empty but
          become empty after user click on select field.
          This will resolve conflict of when we want to fetch data
          when filters are removing in UI at the moment
@@ -130,6 +130,8 @@ const DashboardModerationQueue = ({
     }, [dataSources, moderationStatuses, countries]);
 
     const handleAfterDateChange = date => {
+        setAfterDateError(false);
+        setBeforeDateError(false);
         if (!isValidDate(date)) {
             dispatch(updateAfterDate(null));
             setErrorDateText(DATE_FORMAT_ERROR);
@@ -137,13 +139,12 @@ const DashboardModerationQueue = ({
             return;
         }
         if (!isValidDateRange(beforeDate, date)) {
-            dispatch(updateAfterDate(null));
+            dispatch(updateAfterDate(date));
             setErrorDateText(DATE_RANGE_ERROR);
             setAfterDateError(true);
             return;
         }
 
-        setAfterDateError(false);
         dispatch(updateAfterDate(date));
         dispatch(clearModerationEvents());
         dispatch(
@@ -157,6 +158,8 @@ const DashboardModerationQueue = ({
     };
 
     const handleBeforeDateChange = date => {
+        setAfterDateError(false);
+        setBeforeDateError(false);
         if (!isValidDate(date)) {
             dispatch(updateBeforeDate(null));
             setErrorDateText(DATE_FORMAT_ERROR);
@@ -164,13 +167,12 @@ const DashboardModerationQueue = ({
             return;
         }
         if (!isValidDateRange(date, afterDate)) {
-            dispatch(updateBeforeDate(null));
+            dispatch(updateBeforeDate(date));
             setErrorDateText(DATE_RANGE_ERROR);
             setBeforeDateError(true);
             return;
         }
 
-        setBeforeDateError(false);
         dispatch(updateBeforeDate(date));
         dispatch(clearModerationEvents());
         dispatch(


### PR DESCRIPTION
 [OSDEV-1532](https://opensupplyhub.atlassian.net/browse/OSDEV-1532) - Fixed the date range picker on the `Moderation Queue` page. A Data Moderator can change the Before date even if an Error message is displayed.

[OSDEV-1532]: https://opensupplyhub.atlassian.net/browse/OSDEV-1532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ