### PR TITLE
[OSDEV-1806] Fix parent company validation

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-1777](https://opensupplyhub.atlassian.net/browse/OSDEV-1777) - A consistent URL style was established across all pages of the SLC workflow. After the changes, the URL begins from `/contribute/single-location/`.
 * [OSDEV-1678](https://opensupplyhub.atlassian.net/browse/OSDEV-1678) - Added asterisks next to each required form field (Name, Address, and Country) on the "Production Location Information" page. Highlighted an empty field and displayed an error message if it loses focus.
 * [OSDEV-1778](https://opensupplyhub.atlassian.net/browse/OSDEV-1778) - Fixed the validation for number of workers field in POST, PATCH production locations API. The min field must be less than or equal to the max field.
+* [OSDEV-1806](https://opensupplyhub.atlassian.net/browse/OSDEV-1806) - Refactored Parent Company field validation.
 
 ### What's new
 * *Describe what's new here. The changes that can impact user experience should be listed in this section.*

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -13,7 +13,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-1806](https://opensupplyhub.atlassian.net/browse/OSDEV-1806) - Refactored the Parent Company field validation. The field is now validated as a regular character field.
 
 ### Release instructions:
-* *Provide release instructions here.*
+* Ensure that the following commands are included in the `post_deployment` command:
+    * `migrate`
+    * `reindex_database`
 
 
 ## Release 1.31.0

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -3,6 +3,19 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). The format is based on the `RELEASE-NOTES-TEMPLATE.md` file.
 
+## Release 1.32
+
+## Introduction
+* Product name: Open Supply Hub
+* Release date: March 22, 2025
+
+### Bugfix
+* [OSDEV-1806](https://opensupplyhub.atlassian.net/browse/OSDEV-1806) - Refactored the Parent Company field validation. The field is now validated as a regular character field.
+
+### Release instructions:
+* *Provide release instructions here.*
+
+
 ## Release 1.31.0
 
 ## Introduction
@@ -29,7 +42,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-1777](https://opensupplyhub.atlassian.net/browse/OSDEV-1777) - A consistent URL style was established across all pages of the SLC workflow. After the changes, the URL begins from `/contribute/single-location/`.
 * [OSDEV-1678](https://opensupplyhub.atlassian.net/browse/OSDEV-1678) - Added asterisks next to each required form field (Name, Address, and Country) on the "Production Location Information" page. Highlighted an empty field and displayed an error message if it loses focus.
 * [OSDEV-1778](https://opensupplyhub.atlassian.net/browse/OSDEV-1778) - Fixed the validation for number of workers field in POST, PATCH production locations API. The min field must be less than or equal to the max field.
-* [OSDEV-1806](https://opensupplyhub.atlassian.net/browse/OSDEV-1806) - Refactored Parent Company field validation.
 
 ### What's new
 * [OSDEV-1764](https://opensupplyhub.atlassian.net/browse/OSDEV-1764) - Added a new claiming email for the Moderation queue/SLC workflow, which is sent once a data moderator creates a new location based on the moderation event the customer submitted through the SLC workflow.

--- a/src/django/api/serializers/v1/production_location_schema_serializer.py
+++ b/src/django/api/serializers/v1/production_location_schema_serializer.py
@@ -3,7 +3,6 @@ from api.serializers.v1.coordinates_serializer \
 from api.serializers.v1.number_of_workers_serializer \
   import NumberOfWorkersSerializer
 from api.serializers.v1.string_or_list_field import StringOrListField
-from django.core.validators import RegexValidator
 from rest_framework import serializers
 
 
@@ -35,14 +34,8 @@ class ProductionLocationSchemaSerializer(serializers.Serializer):
     )
     sector = StringOrListField(required=False)
     parent_company = serializers.CharField(
+        max_length=200,
         required=False,
-        validators=[
-            RegexValidator(
-                regex=r'^[a-zA-Z0-9\s.,&()-]*$',
-                message=("Field parent_company must contain only letters, "
-                         "numbers, spaces, and allowed symbols (, . & - ()).")
-            )
-        ],
         error_messages={
             'invalid': 'Field parent_company must be a valid string.'
         },
@@ -62,7 +55,6 @@ class ProductionLocationSchemaSerializer(serializers.Serializer):
     )
 
     def _validate_string_field(self, data, field_name):
-        """Helper method to validate string fields aren't numeric."""
         if field_name in data and data[field_name].isdigit():
             return {
                 "field": field_name,

--- a/src/django/api/tests/test_production_locations_create.py
+++ b/src/django/api/tests/test_production_locations_create.py
@@ -1,5 +1,4 @@
 import json
-
 from unittest.mock import Mock, patch
 from rest_framework.test import APITestCase
 from django.urls import reverse
@@ -196,7 +195,6 @@ class TestProductionLocationsCreate(APITestCase):
             '%Y-%m-%dT%H:%M:%S.%f'
         ) + 'Z'
 
-        # Check the response.
         self.assertEqual(
             response_body_dict.get('moderation_status'),
             'PENDING'
@@ -222,26 +220,40 @@ class TestProductionLocationsCreate(APITestCase):
         expected_response_body = {
             'detail': 'The request body is invalid.',
             'errors': [
-                {'field': 'sector',
-                 'detail': ('Field sector must be '
-                            'a string or a list of strings.')
-                 },
-                {'field': 'location_type',
-                 'detail': ('Field location_type must be a string'
-                            ' or a list of strings.')
-                 },
-                {'field': 'number_of_workers',
-                 'errors': [
-                            {'field': 'min',
-                             'detail': ('Ensure this value is greater than'
-                                        ' or equal to 1.')
-                             },
-                            {'field': 'max',
-                             'detail': ('Ensure this value is greater than'
-                                        ' or equal to 1.')
-                             }
-                            ]
-                 }
+                {
+                    'field': 'sector',
+                    'detail':
+                        (
+                            'Field sector must be '
+                            'a string or a list of strings.'
+                        )
+                },
+                {
+                    'field': 'location_type',
+                    'detail': (
+                        'Field location_type must be a string'
+                        ' or a list of strings.'
+                    )
+                },
+                {
+                    'field': 'number_of_workers',
+                    'errors': [
+                        {
+                            'field': 'min',
+                            'detail': (
+                                'Ensure this value is greater than'
+                                ' or equal to 1.'
+                            )
+                        },
+                        {
+                            'field': 'max',
+                            'detail': (
+                                'Ensure this value is greater than'
+                                ' or equal to 1.'
+                            )
+                        }
+                    ]
+                }
             ]
          }
         initial_moderation_event_count = ModerationEvent.objects.count()
@@ -287,3 +299,107 @@ class TestProductionLocationsCreate(APITestCase):
         # Ensure that no ModerationEvent record has been created.
         self.assertEqual(ModerationEvent.objects.count(),
                          initial_moderation_event_count)
+
+    @patch('api.geocoding.requests.get')
+    def test_moderation_event_not_created_with_invalid_parent_company(
+            self,
+            mock_get):
+        mock_get.return_value = Mock(ok=True, status_code=200)
+        mock_get.return_value.json.return_value = geocoding_data
+
+        expected_response_body = {
+            'detail': 'The request body is invalid.',
+            'errors': [
+                {
+                    'field': 'parent_company',
+                    'detail': (
+                        'Field parent_company must be a string'
+                        ' not a number.'
+                    )
+                },
+            ]
+         }
+        initial_moderation_event_count = ModerationEvent.objects.count()
+
+        invalid_req_body = json.dumps({
+            'source': 'API',
+            'name': 'Blue Horizon Facility',
+            'address': '990 Spring Garden St., Philadelphia PA 19123',
+            'country': 'US',
+            'parent_company': 12345,
+        })
+
+        response = self.client.post(
+            self.url,
+            invalid_req_body,
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code,
+                         status.HTTP_422_UNPROCESSABLE_ENTITY)
+
+        response_body_dict = json.loads(response.content)
+        self.assertEqual(response_body_dict, expected_response_body)
+        self.assertEqual(ModerationEvent.objects.count(),
+                         initial_moderation_event_count)
+
+    @patch('api.geocoding.requests.get')
+    def test_moderation_event_created_with_valid_parent_company(
+            self,
+            mock_get):
+        mock_get.return_value = Mock(ok=True, status_code=200)
+        mock_get.return_value.json.return_value = geocoding_data
+
+        special_characters = '&@, \' _ #()'
+        numbers = '1234567890'
+        multi_lang_letters = '贾建龙ÖrmeTİCіїъыParentCompanyการผลิตהפָקָהผลิต'
+        valid_parent_company = (
+            special_characters +
+            numbers +
+            multi_lang_letters
+        )
+
+        valid_req_body = json.dumps({
+            'source': 'SLC',
+            'name': 'Blue Horizon Facility',
+            'address': '990 Spring Garden St., Philadelphia PA 19123',
+            'country': 'US',
+            'parent_company': valid_parent_company
+        })
+
+        response = self.client.post(
+            self.url,
+            valid_req_body,
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 202)
+
+        response_body_dict = json.loads(response.content)
+        response_moderation_id = response_body_dict.get('moderation_id')
+        moderation_event = ModerationEvent.objects.get(
+            pk=response_moderation_id
+        )
+        stringified_created_at = moderation_event.created_at.strftime(
+            '%Y-%m-%dT%H:%M:%S.%f'
+        ) + 'Z'
+
+        self.assertEqual(
+            response_body_dict.get('moderation_status'),
+            'PENDING'
+        )
+        self.assertEqual(
+            response_body_dict.get('created_at'),
+            stringified_created_at
+        )
+        self.assertEqual(
+            response_moderation_id,
+            str(moderation_event.uuid)
+        )
+        self.assertIn("cleaned_data", response_body_dict)
+        parent_company = (
+            response_body_dict
+            .get('cleaned_data', {})
+            .get('fields', {})
+            .get('parent_company')
+        )
+        self.assertEqual(len(response_body_dict), 4)
+        self.assertEqual(parent_company, valid_parent_company)

--- a/src/django/api/tests/test_production_locations_create.py
+++ b/src/django/api/tests/test_production_locations_create.py
@@ -1,4 +1,5 @@
 import json
+
 from unittest.mock import Mock, patch
 from rest_framework.test import APITestCase
 from django.urls import reverse
@@ -313,7 +314,7 @@ class TestProductionLocationsCreate(APITestCase):
                 {
                     'field': 'parent_company',
                     'detail': (
-                        'Field parent_company must be a string'
+                        'Field parent_company must be a string,'
                         ' not a number.'
                     )
                 },
@@ -343,7 +344,7 @@ class TestProductionLocationsCreate(APITestCase):
                          initial_moderation_event_count)
 
     @patch('api.geocoding.requests.get')
-    def test_moderation_event_created_with_valid_parent_company(
+    def test_moderation_event_created_with_valid_char_field(
             self,
             mock_get):
         mock_get.return_value = Mock(ok=True, status_code=200)
@@ -352,7 +353,7 @@ class TestProductionLocationsCreate(APITestCase):
         special_characters = '&@, \' _ #()'
         numbers = '1234567890'
         multi_lang_letters = '贾建龙ÖrmeTİCіїъыParentCompanyการผลิตהפָקָהผลิต'
-        valid_parent_company = (
+        valid_char_field = (
             special_characters +
             numbers +
             multi_lang_letters
@@ -360,10 +361,10 @@ class TestProductionLocationsCreate(APITestCase):
 
         valid_req_body = json.dumps({
             'source': 'SLC',
-            'name': 'Blue Horizon Facility',
+            'name': valid_char_field,
             'address': '990 Spring Garden St., Philadelphia PA 19123',
             'country': 'US',
-            'parent_company': valid_parent_company
+            'parent_company': valid_char_field
         })
 
         response = self.client.post(
@@ -395,6 +396,11 @@ class TestProductionLocationsCreate(APITestCase):
             str(moderation_event.uuid)
         )
         self.assertIn("cleaned_data", response_body_dict)
+        name = (
+            response_body_dict
+            .get('cleaned_data', {})
+            .get('name')
+        )
         parent_company = (
             response_body_dict
             .get('cleaned_data', {})
@@ -402,4 +408,5 @@ class TestProductionLocationsCreate(APITestCase):
             .get('parent_company')
         )
         self.assertEqual(len(response_body_dict), 4)
-        self.assertEqual(parent_company, valid_parent_company)
+        self.assertEqual(name, valid_char_field)
+        self.assertEqual(parent_company, valid_char_field)

--- a/src/django/api/tests/test_production_locations_partial_update.py
+++ b/src/django/api/tests/test_production_locations_partial_update.py
@@ -380,7 +380,7 @@ class TestProductionLocationsPartialUpdate(APITestCase):
                 {
                     'field': 'parent_company',
                     'detail': (
-                        'Field parent_company must be a string'
+                        'Field parent_company must be a string,'
                         ' not a number.'
                     )
                 },
@@ -410,7 +410,7 @@ class TestProductionLocationsPartialUpdate(APITestCase):
                          initial_moderation_event_count)
 
     @patch('api.geocoding.requests.get')
-    def test_moderation_event_created_with_valid_parent_company(
+    def test_moderation_event_created_with_valid_char_field(
             self,
             mock_get):
         mock_get.return_value = Mock(ok=True, status_code=200)
@@ -419,7 +419,7 @@ class TestProductionLocationsPartialUpdate(APITestCase):
         special_characters = '&@, \' _ #()'
         numbers = '1234567890'
         multi_lang_letters = '贾建龙ÖrmeTİCіїъыParentCompanyการผลิตהפָקָהผลิต'
-        valid_parent_company = (
+        valid_char_field = (
             special_characters +
             numbers +
             multi_lang_letters
@@ -427,10 +427,10 @@ class TestProductionLocationsPartialUpdate(APITestCase):
 
         valid_req_body = json.dumps({
             'source': 'SLC',
-            'name': 'Blue Horizon Facility',
+            'name': valid_char_field,
             'address': '990 Spring Garden St., Philadelphia PA 19123',
             'country': 'US',
-            'parent_company': valid_parent_company
+            'parent_company': valid_char_field
         })
 
         response = self.client.patch(
@@ -462,6 +462,11 @@ class TestProductionLocationsPartialUpdate(APITestCase):
             str(moderation_event.uuid)
         )
         self.assertIn("cleaned_data", response_body_dict)
+        name = (
+            response_body_dict
+            .get('cleaned_data', {})
+            .get('name')
+        )
         parent_company = (
             response_body_dict
             .get('cleaned_data', {})
@@ -469,4 +474,5 @@ class TestProductionLocationsPartialUpdate(APITestCase):
             .get('parent_company')
         )
         self.assertEqual(len(response_body_dict), 4)
-        self.assertEqual(parent_company, valid_parent_company)
+        self.assertEqual(name, valid_char_field)
+        self.assertEqual(parent_company, valid_char_field)

--- a/src/django/api/tests/test_production_locations_partial_update.py
+++ b/src/django/api/tests/test_production_locations_partial_update.py
@@ -473,6 +473,6 @@ class TestProductionLocationsPartialUpdate(APITestCase):
             .get('fields', {})
             .get('parent_company')
         )
-        self.assertEqual(len(response_body_dict), 4)
+        self.assertEqual(len(response_body_dict), 5)
         self.assertEqual(name, valid_char_field)
         self.assertEqual(parent_company, valid_char_field)


### PR DESCRIPTION
Fix [https://opensupplyhub.atlassian.net/browse/OSDEV-1806](https://opensupplyhub.atlassian.net/browse/OSDEV-1806)
1. Set `parent_company` field as regular char field.
2. Updated tests for POST and PATCH `v1/production-locations`