### PR TITLE
Hotfix - [OSDEV-1626] SLC. Update URL for "Add Data" functionality on site to hide SLC entry point.

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). The format is based on the `RELEASE-NOTES-TEMPLATE.md` file.
 
+## Release 1.28.1
+
+## Introduction
+* Product name: Open Supply Hub
+* Release date: January 31, 2025
+
+### Bugfix
+* [OSDEV-1662](https://opensupplyhub.atlassian.net/browse/OSDEV-1662) - Temporarily hid the new contribution page `Add Location Data` and re-enabled the old navigation to the `List Upload` page via the `/contribute` path.
+
 ## Release 1.28.0
 
 ## Introduction

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * Release date: January 31, 2025
 
 ### Bugfix
-* [OSDEV-1662](https://opensupplyhub.atlassian.net/browse/OSDEV-1662) - Temporarily hid the new contribution page `Add Location Data` and re-enabled the old navigation to the `List Upload` page via the `/contribute` path.
+* [OSDEV-1626](https://opensupplyhub.atlassian.net/browse/OSDEV-1626) - Temporarily hid the new contribution page `Add Location Data` and re-enabled the old navigation to the `List Upload` page via the `/contribute` path.
 
 ## Release 1.28.0
 

--- a/src/react/src/Routes.jsx
+++ b/src/react/src/Routes.jsx
@@ -14,7 +14,6 @@ import RegisterForm from './components/RegisterForm';
 import ResetPasswordForm from './components/ResetPasswordForm';
 import LoginForm from './components/LoginForm';
 import Contribute from './components/Contribute';
-// import AddLocationData from './components/AddLocationData';
 import Homepage from './components/Homepage';
 import FacilityLists from './components/FacilityLists';
 import FacilityListItems from './components/FacilityListItems';
@@ -48,7 +47,6 @@ import {
     authResetPasswordFormRoute,
     authConfirmRegistrationRoute,
     contributeRoute,
-    // multipleLocationRoute,
     listsRoute,
     facilityListItemsRoute,
     facilitiesRoute,
@@ -152,10 +150,6 @@ class Routes extends Component {
                                     path={contributeRoute}
                                     component={Contribute}
                                 />
-                                {/* <Route
-                                    path={multipleLocationRoute}
-                                    component={Contribute}
-                                /> */}
                                 <Route
                                     path={dashboardRoute}
                                     component={Dashboard}

--- a/src/react/src/Routes.jsx
+++ b/src/react/src/Routes.jsx
@@ -14,7 +14,7 @@ import RegisterForm from './components/RegisterForm';
 import ResetPasswordForm from './components/ResetPasswordForm';
 import LoginForm from './components/LoginForm';
 import Contribute from './components/Contribute';
-import AddLocationData from './components/AddLocationData';
+// import AddLocationData from './components/AddLocationData';
 import Homepage from './components/Homepage';
 import FacilityLists from './components/FacilityLists';
 import FacilityListItems from './components/FacilityListItems';
@@ -48,7 +48,7 @@ import {
     authResetPasswordFormRoute,
     authConfirmRegistrationRoute,
     contributeRoute,
-    multipleLocationRoute,
+    // multipleLocationRoute,
     listsRoute,
     facilityListItemsRoute,
     facilitiesRoute,
@@ -150,12 +150,12 @@ class Routes extends Component {
                                 <Route
                                     exact
                                     path={contributeRoute}
-                                    component={AddLocationData}
-                                />
-                                <Route
-                                    path={multipleLocationRoute}
                                     component={Contribute}
                                 />
+                                {/* <Route
+                                    path={multipleLocationRoute}
+                                    component={Contribute}
+                                /> */}
                                 <Route
                                     path={dashboardRoute}
                                     component={Dashboard}


### PR DESCRIPTION
[OSDEV-1626](https://opensupplyhub.atlassian.net/browse/OSDEV-1626) **SLC. Update URL for "Add Data" functionality on site to hide SLC entry point.**

- Temporarily hid the new contribution page `Add Location Data` and re-enabled the old navigation to the `List Upload` page via the `/contribute` path.

[OSDEV-1626]: https://opensupplyhub.atlassian.net/browse/OSDEV-1626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ