### PR TITLE
[OSDEV-1838] Fix search by OS ID that contains slash or other special characters.

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -56,7 +56,8 @@ Also was added sanitization on the server side by using the `Django-Bleach` libr
 * [OSDEV-1787](https://opensupplyhub.atlassian.net/browse/OSDEV-1787) - The tooltip messages for the Claim button have been removed for all statuses of moderation events on the `Contribution Record` page and changed according to the design on `Thanks for adding data for this production location` pop-up.
 * [OSDEV-1789](https://opensupplyhub.atlassian.net/browse/OSDEV-1789) - Fixed an issue where the scroll position was not resetting to the top when navigating through SLC workflow pages.
 * [OSDEV-1795](https://opensupplyhub.atlassian.net/browse/OSDEV-1795) - Resolved database connection issue after PostgreSQL 16.3 upgrade by upgrading pg8000 module version.
-* [OSDEV-1803](https://opensupplyhub.atlassian.net/browse/OSDEV-1803) - Updated text from `Facility Type` to `Location Type` and `Facility Name` to `Location Name` on the SLC `Thank You for Your Submission` page. 
+* [OSDEV-1803](https://opensupplyhub.atlassian.net/browse/OSDEV-1803) - Updated text from `Facility Type` to `Location Type` and `Facility Name` to `Location Name` on the SLC `Thank You for Your Submission` page.
+* [OSDEV-1838](https://opensupplyhub.atlassian.net/browse/OSDEV-1838) - Fixed an issue where the router redirected to an unsupported page when the OS ID contained a forward slash. The fix was implemented by encoding the OS ID value using the `encodeURIComponent()` function before passing it as a URL parameter.
 
 ### What's new
 * [OSDEV-1814](https://opensupplyhub.atlassian.net/browse/OSDEV-1814) - Added toggle switch button for production location info page to render additional data if necessary. If toggle switch button is inactive (default behavior), additional data won't be send to the server along with name, address and country.

--- a/src/react/src/__tests__/components/SearchByOsIdTab.test.js
+++ b/src/react/src/__tests__/components/SearchByOsIdTab.test.js
@@ -68,6 +68,57 @@ describe('SearchByOsIdTab component', () => {
         );
     });
 
+    it('should replace special characters in the URL with their encoded values', () => {
+        const { getByPlaceholderText, getByRole } = renderWithProviders(
+            <Router history={history}>
+                <SearchByOsIdTab />
+            </Router>
+        );
+        const input = getByPlaceholderText('Enter the OS ID');
+
+        fireEvent.change(input, { target: { value: 'CN2021250D1D/TN' } });
+        fireEvent.click(getByRole('button', { name: /Search by ID/i }));
+
+        expect(history.location.pathname).toBe(
+            '/contribute/single-location/search/id/CN2021250D1D%2FTN'
+        );
+
+        fireEvent.change(input, { target: { value: 'CN2021250D1D?TN' } });
+        fireEvent.click(getByRole('button', { name: /Search by ID/i }));
+
+        expect(history.location.pathname).toBe(
+            '/contribute/single-location/search/id/CN2021250D1D%3FTN'
+        );
+
+        fireEvent.change(input, { target: { value: 'CN2021250D1D#TN' } });
+        fireEvent.click(getByRole('button', { name: /Search by ID/i }));
+
+        expect(history.location.pathname).toBe(
+            '/contribute/single-location/search/id/CN2021250D1D%23TN'
+        );
+
+        fireEvent.change(input, { target: { value: 'CN2021250D1D$TN' } });
+        fireEvent.click(getByRole('button', { name: /Search by ID/i }));    
+
+        expect(history.location.pathname).toBe(
+            '/contribute/single-location/search/id/CN2021250D1D%24TN'
+        );
+
+        fireEvent.change(input, { target: { value: 'CN2021250D1D&TN' } });
+        fireEvent.click(getByRole('button', { name: /Search by ID/i }));
+
+        expect(history.location.pathname).toBe(
+            '/contribute/single-location/search/id/CN2021250D1D%26TN'
+        );
+
+        fireEvent.change(input, { target: { value: 'CN2021250D1D@TN' } });
+        fireEvent.click(getByRole('button', { name: /Search by ID/i }));
+
+        expect(history.location.pathname).toBe(
+            '/contribute/single-location/search/id/CN2021250D1D%40TN'
+        );
+    });
+
     it('transforms input to uppercase when typing', () => {
         const { getByPlaceholderText } = renderWithProviders(<SearchByOsIdTab />);
         const input = getByPlaceholderText('Enter the OS ID');

--- a/src/react/src/components/Contribute/SearchByOsIdTab.jsx
+++ b/src/react/src/components/Contribute/SearchByOsIdTab.jsx
@@ -31,7 +31,11 @@ const SearchByOsIdTab = ({ classes }) => {
     };
 
     const handleSearch = () => {
-        history.push(`/contribute/single-location/search/id/${inputOsId}`);
+        history.push(
+            `/contribute/single-location/search/id/${encodeURIComponent(
+                inputOsId,
+            )}`,
+        );
     };
 
     return (


### PR DESCRIPTION
[OSDEV-1838](https://opensupplyhub.atlassian.net/browse/OSDEV-1838) - SLC. Fix search by OS ID that contains slash.

This PR fixes an issue where the router redirected to an unsupported page when the OS ID contained a forward slash. The issue was resolved by encoding the OS ID value using the `encodeURIComponent()` function before passing it as a URL parameter.

![Screenshot from 2025-03-10 22-14-33](https://github.com/user-attachments/assets/65eb8adc-1db1-4d1f-9232-b9c0d0227680)
![Screenshot from 2025-03-10 22-15-14](https://github.com/user-attachments/assets/b2ce1a8f-8c88-412b-b001-ef186fc3c5f3)


[OSDEV-1838]: https://opensupplyhub.atlassian.net/browse/OSDEV-1838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ