### PR TITLE
[OSDEV-1563] Fix updating of the moderation decision date after moderation event approval.

### DIFF
--- a/src/django/api/moderation_event_actions/approval/event_approval_template.py
+++ b/src/django/api/moderation_event_actions/approval/event_approval_template.py
@@ -271,6 +271,7 @@ class EventApprovalTemplate(ABC):
     @staticmethod
     def _update_event(event: ModerationEvent, item: FacilityListItem) -> None:
         event.status = ModerationEvent.Status.APPROVED
+        event.status_change_date = timezone.now()
         event.os_id = item.facility_id
         event.save()
 


### PR DESCRIPTION
[OSDEV-1563](https://opensupplyhub.atlassian.net/browse/OSDEV-1563) - Moderation Decision Date isn't updated after POST: /api/v1/moderation-events/{moderation_id}/production-locations/

Added functionality to update the status_change_date field of a moderation event after the approval action. This is done using the following endpoints:

- POST: /api/v1/moderation-events/{moderation_id}/production-locations/
- PATCH: /api/v1/moderation-events/{moderation_id}/production-locations/{os_id}/
