### PR TITLE
[OSDEV-1831] Update text of tooltip on the "Thank you for adding data" pop-up base on the claim status of the production location.

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -60,6 +60,7 @@ Also was added sanitization on the server side by using the `Django-Bleach` libr
 * [OSDEV-1803](https://opensupplyhub.atlassian.net/browse/OSDEV-1803) - Updated text from `Facility Type` to `Location Type` and `Facility Name` to `Location Name` on the SLC `Thank You for Your Submission` page.
 * [OSDEV-1838](https://opensupplyhub.atlassian.net/browse/OSDEV-1838) - Fixed an issue where the router redirected to an unsupported page when the OS ID contained a forward slash. The fix was implemented by encoding the OS ID value using the `encodeURIComponent()` function before passing it as a URL parameter.
 * [OSDEV-1840](https://opensupplyhub.atlassian.net/browse/OSDEV-1840) - Fixed the snapshot status checking procedure. This will prevent a crash when trying to restore a database from an inaccessible snapshot.
+* [OSDEV-1831](https://opensupplyhub.atlassian.net/browse/OSDEV-1831) - Updated copies of tooltips on the “Thank you for adding data” pop-up. The texts vary depending on the claim status for a particular location.
 
 ### What's new
 * [OSDEV-1814](https://opensupplyhub.atlassian.net/browse/OSDEV-1814) - Added toggle switch button for production location info page to render additional data if necessary. If toggle switch button is inactive (default behavior), additional data won't be send to the server along with name, address and country.

--- a/src/react/src/components/Contribute/ProductionLocationDialog.jsx
+++ b/src/react/src/components/Contribute/ProductionLocationDialog.jsx
@@ -72,26 +72,20 @@ const getStatusBadgeClass = (classes, status) => {
 };
 
 const getPendingTooltipText = claimStatus => {
-    switch (claimStatus) {
-        case PRODUCTION_LOCATION_CLAIM_STATUSES_ENUM.CLAIMED:
-            return 'Text for claimed status';
-        case PRODUCTION_LOCATION_CLAIM_STATUSES_ENUM.PENDING:
-            return 'Text for pending status';
-        case PRODUCTION_LOCATION_CLAIM_STATUSES_ENUM.UNCLAIMED:
-            return 'Text for unclaimed status';
-        default:
-            return 'Your submission is under review. You will receive a notification once the production location is live on OS Hub. You can proceed to submit a claim while your request is pending.';
+    if (claimStatus === PRODUCTION_LOCATION_CLAIM_STATUSES_ENUM.UNCLAIMED) {
+        return 'Your submission is under review. You will receive a notification once the production location is live on OS Hub. You can proceed to submit a claim while your request is pending.';
     }
+    return 'Your submission is under review. You will receive an email confirming your OS ID once your information is live on OS Hub.';
 };
 
 const getClaimTooltipText = claimStatus => {
     switch (claimStatus) {
         case PRODUCTION_LOCATION_CLAIM_STATUSES_ENUM.CLAIMED:
-            return 'Production location has been claimed already.';
+            return 'This location cannot be claimed because it has already been claimed.';
         case PRODUCTION_LOCATION_CLAIM_STATUSES_ENUM.PENDING:
-            return 'There is a pending claim for this production location.';
+            return 'This location cannot be claimed because a pending claim already exists.';
         default:
-            return "You'll be able to claim the location after the moderation is done.";
+            return 'You will be able to claim this location once the OS ID is live on OS Hub.';
     }
 };
 

--- a/src/react/src/components/Contribute/ProductionLocationDialog.jsx
+++ b/src/react/src/components/Contribute/ProductionLocationDialog.jsx
@@ -314,7 +314,7 @@ const ProductionLocationDialog = ({
                                 </>
                             ) : (
                                 <DialogTooltip
-                                    text={getTooltipText(claimStatus)}
+                                    text={getClaimTooltipText(claimStatus)}
                                     aria-label="Claim button tooltip"
                                     childComponent={claimButton({
                                         classes,

--- a/src/react/src/components/Contribute/ProductionLocationDialog.jsx
+++ b/src/react/src/components/Contribute/ProductionLocationDialog.jsx
@@ -104,7 +104,6 @@ const ProductionLocationDialog = ({
     claimStatus,
 }) => {
     const history = useHistory();
-    console.log('claimStatus >>>', claimStatus);
 
     const [isMobile, setIsMobile] = useState(false);
     const getIsMobileMemoized = useMemo(() => getIsMobile(innerWidth), [

--- a/src/react/src/components/Contribute/ProductionLocationDialog.jsx
+++ b/src/react/src/components/Contribute/ProductionLocationDialog.jsx
@@ -72,14 +72,14 @@ const getStatusBadgeClass = (classes, status) => {
 };
 
 const getTooltipText = claimStatus => {
-    if (claimStatus === PRODUCTION_LOCATION_CLAIM_STATUSES_ENUM.CLAIMED) {
-        return 'Production location has been claimed already.';
+    switch (claimStatus) {
+        case PRODUCTION_LOCATION_CLAIM_STATUSES_ENUM.CLAIMED:
+            return 'Production location has been claimed already.';
+        case PRODUCTION_LOCATION_CLAIM_STATUSES_ENUM.PENDING:
+            return 'There is a pending claim for this production location.';
+        default:
+            return "You'll be able to claim the location after the moderation is done.";
     }
-    if (claimStatus === PRODUCTION_LOCATION_CLAIM_STATUSES_ENUM.PENDING) {
-        return 'There is a pending claim for this production location.';
-    }
-
-    return "You'll be able to claim the location after the moderation is done.";
 };
 
 const ProductionLocationDialog = ({
@@ -91,6 +91,7 @@ const ProductionLocationDialog = ({
     claimStatus,
 }) => {
     const history = useHistory();
+    console.log('claimStatus >>>', claimStatus);
 
     const [isMobile, setIsMobile] = useState(false);
     const getIsMobileMemoized = useMemo(() => getIsMobile(innerWidth), [

--- a/src/react/src/components/Contribute/ProductionLocationDialog.jsx
+++ b/src/react/src/components/Contribute/ProductionLocationDialog.jsx
@@ -162,7 +162,8 @@ const ProductionLocationDialog = ({
     const deleteIcon =
         moderationStatus === MODERATION_STATUSES_ENUM.PENDING ? (
             <DialogTooltip
-                text="Your submission is under review. You will receive a notification once the production location is live on OS Hub. You can proceed to submit a claim while your request is pending."
+                text={getPendingTooltipText(claimStatus)}
+                aria-label="Pending status tooltip"
                 childComponent={infoIcon(classes)}
             />
         ) : null;

--- a/src/react/src/components/Contribute/ProductionLocationDialog.jsx
+++ b/src/react/src/components/Contribute/ProductionLocationDialog.jsx
@@ -80,7 +80,7 @@ const getPendingTooltipText = claimStatus => {
         case PRODUCTION_LOCATION_CLAIM_STATUSES_ENUM.UNCLAIMED:
             return 'Text for unclaimed status';
         default:
-            return 'Default text when user can not claim because no os id is available';
+            return 'Your submission is under review. You will receive a notification once the production location is live on OS Hub. You can proceed to submit a claim while your request is pending.';
     }
 };
 

--- a/src/react/src/components/Contribute/ProductionLocationDialog.jsx
+++ b/src/react/src/components/Contribute/ProductionLocationDialog.jsx
@@ -75,17 +75,17 @@ const getPendingTooltipText = claimStatus => {
     if (claimStatus === PRODUCTION_LOCATION_CLAIM_STATUSES_ENUM.UNCLAIMED) {
         return 'Your submission is under review. You will receive a notification once the production location is live on OS Hub. You can proceed to submit a claim while your request is pending.';
     }
-    return 'Your submission is under review. You will receive an email confirming your OS ID once your information is live on OS Hub.';
+    return 'Your submission is being reviewed. You will receive an email with your OS ID once the review is complete.';
 };
 
 const getClaimTooltipText = claimStatus => {
     switch (claimStatus) {
         case PRODUCTION_LOCATION_CLAIM_STATUSES_ENUM.CLAIMED:
-            return 'This location cannot be claimed because it has already been claimed.';
+            return 'This location has already been claimed and therefore cannot be claimed again.';
         case PRODUCTION_LOCATION_CLAIM_STATUSES_ENUM.PENDING:
             return 'This location cannot be claimed because a pending claim already exists.';
         default:
-            return 'You will be able to claim this location once the OS ID is live on OS Hub.';
+            return 'You will be able to claim this location once the review is complete.';
     }
 };
 

--- a/src/react/src/components/Contribute/ProductionLocationDialog.jsx
+++ b/src/react/src/components/Contribute/ProductionLocationDialog.jsx
@@ -71,7 +71,20 @@ const getStatusBadgeClass = (classes, status) => {
     }
 };
 
-const getTooltipText = claimStatus => {
+const getPendingTooltipText = claimStatus => {
+    switch (claimStatus) {
+        case PRODUCTION_LOCATION_CLAIM_STATUSES_ENUM.CLAIMED:
+            return 'Text for claimed status';
+        case PRODUCTION_LOCATION_CLAIM_STATUSES_ENUM.PENDING:
+            return 'Text for pending status';
+        case PRODUCTION_LOCATION_CLAIM_STATUSES_ENUM.UNCLAIMED:
+            return 'Text for unclaimed status';
+        default:
+            return 'Default text when user can not claim because no os id is available';
+    }
+};
+
+const getClaimTooltipText = claimStatus => {
     switch (claimStatus) {
         case PRODUCTION_LOCATION_CLAIM_STATUSES_ENUM.CLAIMED:
             return 'Production location has been claimed already.';


### PR DESCRIPTION
[OSDEV-1831](https://opensupplyhub.atlassian.net/browse/OSDEV-1831) - SLC UAT Bug - Update copy in "Thank you for adding data" pop-up (new OS ID use case).

This PR updates copies of tooltips on the “Thank you for adding data” pop-up. The texts vary depending on the claim status for a particular location.

[OSDEV-1831]: https://opensupplyhub.atlassian.net/browse/OSDEV-1831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ