### PR TITLE
[OSDEV-1814] Add toggle switch for Additional data section

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -3,35 +3,19 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). The format is based on the `RELEASE-NOTES-TEMPLATE.md` file.
 
-## Release 2.0.0
+## Release 1.32.0
 
 ## Introduction
 * Product name: Open Supply Hub
 * Release date: March 22, 2025
 
-### Database changes
-* *Describe high-level database changes.*
-
-#### Migrations:
-* *Describe migrations here.*
-
-#### Schema changes
-* *Describe schema changes here.*
-
-### Code/API changes
-* *Describe code/API changes here.*
-
-### Architecture/Environment changes
-* *Describe architecture/environment changes here.*
-
-### Bugfix
-* *Describe bugfix here.*
-
 ### What's new
 * [OSDEV-1814](https://opensupplyhub.atlassian.net/browse/OSDEV-1814) - Added toggle switch button for production location info page to render additional data if necessary. If toggle switch button is inactive (default behavior), additional data won't be send to the server along with name, address and country.
 
 ### Release instructions:
-* *Provide release instructions here.*
+* Ensure that the following commands are included in the `post_deployment` command:
+    * `migrate`
+    * `reindex_database`
 
 
 ## Release 1.31.0

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -3,6 +3,37 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). The format is based on the `RELEASE-NOTES-TEMPLATE.md` file.
 
+## Release 2.0.0
+
+## Introduction
+* Product name: Open Supply Hub
+* Release date: March 22, 2025
+
+### Database changes
+* *Describe high-level database changes.*
+
+#### Migrations:
+* *Describe migrations here.*
+
+#### Schema changes
+* *Describe schema changes here.*
+
+### Code/API changes
+* *Describe code/API changes here.*
+
+### Architecture/Environment changes
+* *Describe architecture/environment changes here.*
+
+### Bugfix
+* *Describe bugfix here.*
+
+### What's new
+* [OSDEV-1814](https://opensupplyhub.atlassian.net/browse/OSDEV-1814) - Added toggle switch button for production location info page to render additional data if necessary. If toggle switch button is inactive (default behavior), additional data won't be send to the server along with name, address and country.
+
+### Release instructions:
+* *Provide release instructions here.*
+
+
 ## Release 1.31.0
 
 ## Introduction

--- a/src/react/src/__tests__/components/ProductionLocationInfo.test.js
+++ b/src/react/src/__tests__/components/ProductionLocationInfo.test.js
@@ -286,5 +286,9 @@ describe("ProductionLocationInfo component, test invalid incoming data for UPDAT
         expect(getByText("Enter the number of workers as a number or range")).toBeInTheDocument();
 
         expect(updateButton).toBeDisabled();
+
+        fireEvent.click(switchButton);
+        expect(queryByText("Enter the number of workers as a number or range")).not.toBeInTheDocument();
+        expect(updateButton).toBeEnabled();
     });
 });

--- a/src/react/src/__tests__/components/ProductionLocationInfo.test.js
+++ b/src/react/src/__tests__/components/ProductionLocationInfo.test.js
@@ -270,7 +270,7 @@ describe("ProductionLocationInfo component, test invalid incoming data for UPDAT
             { preloadedState: defaultState },
         )
 
-    test("submit button should be enabled when number of workers invalid but additional info is hidden", () => {
+    test("update button should be enabled when number of workers invalid but additional info is hidden", () => {
         const { getByRole, getByText, getByTestId, getByPlaceholderText, queryByText } = renderComponent();
 
         expect(queryByText("Enter the number of workers as a number or range")).not.toBeInTheDocument();

--- a/src/react/src/__tests__/components/ProductionLocationInfo.test.js
+++ b/src/react/src/__tests__/components/ProductionLocationInfo.test.js
@@ -1,6 +1,6 @@
 import React from "react";
-import { fireEvent, waitFor } from "@testing-library/react";
-import { BrowserRouter as Router } from "react-router-dom";
+import { fireEvent } from "@testing-library/react";
+import { MemoryRouter, Route, BrowserRouter as Router } from "react-router-dom";
 
 import ProductionLocationInfo from "../../components/Contribute/ProductionLocationInfo";
 import renderWithProviders from "../../util/testUtils/renderWithProviders";
@@ -60,7 +60,7 @@ describe("ProductionLocationInfo component, test input fields for POST v1/produc
             </Router>,
             { preloadedState: defaultState },
         )
-    /*
+
     test("renders the production location form", () => {
         const { getByText, getByPlaceholderText, getAllByText, getByTestId } = renderComponent();
 
@@ -160,12 +160,9 @@ describe("ProductionLocationInfo component, test input fields for POST v1/produc
         expect(queryByText("Number of Workers")).not.toBeInTheDocument();
         expect(queryByText("Parent Company")).not.toBeInTheDocument();
     });
-    */
 
-    test("displays error when number of workers is not a valid number and disable submit button", async () => {
+    test("displays error when number of workers is not a valid number and disable submit button", () => {
         const { getByRole, getByPlaceholderText, getByTestId } = renderComponent();
-
-        // await waitFor(() => console.log(document.body.innerHTML));
 
         const submitButton = getByRole("button", { name: /Submit/i });
         expect(submitButton).toBeDisabled();
@@ -180,31 +177,29 @@ describe("ProductionLocationInfo component, test input fields for POST v1/produc
 
         expect(submitButton).toBeEnabled();
 
-        // await waitFor(() => console.log(document.body.innerHTML));
-
         const switchButton = getByTestId("switch-additional-info-fields");
         expect(switchButton).not.toBeChecked();
 
         fireEvent.click(switchButton);
         expect(switchButton).toBeChecked();
 
-        const numberInput = getByPlaceholderText("Enter the number of workers as a number or range");
-        fireEvent.change(numberInput, { target: { value: "Test" } });
+        const numberOfWorkersInput = getByPlaceholderText("Enter the number of workers as a number or range");
+        fireEvent.change(numberOfWorkersInput, { target: { value: "Test" } });
 
         expect(getByPlaceholderText("Enter the number of workers as a number or range")).toHaveAttribute("aria-invalid", "true");
         expect(submitButton).toBeDisabled();
 
-        fireEvent.change(numberInput, { target: { value: "100" } });
+        fireEvent.change(numberOfWorkersInput, { target: { value: "100" } });
 
         expect(getByPlaceholderText("Enter the number of workers as a number or range")).toHaveAttribute("aria-invalid", "false");
         expect(submitButton).toBeEnabled();
 
-        fireEvent.change(numberInput, { target: { value: "100-150" } });
+        fireEvent.change(numberOfWorkersInput, { target: { value: "100-150" } });
 
         expect(getByPlaceholderText("Enter the number of workers as a number or range")).toHaveAttribute("aria-invalid", "false");
         expect(submitButton).toBeEnabled();
 
-        fireEvent.change(numberInput, { target: { value: "200-100" } });
+        fireEvent.change(numberOfWorkersInput, { target: { value: "200-100" } });
 
         expect(getByPlaceholderText("Enter the number of workers as a number or range")).toHaveAttribute("aria-invalid", "true");
         expect(submitButton).toBeDisabled();
@@ -212,6 +207,7 @@ describe("ProductionLocationInfo component, test input fields for POST v1/produc
 });
 
 describe("ProductionLocationInfo component, test invalid incoming data for UPDATE v1/production-locations", () => {
+    const osID = 'GR2019098DC1P4A';
     const defaultState = {
         auth: {
             user: { user: { isAnon: false } },
@@ -226,7 +222,7 @@ describe("ProductionLocationInfo component, test invalid incoming data for UPDAT
                         lat: 40.6875863,
                         lng: 22.9389083
                     },
-                    os_id: 'GR2019098DC1P4A',
+                    os_id: osID,
                     location_type: ['Apparel'],
                     country: {
                         name: 'Greece',
@@ -265,24 +261,29 @@ describe("ProductionLocationInfo component, test invalid incoming data for UPDAT
 
     const renderComponent = (props = {}) =>
         renderWithProviders(
-            <Router>
-                <ProductionLocationInfo {...defaultProps} {...props} />
-            </Router>,
+            <MemoryRouter initialEntries={[`/contribute/single-location/${osID}/info/`]}>
+                <Route 
+                    path="/contribute/single-location/:osID/info/"
+                    component={() => <ProductionLocationInfo {...defaultProps} {...props} />}
+                />
+            </MemoryRouter>,
             { preloadedState: defaultState },
         )
 
-    test("submit button should be enabled when number of workers invalid but additional info is hidden", async () => {
-        const { getByRole, getByTestId } = renderComponent();
+    test("submit button should be enabled when number of workers invalid but additional info is hidden", () => {
+        const { getByRole, getByText, getByTestId, getByPlaceholderText, queryByText } = renderComponent();
 
-        // await waitFor(() => console.log(document.body.innerHTML));
+        expect(queryByText("Enter the number of workers as a number or range")).not.toBeInTheDocument();
 
         const updateButton = getByRole("button", { name: /Update/i });
-
-        await waitFor(() => console.log(document.body.innerHTML));
         expect(updateButton).toBeEnabled();
 
         const switchButton = getByTestId("switch-additional-info-fields");
         fireEvent.click(switchButton);
+
+        const numberOfWorkersInput = getByPlaceholderText("Enter the number of workers as a number or range");
+        expect(numberOfWorkersInput).toHaveAttribute("aria-invalid", "true");
+        expect(getByText("Enter the number of workers as a number or range")).toBeInTheDocument();
 
         expect(updateButton).toBeDisabled();
     });

--- a/src/react/src/util/styles.js
+++ b/src/react/src/util/styles.js
@@ -1286,14 +1286,14 @@ export const productionLocationInfoStyles = theme =>
             width: '100%',
             alignItems: 'center',
         }),
-        marginRight: Object.freeze({
-            marginRight: '20px',
-        }),
         buttonsContainerStyles: Object.freeze({
             display: 'flex',
             flexDirection: 'row',
             width: '100%',
             justifyContent: 'center',
+        }),
+        switchButton: Object.freeze({
+            marginTop: '10px',
         }),
         selectStyles: Object.freeze({
             maxWidth: '528px',


### PR DESCRIPTION
Fix [OSDEV-1814]( https://opensupplyhub.atlassian.net/browse/OSDEV-1814)

1. Replaced arrow dropdown icon by toggle switch button in production location info page.
2. When go to update flow (`contribute/single-location/{os_id}/info/`), Update button is active by default. 
3. _Additional data_ section hidden by default for update and create new production location flows.
4. When _Additional dat_a section expanded, update button can be disabled due to invalid incoming fields (such as number of workers range that starts from zero).
5.  When _Additional data_ section expanded, pre-filled values will be send to the server along with name, country and address values. This applies event if user just expand _Additional data_ section and don't input any data from their side.

[OSDEV-1814]: https://opensupplyhub.atlassian.net/browse/OSDEV-1814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ