### PR TITLE
[OSDEV-1579] Update copy api limit automated emails

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -37,6 +37,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
     * Successful Search: If the search is successful, the results screen displays a list of production locations. Each item includes the following information about the production location: name, OS ID, address, and country name. Users can either select a specific production location or press the "I don’t see my Location" button, which triggers a confirmation dialog window.
     * Confirmation Dialog Window: In this window, users can confirm that no correct location was found using the provided search parameters. They can either proceed to create a new production location or return to the search.
     * Unsuccessful Search: If the search is unsuccessful, an explanation is provided along with two options: return to the search or add a new production location.
+* [OSDEV-1579](https://opensupplyhub.atlassian.net/browse/OSDEV-1579) - Updated the API limit automated email to remove an outdated link referring to OAR and improve the languate for clarity. With this update the contributor will be informed of the correct process to follow if they have reached their API calls limit.
 
 ### Release instructions:
 * Ensure that the following commands are included in the `post_deployment` command:

--- a/src/django/api/templates/mail/api_limit_body.html
+++ b/src/django/api/templates/mail/api_limit_body.html
@@ -15,7 +15,7 @@
     <p>
       To purchase additional queries, please contact our support team directly at <a href="support@opensupplyhub.org">support@opensupplyhub.org</a>. We will assist you in selecting a package and arranging payment promptly.
     </p>
-      <p>
+    <p>
       Best Regards,
     </p>
     {% include "mail/signature_block.html" %}

--- a/src/django/api/templates/mail/api_limit_body.html
+++ b/src/django/api/templates/mail/api_limit_body.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <title>
-      Open Supply Hub contributor API limit notice
+      Open Supply Hub API access limit reached
     </title>
   </head>
   <body>
@@ -10,17 +10,13 @@
       Hello,
     </p>
     <p>
-      We’re writing to notify you that you have reached your access limit for
-      the Open Supply Hub (OS Hub) API and your use of the API has now been blocked. To purchase more
-      queries, please complete
-      <a
-        href="https://docs.google.com/forms/d/e/1FAIpQLSdJax3sVHw1IeDkBs0tmfQonWaX8SiR9UYlqXUfk0rLH73Y3w/viewform"
-        >this short form</a
-      >
-      letting us know which new package you would like and a member of the OS Hub
-      Team will be in touch to arrange payment and access.
+     You have reached your access limit for the Open Supply Hub (OS Hub) API, and your access has been temporarily blocked.
     </p>
     <p>
+      To purchase additional queries, please contact our support team directly at <a href="support@opensupplyhub.org">support@opensupplyhub.org</a>. 
+        We will assist you in selecting a package and arranging payment promptly.
+    </p>
+      <p>
       Best Regards,
     </p>
     {% include "mail/signature_block.html" %}

--- a/src/django/api/templates/mail/api_limit_body.html
+++ b/src/django/api/templates/mail/api_limit_body.html
@@ -13,8 +13,7 @@
      You have reached your access limit for the Open Supply Hub (OS Hub) API, and your access has been temporarily blocked.
     </p>
     <p>
-      To purchase additional queries, please contact our support team directly at <a href="support@opensupplyhub.org">support@opensupplyhub.org</a>. 
-        We will assist you in selecting a package and arranging payment promptly.
+      To purchase additional queries, please contact our support team directly at <a href="support@opensupplyhub.org">support@opensupplyhub.org</a>. We will assist you in selecting a package and arranging payment promptly.
     </p>
       <p>
       Best Regards,

--- a/src/django/api/templates/mail/api_limit_body.txt
+++ b/src/django/api/templates/mail/api_limit_body.txt
@@ -1,11 +1,10 @@
 {% block content %}
 Hello,
 
-We’re writing to notify you that you have reached your access limit for the Open Supply Hub
-(OS Hub) API and your use of the API has now been blocked. To purchase more queries,
-please complete this short form (https://docs.google.com/forms/d/e/1FAIpQLSdJax3sVHw1IeDkBs0tmfQonWaX8SiR9UYlqXUfk0rLH73Y3w/viewform)
-letting us know which new package you would like and a member of the OS Hub Team
-will be in touch to arrange payment and access.
+You have reached your access limit for the Open Supply Hub (OS Hub) API, and your access has been temporarily blocked. 
+
+To purchase additional queries, please contact our support team directly at support@opensupplyhub.org. 
+We will assist you in selecting a package and arranging payment promptly.
 
 Best Regards,
 

--- a/src/django/api/templates/mail/api_limit_subject.txt
+++ b/src/django/api/templates/mail/api_limit_subject.txt
@@ -1,1 +1,1 @@
-Open Supply Hub API limit notice
+Open Supply Hub API access limit reached


### PR DESCRIPTION
Removed an outdated link referring to OAR. Improved the language for clarity and added the correct process for contacting the OS Hub team when the user reaches their API calls limit.