### PR TITLE
Updated the prefix from "stg" to "dev" for the Development environment in the AWS infrastructure.

### DIFF
--- a/deployment/environments/terraform-development.tfvars
+++ b/deployment/environments/terraform-development.tfvars
@@ -17,7 +17,7 @@ rds_allocated_storage = "128"
 rds_engine_version = "13"
 rds_parameter_group_family = "postgres13"
 rds_instance_type = "db.t3.micro"
-rds_database_identifier = "opensupplyhub-enc-stg"
+rds_database_identifier = "opensupplyhub-enc-dev"
 rds_database_name = "opensupplyhub"
 rds_multi_az = false
 rds_storage_encrypted = true
@@ -49,8 +49,8 @@ batch_default_ce_instance_types = ["c5", "m5"]
 
 app_ecs_grace_period_seconds = 300
 
-ec_memcached_identifier = "opensupplyhub-stg"
-rds_final_snapshot_identifier = "opensupplyhub-rds-stg"
+ec_memcached_identifier = "opensupplyhub-dev"
+rds_final_snapshot_identifier = "opensupplyhub-rds-dev"
 topic_dedup_basic_name = "basic-name"
 dedupe_hub_live = true
 dedupe_hub_name = "deduplicate"

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -25,7 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * *Describe architecture/environment changes here.*
 
 ### Bugfix
-* *Describe bugfix here.*
+* Some of the resources related to the Development AWS environment still have the `stg` prefix, which can be confusing since we also have a Staging environment with the same prefix. To clarify the resource names, including the database instance, the prefix has been updated from `stg` to `dev` for the development environment.
 
 ### What's new
 * [OSDEV-1374](https://opensupplyhub.atlassian.net/browse/OSDEV-1374) - Implemented integration for the `Search results` page to show results of searching by name and address (`/contribute/production-location/search`):


### PR DESCRIPTION
Some of the resources related to the Development AWS environment still have the `stg` prefix, which can be confusing since we also have a Staging environment with the same prefix. To clarify the resource names, including the database instance, the prefix has been updated from `stg` to `dev` for the development environment.