### PR TITLE
[OSDEV-1789] SLC. "Search results" scrolls from the bottom

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Bugfix
 * [OSDEV-1806](https://opensupplyhub.atlassian.net/browse/OSDEV-1806) - Refactored the Parent Company field validation. The field is now validated as a regular character field.
+* [OSDEV-1789](https://opensupplyhub.atlassian.net/browse/OSDEV-1789) - Fixed an issue where the scroll position was not resetting to the top when navigating through SLC workflow pages.
 
 ### Release instructions:
 * Ensure that the following commands are included in the `post_deployment` command:

--- a/src/react/src/components/Contribute/ContributeProductionLocation.jsx
+++ b/src/react/src/components/Contribute/ContributeProductionLocation.jsx
@@ -11,6 +11,7 @@ import SearchByOsIdTab from './SearchByOsIdTab';
 import SearchByNameAndAddressTab from './SearchByNameAndAddressTab';
 import RequireAuthNotice from '../RequireAuthNotice';
 import { makeContributeProductionLocationStyles } from '../../util/styles';
+import { useResetScrollPosition } from '../../util/hooks';
 
 const TAB_OS_ID = 'os-id';
 const TAB_NAME_ADDRESS = 'name-address';
@@ -32,9 +33,7 @@ const ContributeProductionLocation = ({
         VALID_TABS.includes(tabInQuery) ? tabInQuery : TAB_NAME_ADDRESS,
     );
 
-    useEffect(() => {
-        window.scrollTo(0, 0);
-    }, [location]);
+    useResetScrollPosition(location);
 
     useEffect(() => {
         if (VALID_TABS.includes(tabInQuery)) {

--- a/src/react/src/components/Contribute/ContributeProductionLocation.jsx
+++ b/src/react/src/components/Contribute/ContributeProductionLocation.jsx
@@ -33,6 +33,10 @@ const ContributeProductionLocation = ({
     );
 
     useEffect(() => {
+        window.scrollTo(0, 0);
+    }, [location]);
+
+    useEffect(() => {
         if (VALID_TABS.includes(tabInQuery)) {
             setSelectedTab(tabInQuery);
         } else {

--- a/src/react/src/components/Contribute/ProductionLocationInfo.jsx
+++ b/src/react/src/components/Contribute/ProductionLocationInfo.jsx
@@ -17,6 +17,7 @@ import RequireAuthNotice from '../RequireAuthNotice';
 import StyledSelect from '../Filters/StyledSelect';
 import RequiredAsterisk from '../RequiredAsterisk';
 import { productionLocationInfoStyles } from '../../util/styles';
+import { useResetScrollPosition } from '../../util/hooks';
 import {
     countryOptionsPropType,
     facilityProcessingTypeOptionsPropType,
@@ -108,9 +109,7 @@ const ProductionLocationInfo = ({
     const customSelectComponents = { DropdownIndicator: null };
     const isCountryError = countryTouched && !inputCountry?.value;
 
-    useEffect(() => {
-        window.scrollTo(0, 0);
-    }, [location]);
+    useResetScrollPosition(location);
 
     const inputData = useMemo(
         () => ({

--- a/src/react/src/components/Contribute/SearchByNameAndAddressResult.jsx
+++ b/src/react/src/components/Contribute/SearchByNameAndAddressResult.jsx
@@ -34,6 +34,10 @@ const SearchByNameAndAddressResult = ({
     const location = useLocation();
 
     useEffect(() => {
+        window.scrollTo(0, 0);
+    }, [location]);
+
+    useEffect(() => {
         const searchParams = new URLSearchParams(location.search);
         const name = searchParams.get('name');
         const address = searchParams.get('address');

--- a/src/react/src/components/Contribute/SearchByNameAndAddressResult.jsx
+++ b/src/react/src/components/Contribute/SearchByNameAndAddressResult.jsx
@@ -20,6 +20,7 @@ import {
 import history from '../../util/history';
 import { productionLocationPropType } from '../../util/propTypes';
 import { makeSearchByNameAndAddressResultStyles } from '../../util/styles';
+import { useResetScrollPosition } from '../../util/hooks';
 
 const SearchByNameAndAddressResult = ({
     data: productionLocations,
@@ -33,9 +34,7 @@ const SearchByNameAndAddressResult = ({
     const TITLE = 'Production Location Search';
     const location = useLocation();
 
-    useEffect(() => {
-        window.scrollTo(0, 0);
-    }, [location]);
+    useResetScrollPosition(location);
 
     useEffect(() => {
         const searchParams = new URLSearchParams(location.search);

--- a/src/react/src/components/Contribute/SearchByOsIdResult.jsx
+++ b/src/react/src/components/Contribute/SearchByOsIdResult.jsx
@@ -16,6 +16,7 @@ import {
 } from '../../actions/contributeProductionLocation';
 import { contributeProductionLocationRoute } from '../../util/constants';
 import { makeSearchByOsIdResultStyles } from '../../util/styles';
+import { useResetScrollPosition } from '../../util/hooks';
 import { productionLocationPropType } from '../../util/propTypes';
 
 import BackToSearchButton from './BackToSearchButton';
@@ -36,9 +37,7 @@ const SearchByOsIdResult = ({
     const location = useLocation();
     const { osID } = useParams();
 
-    useEffect(() => {
-        window.scrollTo(0, 0);
-    }, [location]);
+    useResetScrollPosition(location);
 
     useEffect(() => {
         if (osID) {

--- a/src/react/src/components/Contribute/SearchByOsIdResult.jsx
+++ b/src/react/src/components/Contribute/SearchByOsIdResult.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useHistory, useParams } from 'react-router-dom';
+import { useHistory, useParams, useLocation } from 'react-router-dom';
 import { connect } from 'react-redux';
 import isEmpty from 'lodash/isEmpty';
 import { object, bool, func } from 'prop-types';
@@ -33,7 +33,12 @@ const SearchByOsIdResult = ({
 }) => {
     const TITLE = 'Production Location Search';
     const history = useHistory();
+    const location = useLocation();
     const { osID } = useParams();
+
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, [location]);
 
     useEffect(() => {
         if (osID) {

--- a/src/react/src/util/hooks.js
+++ b/src/react/src/util/hooks.js
@@ -374,3 +374,9 @@ export const useFileUploadHandler = ({
 
     return { fileInput };
 };
+
+export const useResetScrollPosition = location => {
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, [location]);
+};


### PR DESCRIPTION
[OSDEV-1789](https://opensupplyhub.atlassian.net/browse/OSDEV-1789) **SLC. "Search results" scrolls from the bottom**

- Fixed an issue where the scroll position was not resetting to the top when navigating through SLC workflow pages.

[OSDEV-1789]: https://opensupplyhub.atlassian.net/browse/OSDEV-1789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ