### PR TITLE
[OSDEV-1832] Increase the memory allocation for the DedupeHub in Terraform configuration for Pre-Prod & Production

### DIFF
--- a/deployment/environments/terraform-preprod.tfvars
+++ b/deployment/environments/terraform-preprod.tfvars
@@ -52,7 +52,7 @@ dedupe_hub_name = "deduplicate"
 dedupe_hub_version = 1
 app_cc_ecs_desired_count = 0
 app_dd_fargate_cpu = 4096
-app_dd_fargate_memory = 12288
+app_dd_fargate_memory = 16384
 app_dd_ecs_desired_count = 1
 
 opensearch_instance_type = "m6g.large.search"

--- a/deployment/environments/terraform-production.tfvars
+++ b/deployment/environments/terraform-production.tfvars
@@ -51,7 +51,7 @@ dedupe_hub_name = "deduplicate"
 dedupe_hub_version = 1
 app_cc_ecs_desired_count = 0
 app_dd_fargate_cpu = 4096
-app_dd_fargate_memory = 12288
+app_dd_fargate_memory = 16384
 app_dd_ecs_desired_count = 1
 django_log_level="DEBUG"
 

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -24,6 +24,7 @@ Also was added sanitization on the server side by using the `Django-Bleach` libr
 
 ### Architecture/Environment changes
 * [OSDEV-899](https://opensupplyhub.atlassian.net/browse/OSDEV-899) - Splitted the Django container into two components: FE (React) and BE (Django). Requests to the frontend (React) will be processed by the CDN (CloudFront), while requests to the API will be redirected to the Django container. This approach will allow for more efficient use of ECS cluster computing resources and improve frontend performance.
+* [OSDEV-1832](https://opensupplyhub.atlassian.net/browse/OSDEV-1832) - Increased the memory allocation for the `DedupeHub` container from `12GB` to `16GB` in terraform deployment configuration to address memory overload issues during facility reindexing for `Production` & `Pre-Production` environments.
 
   The following endpoints will be redirected to the Django container:
   * tile/*


### PR DESCRIPTION
[OSDEV-1832](https://opensupplyhub.atlassian.net/browse/OSDEV-1832) **Increase the memory allocation for the DedupeHub in Terraform configuration for Pre-Prod & Production**

- Increased the memory allocation for the `DedupeHub` container from `12GB` to `16GB` in terraform deployment configuration to address memory overload issues during facility reindexing for `Production` & `Pre-Production` environments.

[OSDEV-1832]: https://opensupplyhub.atlassian.net/browse/OSDEV-1832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ