### PR TITLE
[OSDEV-1769] Refactor potential matches response for POST api/facilities/?create=true

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -56,7 +56,8 @@ Also was added sanitization on the server side by using the `Django-Bleach` libr
 * [OSDEV-1787](https://opensupplyhub.atlassian.net/browse/OSDEV-1787) - The tooltip messages for the Claim button have been removed for all statuses of moderation events on the `Contribution Record` page and changed according to the design on `Thanks for adding data for this production location` pop-up.
 * [OSDEV-1789](https://opensupplyhub.atlassian.net/browse/OSDEV-1789) - Fixed an issue where the scroll position was not resetting to the top when navigating through SLC workflow pages.
 * [OSDEV-1795](https://opensupplyhub.atlassian.net/browse/OSDEV-1795) - Resolved database connection issue after PostgreSQL 16.3 upgrade by upgrading pg8000 module version.
-* [OSDEV-1803](https://opensupplyhub.atlassian.net/browse/OSDEV-1803) - Updated text from `Facility Type` to `Location Type` and `Facility Name` to `Location Name` on the SLC `Thank You for Your Submission` page. 
+* [OSDEV-1803](https://opensupplyhub.atlassian.net/browse/OSDEV-1803) - Updated text from `Facility Type` to `Location Type` and `Facility Name` to `Location Name` on the SLC `Thank You for Your Submission` page.
+* [OSDEV-1769](https://opensupplyhub.atlassian.net/browse/OSDEV-1769) - Fixed the response for potential matches for POST `api/facilities/?create=true`: applied an array of potential matches instead of returning a single potential match.
 
 ### What's new
 * [OSDEV-1814](https://opensupplyhub.atlassian.net/browse/OSDEV-1814) - Added toggle switch button for production location info page to render additional data if necessary. If toggle switch button is inactive (default behavior), additional data won't be send to the server along with name, address and country.

--- a/src/django/api/processing.py
+++ b/src/django/api/processing.py
@@ -286,13 +286,16 @@ def get_potential_match_result(match_item, items_count, context,
         ).data
     facility_dict['confidence'] = match_item.confidence
 
-    if match_item.confidence < AUTOMATIC_THRESHOLD or items_count > 1:
-        if should_create:
-            facility_dict['confirm_match_url'] = reverse(
-                'facility-match-confirm',
-                kwargs={'pk': match_item.id})
-            facility_dict['reject_match_url'] = reverse(
-                'facility-match-reject',
-                kwargs={'pk': match_item.id})
+    if (
+        (match_item.confidence < AUTOMATIC_THRESHOLD or items_count > 1)
+        and
+        should_create
+    ):
+        facility_dict['confirm_match_url'] = reverse(
+            'facility-match-confirm',
+            kwargs={'pk': match_item.id})
+        facility_dict['reject_match_url'] = reverse(
+            'facility-match-reject',
+            kwargs={'pk': match_item.id})
 
     return facility_dict

--- a/src/django/api/processing.py
+++ b/src/django/api/processing.py
@@ -221,7 +221,7 @@ def handle_potential_matches(
     should_create,
     result
 ):
-    return [
+    matches = [
         get_potential_match_result(
             f_l_item,
             match,
@@ -232,6 +232,8 @@ def handle_potential_matches(
         )
         for match in pending_matches
     ]
+    result['matches'] = matches
+    return result
 
 
 def get_error_match_result(id, result):

--- a/src/django/api/processing.py
+++ b/src/django/api/processing.py
@@ -198,6 +198,7 @@ def handle_external_match_process_result(id, result, request, should_create):
         if match.status == match_object_type.PENDING
     ]
 
+    # Potential Matches
     return [
         get_potential_match_result(
             f_l_item,

--- a/src/django/api/processing.py
+++ b/src/django/api/processing.py
@@ -197,16 +197,22 @@ def handle_external_match_process_result(id, result, request, should_create):
         match for match in queryset_f_m
         if match.status == match_object_type.PENDING
     ]
-    for item in pending_matches:
-        # Potential Match
-        return get_potential_match_result(f_l_item,
-                                          item,
-                                          len(pending_matches),
-                                          context,
-                                          should_create,
-                                          result)
 
-    return result
+    result_matches = []
+    for item in pending_matches:
+        # Potential Matches
+        result_matches.append(
+            get_potential_match_result(
+                f_l_item,
+                item,
+                len(pending_matches),
+                context,
+                should_create,
+                result
+            )
+        )
+
+    return result_matches
 
 
 def get_error_match_result(id, result):

--- a/src/django/api/processing.py
+++ b/src/django/api/processing.py
@@ -198,21 +198,15 @@ def handle_external_match_process_result(id, result, request, should_create):
         if match.status == match_object_type.PENDING
     ]
 
-    result_matches = []
-    for item in pending_matches:
-        # Potential Matches
-        result_matches.append(
-            get_potential_match_result(
-                f_l_item,
-                item,
-                len(pending_matches),
-                context,
-                should_create,
-                result
-            )
+    return [
+        get_potential_match_result(
+            f_l_item, item,
+            len(pending_matches),
+            context,
+            should_create, result
         )
-
-    return result_matches
+        for item in pending_matches
+    ]
 
 
 def get_error_match_result(id, result):

--- a/src/django/api/processing.py
+++ b/src/django/api/processing.py
@@ -200,10 +200,12 @@ def handle_external_match_process_result(id, result, request, should_create):
 
     return [
         get_potential_match_result(
-            f_l_item, item,
+            f_l_item,
+            item,
             len(pending_matches),
             context,
-            should_create, result
+            should_create,
+            result
         )
         for item in pending_matches
     ]

--- a/src/django/api/tests/test_facility_create_api.py
+++ b/src/django/api/tests/test_facility_create_api.py
@@ -156,12 +156,12 @@ class FacilityCreateAPITest(APITestCase):
         result_three = handle_external_match_process_result(
             self.list_item_three.id, result_obj_three, None, True
         )
-        self.assertEqual(result_three['status'], 'POTENTIAL_MATCH')
+        self.assertEqual(result_three[0]['status'], 'POTENTIAL_MATCH')
         self.assertIsNotNone(
-            result_three['matches'][0]['confirm_match_url']
+            result_three[0]['matches'][0]['confirm_match_url']
         )
         self.assertIsNotNone(
-            result_three['matches'][0]['reject_match_url']
+            result_three[0]['matches'][0]['reject_match_url']
         )
 
         result_obj_four = {

--- a/src/django/api/tests/test_facility_create_api.py
+++ b/src/django/api/tests/test_facility_create_api.py
@@ -156,12 +156,12 @@ class FacilityCreateAPITest(APITestCase):
         result_three = handle_external_match_process_result(
             self.list_item_three.id, result_obj_three, None, True
         )
-        self.assertEqual(result_three[0]['status'], 'POTENTIAL_MATCH')
+        self.assertEqual(result_three['status'], 'POTENTIAL_MATCH')
         self.assertIsNotNone(
-            result_three[0]['matches'][0]['confirm_match_url']
+            result_three['matches'][0]['confirm_match_url']
         )
         self.assertIsNotNone(
-            result_three[0]['matches'][0]['reject_match_url']
+            result_three['matches'][0]['reject_match_url']
         )
 
         result_obj_four = {


### PR DESCRIPTION
Fix [OSDEV-1769](https://opensupplyhub.atlassian.net/browse/OSDEV-1769)

Fixed the response for potential matches for POST `api/facilities/?create=true`: applied an array of potential matches instead of returning a single potential match.

[OSDEV-1769]: https://opensupplyhub.atlassian.net/browse/OSDEV-1769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ