### PR TITLE
[OSDEV-1867] SLC. Update Messy Data link to data cleaning service splash page

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -71,6 +71,7 @@ Also was added sanitization on the server side by using the `Django-Bleach` libr
 * [OSDEV-1786](https://opensupplyhub.atlassian.net/browse/OSDEV-1786) - Linked "My Claimed Facilities" page to SLC if no claimed production locations found, changed search button text.
 * [OSDEV-1607](https://opensupplyhub.atlassian.net/browse/OSDEV-1607) - Enabled SLC flow.
 * [OSDEV-1864](https://opensupplyhub.atlassian.net/browse/OSDEV-1864) - Disabled the 'Submit/Update' button on the SLC Production Location Information page when the `disable_list_uploading` feature flag is active.
+* [OSDEV-1867](https://opensupplyhub.atlassian.net/browse/OSDEV-1867) - Updated the 'Messy Data' link on the Contribute page to direct users to the Data Cleaning Service splash page instead of the old Preparing Data page.
 
 ### Release instructions:
 * Ensure that the following commands are included in the `post_deployment` command:

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -71,7 +71,7 @@ Also was added sanitization on the server side by using the `Django-Bleach` libr
 * [OSDEV-1786](https://opensupplyhub.atlassian.net/browse/OSDEV-1786) - Linked "My Claimed Facilities" page to SLC if no claimed production locations found, changed search button text.
 * [OSDEV-1607](https://opensupplyhub.atlassian.net/browse/OSDEV-1607) - Enabled SLC flow.
 * [OSDEV-1864](https://opensupplyhub.atlassian.net/browse/OSDEV-1864) - Disabled the 'Submit/Update' button on the SLC Production Location Information page when the `disable_list_uploading` feature flag is active.
-* [OSDEV-1867](https://opensupplyhub.atlassian.net/browse/OSDEV-1867) - Updated the 'Messy Data' link on the Contribute page to direct users to the Data Cleaning Service splash page instead of the old Preparing Data page.
+* [OSDEV-1867](https://opensupplyhub.atlassian.net/browse/OSDEV-1867) - Updated the 'Messy Data' link on the `Contribute` page and `List Upload` page to direct users to the `Data Cleaning Service splash` page instead of the old `Preparing Data` page.
 
 ### Release instructions:
 * Ensure that the following commands are included in the `post_deployment` command:

--- a/src/react/src/util/constants.jsx
+++ b/src/react/src/util/constants.jsx
@@ -23,7 +23,7 @@ export const EMPTY_PLACEHOLDER = 'N/A';
 export const InfoPaths = {
     storiesResources: 'stories-resources',
     privacyPolicy: 'privacy-policy',
-    contribute: 'resources/preparing-data',
+    contribute: 'data-cleaning-service',
     dataQuality: 'resources/a-free-universal-id-matching-algorithm',
     claimedFacilities: 'stories-resources/claim-a-facility',
     termsOfService: 'terms-of-service',


### PR DESCRIPTION
[OSDEV-1867](https://opensupplyhub.atlassian.net/browse/OSDEV-1867) **SLC. Update Messy Data link to data cleaning service splash page**

- Updated the 'Messy Data' link on the `Contribute` page and `List Upload` page to direct users to the `Data Cleaning Service splash` page instead of the old `Preparing Data` page.

[OSDEV-1867]: https://opensupplyhub.atlassian.net/browse/OSDEV-1867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ