### PR TITLE
Add next responsible person for 1.28, 1.29 release

### DIFF
--- a/doc/release/RELEASE-PROTOCOL.md
+++ b/doc/release/RELEASE-PROTOCOL.md
@@ -51,6 +51,8 @@ This document outlines the SDLC pillars of the opensupplyhub monorepo, as well a
 | v1.25.0 | November 30, 2024  | November 26, 2024 | @Oleksandr Mazur |
 | v1.26.0 | December 14, 2024  | December 10, 2024 | @Nessa Drew |
 | v1.27.0 | January 11, 2025  | January 7, 2025 | @Nessa Drew |
+| v1.28.0 | January 25, 2025  | January 21, 2025 | @Vlad Shapik |
+| v1.29.0 | February 8, 2025  | February 4, 2025 | @Vlad Shapik |
 
 ## General Information
 


### PR DESCRIPTION
Added information about the person responsible for the 1.28, and 1.29 release.