### PR TITLE
[OSDEV-1577] Add geo-bounding box support to the GET `/v1/production-locations/` endpoint

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -19,36 +19,44 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * *Describe schema changes here.*
 
 ### Code/API changes
-* *Describe code/API changes here.*
+* [OSDEV-1577](https://opensupplyhub.atlassian.net/browse/OSDEV-1577) - Added geo-bounding box query support to the GET `/api/v1/production-locations/` endpoint. To filter production locations whose geopoints fall within the bounding box, it is necessary to specify valid values for the parameters `geo_bounding_box[top]`, `geo_bounding_box[left]`, `geo_bounding_box[bottom]`, and `geo_bounding_box[right]`. 
+
+    The validation rules are as follows:
+    * All coordinates of the geo-boundary box (top, left, bottom, right) must be provided.
+    * All values must be integers.
+    * The top and bottom coordinates must be between -90 and 90.
+    * The left and right coordinates must be between -180 and 180.
+    * The top must be greater than the bottom.
+    * The right must be greater than the left.
 
 ### Architecture/Environment changes
 * [OSDEV-899](https://opensupplyhub.atlassian.net/browse/OSDEV-899) - With this task, we split the Django container into two components: FE (React) and BE (Django). Requests to the frontend (React) will be processed by the CDN (CloudFront), while requests to the API will be redirected to the Django container. This approach will allow for more efficient use of ECS cluster computing resources and improve frontend performance.
 
-  The following endpoints will be redirected to the Django container:
-  * tile/*
-  * api/*
-  * /api-auth/*
-  * /api-token-auth/*
-  * /api-feature-flags/*
-  * /web/environment.js
-  * /admin/*
-  * /health-check/*
-  * /rest-auth/*
-  * /user-login/*
-  * /user-logout/*
-  * /user-signup/*
-  * /user-profile/*
-  * /user-api-info/*
-  * /admin
-  * /static/admin/*
-  * /static/django_extensions/*
-  * /static/drf-yasg/*
-  * /static/gis/*
-  * /static/rest_framework/*
-  * /static/static/*
-  * /static/staticfiles.json
+    The following endpoints will be redirected to the Django container:
+    * tile/*
+    * api/*
+    * /api-auth/*
+    * /api-token-auth/*
+    * /api-feature-flags/*
+    * /web/environment.js
+    * /admin/*
+    * /health-check/*
+    * /rest-auth/*
+    * /user-login/*
+    * /user-logout/*
+    * /user-signup/*
+    * /user-profile/*
+    * /user-api-info/*
+    * /admin
+    * /static/admin/*
+    * /static/django_extensions/*
+    * /static/drf-yasg/*
+    * /static/gis/*
+    * /static/rest_framework/*
+    * /static/static/*
+    * /static/staticfiles.json
 
-  All other traffic will be redirected to the React application.
+    All other traffic will be redirected to the React application.
 
 ### Bugfix
 * *Describe bugfix here.*

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -207,6 +207,13 @@ class FacilitiesListSettings:
     DEFAULT_PAGE_LIMIT = 100
 
 
+class CoordinateLimits:
+    LAT_MIN = -90
+    LAT_MAX = 90
+    LNG_MIN = -180
+    LNG_MAX = 180
+
+
 # API v1
 class APIV1CommonErrorMessages:
     COMMON_REQ_BODY_ERROR = 'The request body is invalid.'

--- a/src/django/api/serializers/v1/opensearch_common_validators/coordinates_validator.py
+++ b/src/django/api/serializers/v1/opensearch_common_validators/coordinates_validator.py
@@ -18,23 +18,21 @@ class CoordinatesValidator(OpenSearchValidationInterface):
                 "detail": "Both latitude and longitude must be provided."
             })
 
-        if lat is not None:
-            if not (
-                CoordinateLimits.LAT_MIN <= lat <= CoordinateLimits.LAT_MAX
-            ):
-                errors.append({
-                    "field": "coordinates",
-                    "detail": "Latitude must be between -90 and 90 degrees."
-                })
+        if lat is not None and not (
+            CoordinateLimits.LAT_MIN <= lat <= CoordinateLimits.LAT_MAX
+        ):
+            errors.append({
+                "field": "coordinates",
+                "detail": "Latitude must be between -90 and 90 degrees."
+            })
 
-        if lng is not None:
-            if not (
-                CoordinateLimits.LNG_MIN <= lng <= CoordinateLimits.LNG_MAX
-            ):
-                errors.append({
-                    "field": "coordinates",
-                    "detail":
-                        "Longitude must be between -180 and 180 degrees."
-                })
+        if lng is not None and not (
+            CoordinateLimits.LNG_MIN <= lng <= CoordinateLimits.LNG_MAX
+        ):
+            errors.append({
+                "field": "coordinates",
+                "detail":
+                    "Longitude must be between -180 and 180 degrees."
+            })
 
         return errors

--- a/src/django/api/serializers/v1/opensearch_common_validators/coordinates_validator.py
+++ b/src/django/api/serializers/v1/opensearch_common_validators/coordinates_validator.py
@@ -1,4 +1,5 @@
 from typing import List
+from api.constants import CoordinateLimits
 from api.serializers.v1.opensearch_validation_interface \
     import OpenSearchValidationInterface
 
@@ -18,14 +19,18 @@ class CoordinatesValidator(OpenSearchValidationInterface):
             })
 
         if lat is not None:
-            if not (-90 <= lat <= 90):
+            if not (
+                CoordinateLimits.LAT_MIN <= lat <= CoordinateLimits.LAT_MAX
+            ):
                 errors.append({
                     "field": "coordinates",
                     "detail": "Latitude must be between -90 and 90 degrees."
                 })
 
         if lng is not None:
-            if not (-180 <= lng <= 180):
+            if not (
+                CoordinateLimits.LNG_MIN <= lng <= CoordinateLimits.LNG_MAX
+            ):
                 errors.append({
                     "field": "coordinates",
                     "detail":

--- a/src/django/api/serializers/v1/opensearch_common_validators/geo_bounding_box_validator.py
+++ b/src/django/api/serializers/v1/opensearch_common_validators/geo_bounding_box_validator.py
@@ -1,0 +1,112 @@
+import json
+from api.serializers.v1.opensearch_validation_interface import (
+    OpenSearchValidationInterface,
+)
+
+
+class GeoBoundingBoxValidator(OpenSearchValidationInterface):
+    def validate_opensearch_params(self, data):
+        errors = []
+        geo_bounding_box_str = data.get('geo_bounding_box')
+        geo_bounding_box = (
+            json.loads(geo_bounding_box_str) if geo_bounding_box_str else None
+        )
+
+        if geo_bounding_box:
+            required_keys = ['top_right', 'bottom_left']
+            for key in required_keys:
+                if key not in geo_bounding_box:
+                    errors.append(
+                        {
+                            "field": "geo_bounding_box",
+                            "detail": (
+                                "The value must be a valid object with "
+                                "`top_right` and `bottom_left` properties."
+                            ),
+                        }
+                    )
+
+                if not isinstance(geo_bounding_box[key], dict):
+                    errors.append(
+                        {
+                            "field": "geo_bounding_box",
+                            "detail": (
+                                "The value must be a valid object with "
+                                "`lat` and `lon` properties."
+                            ),
+                        }
+                    )
+
+                for coord in ['lat', 'lon']:
+                    if coord not in geo_bounding_box[key]:
+                        errors.append(
+                            {
+                                "field": "geo_bounding_box",
+                                "detail": (f"Missing {coord} in {key}."),
+                            }
+                        )
+
+                    try:
+                        value = float(geo_bounding_box[key][coord])
+                    except ValueError:
+                        errors.append(
+                            {
+                                "field": "geo_bounding_box",
+                                "detail": (
+                                    f"The '{coord}' in '{key}' must be "
+                                    "a number."
+                                ),
+                            }
+                        )
+
+                    if coord == 'lat' and not (-90 <= value <= 90):
+                        errors.append(
+                            {
+                                "field": "geo_bounding_box",
+                                "detail": (
+                                    f"The 'lat' in '{key}' must be between "
+                                    "-90 and 90."
+                                ),
+                            }
+                        )
+
+                    if coord == 'lon' and not (-180 <= value <= 180):
+                        errors.append(
+                            {
+                                "field": "geo_bounding_box",
+                                "detail": (
+                                    f"The 'lon' in '{key}' must be between "
+                                    "-180 and 180."
+                                ),
+                            }
+                        )
+
+            if (
+                geo_bounding_box['top_right']['lat']
+                < geo_bounding_box['bottom_left']['lat']
+            ):
+                errors.append(
+                    {
+                        "field": "geo_bounding_box",
+                        "detail": (
+                            "Top right latitude must be greater than "
+                            "bottom left latitude."
+                        ),
+                    }
+                )
+
+            if (
+                geo_bounding_box['top_right']['lon']
+                < geo_bounding_box['bottom_left']['lon']
+            ):
+                errors.append(
+                    {
+                        "field": "geo_bounding_box",
+                        "detail": (
+                            "Top right longitude must be greater than "
+                            "bottom left longitude."
+                        ),
+                    }
+                )
+
+        return errors

--- a/src/django/api/serializers/v1/opensearch_common_validators/geo_bounding_box_validator.py
+++ b/src/django/api/serializers/v1/opensearch_common_validators/geo_bounding_box_validator.py
@@ -42,7 +42,8 @@ class GeoBoundingBoxValidator(OpenSearchValidationInterface):
                 errors.append(
                     {
                         "field": "geo_bounding_box",
-                        "detail": f"The {field} value must be between {min_val} and {max_val}.",
+                        "detail": f"The {field} value must be between "
+                        f"{min_val} and {max_val}.",
                     }
                 )
 

--- a/src/django/api/serializers/v1/opensearch_common_validators/geo_bounding_box_validator.py
+++ b/src/django/api/serializers/v1/opensearch_common_validators/geo_bounding_box_validator.py
@@ -1,3 +1,4 @@
+from api.constants import CoordinateLimits
 from api.serializers.v1.opensearch_validation_interface import (
     OpenSearchValidationInterface,
 )
@@ -29,10 +30,10 @@ class GeoBoundingBoxValidator(OpenSearchValidationInterface):
             return errors
 
         range_limits = {
-            'top': (-90, 90),
-            'bottom': (-90, 90),
-            'left': (-180, 180),
-            'right': (-180, 180),
+            'top': (CoordinateLimits.LAT_MIN, CoordinateLimits.LAT_MAX),
+            'bottom': (CoordinateLimits.LAT_MIN, CoordinateLimits.LAT_MAX),
+            'left': (CoordinateLimits.LNG_MIN, CoordinateLimits.LNG_MAX),
+            'right': (CoordinateLimits.LNG_MIN, CoordinateLimits.LNG_MAX),
         }
 
         for field, (min_val, max_val) in range_limits.items():

--- a/src/django/api/serializers/v1/production_locations_serializer.py
+++ b/src/django/api/serializers/v1/production_locations_serializer.py
@@ -64,7 +64,6 @@ class ProductionLocationsSerializer(Serializer):
     geo_bounding_box_right = FloatField(required=False)
 
     def validate(self, data):
-        print('data >>>', data)
         validators = [
             SizeValidator(),
             NumberOfWorkersValidator(),

--- a/src/django/api/serializers/v1/production_locations_serializer.py
+++ b/src/django/api/serializers/v1/production_locations_serializer.py
@@ -20,6 +20,8 @@ from api.serializers.v1.opensearch_common_validators. \
 from api.serializers.v1.opensearch_common_validators. \
     coordinates_validator import CoordinatesValidator
 from api.constants import APIV1CommonErrorMessages
+from api.serializers.v1.opensearch_common_validators.\
+    geo_bounding_box_validator import GeoBoundingBoxValidator
 
 
 class ProductionLocationsSerializer(Serializer):
@@ -56,6 +58,7 @@ class ProductionLocationsSerializer(Serializer):
         max_value=15,
         required=False,
     )
+    geo_bounding_box = CharField(required=False)
 
     def validate(self, data):
         validators = [
@@ -64,6 +67,7 @@ class ProductionLocationsSerializer(Serializer):
             PercentOfFemaleWorkersValidator(),
             CoordinatesValidator(),
             CountryValidator(),
+            GeoBoundingBoxValidator(),
         ]
 
         error_list_builder = OpenSearchErrorListBuilder(validators)

--- a/src/django/api/serializers/v1/production_locations_serializer.py
+++ b/src/django/api/serializers/v1/production_locations_serializer.py
@@ -64,6 +64,7 @@ class ProductionLocationsSerializer(Serializer):
     geo_bounding_box_right = FloatField(required=False)
 
     def validate(self, data):
+        print('data >>>', data)
         validators = [
             SizeValidator(),
             NumberOfWorkersValidator(),

--- a/src/django/api/serializers/v1/production_locations_serializer.py
+++ b/src/django/api/serializers/v1/production_locations_serializer.py
@@ -58,7 +58,10 @@ class ProductionLocationsSerializer(Serializer):
         max_value=15,
         required=False,
     )
-    geo_bounding_box = CharField(required=False)
+    geo_bounding_box_top = FloatField(required=False)
+    geo_bounding_box_left = FloatField(required=False)
+    geo_bounding_box_bottom = FloatField(required=False)
+    geo_bounding_box_right = FloatField(required=False)
 
     def validate(self, data):
         validators = [

--- a/src/django/api/tests/test_production_locations_query_builder.py
+++ b/src/django/api/tests/test_production_locations_query_builder.py
@@ -260,9 +260,9 @@ class TestProductionLocationsQueryBuilder(TestCase):
     def test_add_geo_bounding_box(self):
         top = 40.7128
         left = -74.0060
-        bottom = 40.7128
-        right = -74.0060
-        self.builder.add_geo_bounding_box(top, right, bottom, left)
+        bottom = 35.7128
+        right = -78.0060
+        self.builder.add_geo_bounding_box(top, left, bottom, right)
         expected = {
             'geo_bounding_box': {
                 'coordinates': {

--- a/src/django/api/tests/test_production_locations_query_builder.py
+++ b/src/django/api/tests/test_production_locations_query_builder.py
@@ -256,3 +256,27 @@ class TestProductionLocationsQueryBuilder(TestCase):
             aggregation
         )
         self.assertNotIn('aggregations', self.builder.query_body)
+
+    def test_add_geo_bounding_box(self):
+        top = 40.7128
+        left = -74.0060
+        bottom = 40.7128
+        right = -74.0060
+        self.builder.add_geo_bounding_box(top, right, bottom, left)
+        expected = {
+            'geo_bounding_box': {
+                'coordinates': {
+                    'top': top,
+                    'left': left,
+                    'bottom': bottom,
+                    'right': right,
+                }
+            }
+        }
+        self.assertIn(
+            'filter', self.builder.query_body['query']['bool']
+        )
+        self.assertEqual(
+            expected,
+            self.builder.query_body['query']['bool']['filter']
+        )

--- a/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
+++ b/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
@@ -1,4 +1,3 @@
-import json
 from api.views.v1.parameters_list import V1_PARAMETERS_LIST
 
 

--- a/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
+++ b/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
@@ -135,14 +135,20 @@ class OpenSearchQueryDirector:
             self.__builder.add_aggregations(aggregation, geohex_grid_precision)
 
     def __process_filter(self, query_params):
-        geo_bounding_box_str = query_params.get(
-            V1_PARAMETERS_LIST.GEO_BOUNDING_BOX
+        top = query_params.get(
+            V1_PARAMETERS_LIST.GEO_BOUNDING_BOX + '[top]'
         )
-        geo_bounding_box = (
-            json.loads(geo_bounding_box_str) if geo_bounding_box_str else None
+        right = query_params.get(
+            V1_PARAMETERS_LIST.GEO_BOUNDING_BOX + '[right]'
+        )
+        bottom = query_params.get(
+            V1_PARAMETERS_LIST.GEO_BOUNDING_BOX + '[bottom]'
+        )
+        left = query_params.get(
+            V1_PARAMETERS_LIST.GEO_BOUNDING_BOX + '[left]'
         )
 
-        if geo_bounding_box and hasattr(
-            self.__builder, 'add_geo_bounding_box'
-        ):
-            self.__builder.add_geo_bounding_box(geo_bounding_box)
+        if top and right and bottom and left:
+            self.__builder.add_geo_bounding_box(
+                top, right, bottom, left
+            )

--- a/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
+++ b/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
@@ -138,17 +138,19 @@ class OpenSearchQueryDirector:
         top = query_params.get(
             V1_PARAMETERS_LIST.GEO_BOUNDING_BOX + '[top]'
         )
-        right = query_params.get(
-            V1_PARAMETERS_LIST.GEO_BOUNDING_BOX + '[right]'
+        left = query_params.get(
+            V1_PARAMETERS_LIST.GEO_BOUNDING_BOX + '[left]'
         )
         bottom = query_params.get(
             V1_PARAMETERS_LIST.GEO_BOUNDING_BOX + '[bottom]'
         )
-        left = query_params.get(
-            V1_PARAMETERS_LIST.GEO_BOUNDING_BOX + '[left]'
+        right = query_params.get(
+            V1_PARAMETERS_LIST.GEO_BOUNDING_BOX + '[right]'
         )
 
-        if top and right and bottom and left:
+        if top and left and bottom and right and hasattr(
+            self.__builder, 'add_geo_bounding_box'
+        ):
             self.__builder.add_geo_bounding_box(
-                top, right, bottom, left
+                top, left, bottom, right
             )

--- a/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
+++ b/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
@@ -151,5 +151,5 @@ class OpenSearchQueryDirector:
             self.__builder, 'add_geo_bounding_box'
         ):
             self.__builder.add_geo_bounding_box(
-                top, left, bottom, right
+                float(top), float(left), float(bottom), float(right)
             )

--- a/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
+++ b/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
@@ -1,3 +1,4 @@
+import json
 from api.views.v1.parameters_list import V1_PARAMETERS_LIST
 
 
@@ -41,6 +42,7 @@ class OpenSearchQueryDirector:
         self.__process_size(query_params)
         self.__process_multi_match(query_params)
         self.__process_aggregation(query_params)
+        self.__process_filter(query_params)
 
         return self.__builder.get_final_query_body()
 
@@ -131,3 +133,16 @@ class OpenSearchQueryDirector:
 
         if aggregation and hasattr(self.__builder, 'add_aggregations'):
             self.__builder.add_aggregations(aggregation, geohex_grid_precision)
+
+    def __process_filter(self, query_params):
+        geo_bounding_box_str = query_params.get(
+            V1_PARAMETERS_LIST.GEO_BOUNDING_BOX
+        )
+        geo_bounding_box = (
+            json.loads(geo_bounding_box_str) if geo_bounding_box_str else None
+        )
+
+        if geo_bounding_box and hasattr(
+            self.__builder, 'add_geo_bounding_box'
+        ):
+            self.__builder.add_geo_bounding_box(geo_bounding_box)

--- a/src/django/api/views/v1/opensearch_query_builder/production_locations_query_builder.py
+++ b/src/django/api/views/v1/opensearch_query_builder/production_locations_query_builder.py
@@ -129,3 +129,10 @@ class ProductionLocationsQueryBuilder(OpenSearchQueryBuilder):
             }
 
         return self.query_body
+
+    def add_geo_bounding_box(self, geo_bounding_box):
+        self.query_body['query']['bool']['filter'] = {
+            'geo_bounding_box': {
+                'coordinates': geo_bounding_box
+            }
+        }

--- a/src/django/api/views/v1/opensearch_query_builder/production_locations_query_builder.py
+++ b/src/django/api/views/v1/opensearch_query_builder/production_locations_query_builder.py
@@ -130,14 +130,14 @@ class ProductionLocationsQueryBuilder(OpenSearchQueryBuilder):
 
         return self.query_body
 
-    def add_geo_bounding_box(self, top, right, bottom, left):
+    def add_geo_bounding_box(self, top, left, bottom, right):
         self.query_body['query']['bool']['filter'] = {
             'geo_bounding_box': {
                 'coordinates': {
                     'top': top,
-                    'right': right,
+                    'left': left,
                     'bottom': bottom,
-                    'left': left
+                    'right': right,
                 }
             }
         }

--- a/src/django/api/views/v1/opensearch_query_builder/production_locations_query_builder.py
+++ b/src/django/api/views/v1/opensearch_query_builder/production_locations_query_builder.py
@@ -130,9 +130,14 @@ class ProductionLocationsQueryBuilder(OpenSearchQueryBuilder):
 
         return self.query_body
 
-    def add_geo_bounding_box(self, geo_bounding_box):
+    def add_geo_bounding_box(self, top, right, bottom, left):
         self.query_body['query']['bool']['filter'] = {
             'geo_bounding_box': {
-                'coordinates': geo_bounding_box
+                'coordinates': {
+                    'top': top,
+                    'right': right,
+                    'bottom': bottom,
+                    'left': left
+                }
             }
         }

--- a/src/django/api/views/v1/parameters_list.py
+++ b/src/django/api/views/v1/parameters_list.py
@@ -33,3 +33,4 @@ class V1_PARAMETERS_LIST:
     DATE_LT = 'date_lt'
     AGGREGATION = 'aggregation'
     GEOHEX_GRID_PRECISION = 'geohex_grid_precision'
+    GEO_BOUNDING_BOX = 'geo_bounding_box'

--- a/src/django/api/views/v1/utils.py
+++ b/src/django/api/views/v1/utils.py
@@ -38,6 +38,7 @@ def serialize_params(serializer_class, query_params):
             V1_PARAMETERS_LIST.DATE_LT,
             V1_PARAMETERS_LIST.GEOHEX_GRID_PRECISION,
             V1_PARAMETERS_LIST.AGGREGATION,
+            V1_PARAMETERS_LIST.GEO_BOUNDING_BOX
         ]:
             flattened_query_params[key] = value[0]
         else:

--- a/src/django/api/views/v1/utils.py
+++ b/src/django/api/views/v1/utils.py
@@ -23,7 +23,11 @@ def serialize_params(serializer_class, query_params):
             f'{V1_PARAMETERS_LIST.COORDINATES}[lat]',
             f'{V1_PARAMETERS_LIST.COORDINATES}[lng]',
             f'{V1_PARAMETERS_LIST.SEARCH_AFTER}[id]',
-            f'{V1_PARAMETERS_LIST.SEARCH_AFTER}[value]'
+            f'{V1_PARAMETERS_LIST.SEARCH_AFTER}[value]',
+            f'{V1_PARAMETERS_LIST.GEO_BOUNDING_BOX}[top]',
+            f'{V1_PARAMETERS_LIST.GEO_BOUNDING_BOX}[left]',
+            f'{V1_PARAMETERS_LIST.GEO_BOUNDING_BOX}[bottom]',
+            f'{V1_PARAMETERS_LIST.GEO_BOUNDING_BOX}[right]',
         ]:
             new_key = key.replace(']', '').replace('[', '_')
             flattened_query_params[new_key] = value[0]
@@ -38,7 +42,6 @@ def serialize_params(serializer_class, query_params):
             V1_PARAMETERS_LIST.DATE_LT,
             V1_PARAMETERS_LIST.GEOHEX_GRID_PRECISION,
             V1_PARAMETERS_LIST.AGGREGATION,
-            V1_PARAMETERS_LIST.GEO_BOUNDING_BOX
         ]:
             flattened_query_params[key] = value[0]
         else:

--- a/src/tests/v1/test_production_locations.py
+++ b/src/tests/v1/test_production_locations.py
@@ -144,14 +144,17 @@ class ProductionLocationsTest(BaseAPITest):
             index=self.production_locations_index_name
         )
 
-        query = "?geo_bounding_box[top]=41&geo_bounding_box[left]="
-        "-103&geo_bounding_box[bottom]=39&geo_bounding_box[right]=-101"
+        query = (
+            "?geo_bounding_box[top]=41&geo_bounding_box[left]="
+            "-103&geo_bounding_box[bottom]=39&geo_bounding_box[right]=-101"
+        )
         response = requests.get(
                 f"{self.root_url}/api/v1/production-locations/{query}",
                 headers=self.basic_headers,
             )
 
         result = response.json()
+        print('result >>>', result)
         self.assertIsNotNone(result['data'])
         self.assertEqual(len(result['data']), 1)
         self.assertEqual(result['data'][0]['os_id'], 'US2020052SV22KJ')

--- a/src/tests/v1/test_production_locations.py
+++ b/src/tests/v1/test_production_locations.py
@@ -154,7 +154,6 @@ class ProductionLocationsTest(BaseAPITest):
             )
 
         result = response.json()
-        print('result >>>', result)
         self.assertIsNotNone(result['data'])
         self.assertEqual(len(result['data']), 1)
         self.assertEqual(result['data'][0]['os_id'], 'US2020052SV22KJ')


### PR DESCRIPTION
[OSDEV-1577](https://opensupplyhub.atlassian.net/browse/OSDEV-1577) - [API] Add Geo-bounding box support to the production locations endpoint.

Added geo-bounding box query support to the GET `/api/v1/production-locations/` endpoint. To filter production locations whose geopoints fall within the bounding box, it is necessary to specify valid values for the parameters `geo_bounding_box[top]`, `geo_bounding_box[left]`, `geo_bounding_box[bottom]`, and `geo_bounding_box[right]`. 

The validation rules are as follows:

- All coordinates of the geo-boundary box (top, left, bottom, right) must be provided.
- All values must be integers.
- The top and bottom coordinates must be between -90 and 90.
- The left and right coordinates must be between -180 and 180.
- The top must be greater than the bottom.
- The right must be greater than the left.

[OSDEV-1577]: https://opensupplyhub.atlassian.net/browse/OSDEV-1577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ