### PR TITLE
[OSDEV-1365] Disable claim button when moderation event on new productino location is REJECTED

### DIFF
--- a/src/react/src/__tests__/components/ProductionLocationDialog.test.js
+++ b/src/react/src/__tests__/components/ProductionLocationDialog.test.js
@@ -104,7 +104,32 @@ describe('ProductionLocationDialog', () => {
         expect(screen.getByText(/Shirts, Pants/i)).toBeInTheDocument();
     });
 
-    test('Continue to Claim button should be active if production location is unclaimed and approved', () => {
+    test.each([
+        ['PENDING', 'unclaimed', true],
+        ['PENDING', 'claimed', true],
+        ['REJECTED', 'claimed', true],
+        ['REJECTED', 'unclaimed', false],
+        ['REJECTED', undefined, true],
+        ['APPROVED', 'unclaimed', false],
+        ['APPROVED', 'claimed', true]
+    ])('handles moderation status %s and claim status %s correctly', (moderationStatus, claimStatus, shouldBeDisabled) => {
+        const { getByRole } = render(
+            <Router>
+                <ProductionLocationDialog
+                    classes={{}}
+                    data={defaultProps.data}
+                    osID={defaultProps.osID}
+                    moderationStatus={moderationStatus}
+                    claimStatus={claimStatus}
+                />
+            </Router>
+        );
+
+        const claimButton = getByRole('button', { name: /Continue to Claim/i });
+        expect(window.getComputedStyle(claimButton).pointerEvents).toBe(shouldBeDisabled ? 'none' : '');
+    });
+
+    test('check link to the claim flow for specific production location', () => {
         const { getByRole } = render(
             <Router>
                 <ProductionLocationDialog
@@ -118,49 +143,8 @@ describe('ProductionLocationDialog', () => {
         );
 
         const claimButton = getByRole('button', { name: /Continue to Claim/i });
-
-        expect(window.getComputedStyle(claimButton).pointerEvents).not.toBe('none');
-
         expect(claimButton).toHaveAttribute('href', `/facilities/${defaultProps.osID}/claim`);
-    });
-
-    test('Continue to Claim button should be active if production location is unclaimed and rejected', () => {
-        const { getByRole } = render(
-            <Router>
-                <ProductionLocationDialog
-                    classes={{}}
-                    data={defaultProps.data}
-                    osID={defaultProps.osID}
-                    moderationStatus='REJECTED'
-                    claimStatus='unclaimed'
-                />
-            </Router>
-        );
-
-        const claimButton = getByRole('button', { name: /Continue to Claim/i });
-
-        expect(window.getComputedStyle(claimButton).pointerEvents).not.toBe('none');
-
-        expect(claimButton).toHaveAttribute('href', `/facilities/${defaultProps.osID}/claim`);
-    });
-
-    test('Continue to Claim button should be disabled if production location has been claimed', () => {
-        const { getByRole } = render(
-            <Router>
-                <ProductionLocationDialog
-                    classes={{}}
-                    data={defaultProps.data}
-                    osID={defaultProps.osID}
-                    moderationStatus={defaultProps.moderationStatus}
-                    claimStatus='claimed'
-                />
-            </Router>
-        );
-
-        const claimButton = getByRole('button', { name: /Continue to Claim/i });
-
-        expect(window.getComputedStyle(claimButton).pointerEvents).toBe('none');
-    });
+    })
 
     test('closes ProductionLocationDialog when close button is clicked', () => {
         const handleShowMock = jest.fn();

--- a/src/react/src/components/Contribute/ProductionLocationDialog.jsx
+++ b/src/react/src/components/Contribute/ProductionLocationDialog.jsx
@@ -80,7 +80,7 @@ const getTooltipText = (claimStatus, moderationStatus) => {
         return 'Production location has been claimed already.';
     }
 
-    return '';
+    return 'Claim is not available.';
 };
 
 const ProductionLocationDialog = ({
@@ -310,7 +310,7 @@ const ProductionLocationDialog = ({
 
 ProductionLocationDialog.defaultProps = {
     osID: null,
-    claimStatus: PRODUCTION_LOCATION_CLAIM_STATUSES_ENUM.UNCLAIMED,
+    claimStatus: null,
 };
 
 ProductionLocationDialog.propTypes = {

--- a/src/react/src/components/Contribute/ProductionLocationInfo.jsx
+++ b/src/react/src/components/Contribute/ProductionLocationInfo.jsx
@@ -54,7 +54,6 @@ import {
     productionLocationInfoRouteCommon,
     searchByNameAndAddressResultRoute,
     MODERATION_STATUSES_ENUM,
-    PRODUCTION_LOCATION_CLAIM_STATUSES_ENUM,
 } from '../../util/constants';
 import COLOURS from '../../util/COLOURS';
 import ProductionLocationDialog from './ProductionLocationDialog';
@@ -794,8 +793,7 @@ const ProductionLocationInfo = ({
                         MODERATION_STATUSES_ENUM.PENDING
                     }
                     claimStatus={
-                        singleProductionLocationData?.claim_status ||
-                        PRODUCTION_LOCATION_CLAIM_STATUSES_ENUM.UNCLAIMED
+                        singleProductionLocationData?.claim_status || null
                     }
                 />
             ) : null}


### PR DESCRIPTION
Follow-up fix for [OSDEV-1365](https://opensupplyhub.atlassian.net/browse/OSDEV-1365)
Disable claim button when moderation event on new productino location is REJECTED.

[OSDEV-1365]: https://opensupplyhub.atlassian.net/browse/OSDEV-1365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ