### PR TITLE
[OSDEV-1779] SLC. Implement correct implementation of the Parent Company field and apply snake_case keys to request payload from production location info page

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -76,6 +76,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-1589](https://opensupplyhub.atlassian.net/browse/OSDEV-1589) - Fixed layout issue on new `contribute` page.
 * [OSDEV-1739](https://opensupplyhub.atlassian.net/browse/OSDEV-1739) - Applied state cleanup on modal unmount to prevent the same dialog from appearing when clicking on a different production location.
 * [OSDEV-1744](https://opensupplyhub.atlassian.net/browse/OSDEV-1744) - Fixed the issue where the text `by user ID:` appeared even when `user_id` was `null` in Contribution Record page.
+* [OSDEV-1779](https://opensupplyhub.atlassian.net/browse/OSDEV-1779) - SLC. Made Parent Company field as regular text field and apply snake_case keys to standard keys (e.g. `location_type`, `number_of_workers`, `parent_company`, `processing_type` and `product_type`) in request payload from production location info page to conform API specs.
 
 ### What's new
 * [OSDEV-1662](https://opensupplyhub.atlassian.net/browse/OSDEV-1662) - Added a new field, `action_perform_by`, to the moderation event. This data appears on the Contribution Record page when a moderator perform any actions like `APPROVED` or `REJECTED`.

--- a/src/react/src/__tests__/utils.tests.js
+++ b/src/react/src/__tests__/utils.tests.js
@@ -1973,7 +1973,7 @@ it('should process array fields and keep non-empty values', () => {
         address: '710 AUZERAIS AVE, SAN JOSE, CA, 95126',
         country: { value: 'US' },
         sector: ['Waste Management'],
-        parent_company: ['ParentCompanySingle'],
+        parent_company: 'ParentCompanySingle',
         product_type: ['Shirts', 'Pants'],
     };
 
@@ -1983,7 +1983,7 @@ it('should process array fields and keep non-empty values', () => {
         address: '710 AUZERAIS AVE, SAN JOSE, CA, 95126',
         country: 'US',
         sector: ['Waste Management'],
-        parent_company: ['ParentCompanySingle'],
+        parent_company: 'ParentCompanySingle',
         product_type: ['Shirts', 'Pants'],
     };
 

--- a/src/react/src/actions/contributeProductionLocation.js
+++ b/src/react/src/actions/contributeProductionLocation.js
@@ -65,7 +65,7 @@ export function createProductionLocation(contribData) {
     const parsedContribData = parseContribData(contribData);
 
     return async dispatch => {
-        dispatch(startCreateProductionLocation());
+        dispatch(startCreateProductionLocation(parsedContribData));
 
         try {
             const { data } = await apiRequest.post(
@@ -89,7 +89,7 @@ export function updateProductionLocation(contribData, osID) {
     const parsedContribData = parseContribData(contribData);
 
     return async dispatch => {
-        dispatch(startUpdateProductionLocation());
+        dispatch(startUpdateProductionLocation(parsedContribData));
 
         try {
             const { data } = await apiRequest.patch(

--- a/src/react/src/components/Contribute/ProductionLocationInfo.jsx
+++ b/src/react/src/components/Contribute/ProductionLocationInfo.jsx
@@ -97,7 +97,7 @@ const ProductionLocationInfo = ({
     const [locationType, setLocationType] = useState(null);
     const [processingType, setProcessingType] = useState(null);
     const [numberOfWorkers, setNumberOfWorkers] = useState('');
-    const [parentCompany, setParentCompany] = useState([]);
+    const [parentCompany, setParentCompany] = useState('');
     const customSelectComponents = { DropdownIndicator: null };
 
     useEffect(() => {
@@ -160,6 +160,9 @@ const ProductionLocationInfo = ({
     const handleAddressChange = event => {
         setAddressTouched(true);
         setInputAddress(event.target.value);
+    };
+    const handleParentCompanyChange = event => {
+        setParentCompany(event.target.value);
     };
 
     let handleProductionLocation;
@@ -243,11 +246,7 @@ const ProductionLocationInfo = ({
                 'processing_type',
                 setProcessingType,
             );
-            updateStateFromData(
-                singleProductionLocationData,
-                'parent_company',
-                setParentCompany,
-            );
+            setParentCompany(singleProductionLocationData.parent_company ?? '');
         }
     }, [singleProductionLocationData, osID]);
 
@@ -728,11 +727,11 @@ const ProductionLocationInfo = ({
                                             InputProps={{
                                                 classes: {
                                                     input: `
-                                            ${
-                                                !isValidNumberOfWorkers(
-                                                    numberOfWorkers,
-                                                ) && classes.errorStyle
-                                            }`,
+                                                    ${
+                                                        !isValidNumberOfWorkers(
+                                                            numberOfWorkers,
+                                                        ) && classes.errorStyle
+                                                    }`,
                                                     notchedOutline:
                                                         classes.notchedOutlineStyles,
                                                 },
@@ -757,16 +756,20 @@ const ProductionLocationInfo = ({
                                             majority ownership for this
                                             production.
                                         </Typography>
-                                        <StyledSelect
-                                            creatable
-                                            name="Parent company"
+                                        <TextField
+                                            id="parent_company"
+                                            className={classes.textInputStyles}
                                             value={parentCompany}
-                                            onChange={setParentCompany}
+                                            onChange={handleParentCompanyChange}
                                             placeholder="Enter the parent company"
+                                            variant="outlined"
                                             aria-label="Parent company"
-                                            styles={selectStyles}
-                                            className={classes.selectStyles}
-                                            components={customSelectComponents}
+                                            InputProps={{
+                                                classes: {
+                                                    notchedOutline:
+                                                        classes.notchedOutlineStyles,
+                                                },
+                                            }}
                                         />
                                     </div>
                                 </>

--- a/src/react/src/util/util.js
+++ b/src/react/src/util/util.js
@@ -6,6 +6,7 @@ import flatten from 'lodash/flatten';
 import identity from 'lodash/identity';
 import split from 'lodash/split';
 import last from 'lodash/last';
+import snakeCase from 'lodash/snakeCase';
 import some from 'lodash/some';
 import size from 'lodash/size';
 import negate from 'lodash/negate';
@@ -34,6 +35,7 @@ import includes from 'lodash/includes';
 import join from 'lodash/join';
 import map from 'lodash/map';
 import mapValues from 'lodash/mapValues';
+import mapKeys from 'lodash/mapKeys';
 import uniq from 'lodash/uniq';
 import has from 'lodash/has';
 import { isURL, isInt } from 'validator';
@@ -1454,20 +1456,24 @@ export const generateRangeField = value => {
     return { min: Number(value), max: Number(value) };
 };
 
-export const parseContribData = contribData => {
-    // eslint-disable-next-line camelcase
-    const { numberOfWorkers, country, ...fields } = contribData;
+const convertToSnakeFields = fields =>
+    mapKeys(fields, (value, key) => snakeCase(key));
 
-    const countryValue = country?.value;
-
-    const transformedFields = mapValues(
+const filterNonEmptyFields = fields =>
+    mapValues(
         pickBy(fields, value => !isEmpty(value)),
         extractProductionLocationContributionValues,
     );
 
+export const parseContribData = contribData => {
+    const { numberOfWorkers, country, ...fields } = contribData;
+    const countryValue = country?.value;
+
+    const filteredFields = filterNonEmptyFields(fields);
+    const snakeCaseFields = convertToSnakeFields(filteredFields);
+
     return {
-        ...transformedFields,
-        // eslint-disable-next-line camelcase
+        ...snakeCaseFields,
         ...(numberOfWorkers && {
             number_of_workers: generateRangeField(numberOfWorkers),
         }),


### PR DESCRIPTION
Pre-prod fix for [OSDEV-1779](https://opensupplyhub.atlassian.net/browse/OSDEV-1779) 
1. Make Parent Company field as regular text field.
2. Apply snake_case keys to standard keys (e.g. `location_type`, `number_of_workers`, `parent_company`, `processing_type` and `product_type`) in request payload from production location info page to conform API specs.

[OSDEV-1779]: https://opensupplyhub.atlassian.net/browse/OSDEV-1779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ