### PR TITLE
Remove the snapshot_identifier value for the Test environment

### DIFF
--- a/deployment/environments/terraform-test.tfvars
+++ b/deployment/environments/terraform-test.tfvars
@@ -21,7 +21,6 @@ rds_database_identifier = "opensupplyhub-enc-tst"
 rds_database_name = "opensupplyhub"
 rds_multi_az = false
 rds_storage_encrypted = true
-snapshot_identifier = "opensupplyhub-rds-tst"
 
 anonymized_database_instance_type = "db.t3.2xlarge"
 anonymized_database_identifier = "database-anonymizer"


### PR DESCRIPTION
The value has been removed from the `main` branch to prevent triggering a DB restore from the snapshot when it is not necessary. This value should only be set in a special branch whose purpose is to restore the DB from a snapshot, and it should be empty in the main branch to avoid triggering the restore.