### PR TITLE
[OSDEV-1201] Added support of geo_polygon parameter for GET v1/production-locations endpoint

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -3,6 +3,37 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). The format is based on the `RELEASE-NOTES-TEMPLATE.md` file.
 
+## Release 2.2.0
+
+## Introduction
+* Product name: Open Supply Hub
+* Release date: April 19, 2025
+
+### Database changes
+* *Describe high-level database changes.*
+
+#### Migrations:
+* *Describe migrations here.*
+
+#### Schema changes
+* *Describe schema changes here.*
+
+### Code/API changes
+* [OSDEV-1201](https://opensupplyhub.atlassian.net/browse/OSDEV-1201) - Added support of `geo_polygon` parameter for GET `v1/production-locations` endpoint.
+
+### Architecture/Environment changes
+* *Describe architecture/environment changes here.*
+
+### Bugfix
+* *Describe bugfix here.*
+
+### What's new
+* *Describe what's new here. The changes that can impact user experience should be listed in this section.*
+
+### Release instructions:
+* *Provide release instructions here.*
+
+
 ## Release 2.1.0
 
 ## Introduction
@@ -17,9 +48,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 #### Schema changes
 * *Describe schema changes here.*
-
-### Code/API changes
-* [OSDEV-1201](https://opensupplyhub.atlassian.net/browse/OSDEV-1201) - Added support of `geo_polygon` parameter for GET `v1/production-locations` endpoint.
 
 ### Architecture/Environment changes
 * [OSDEV-1899](https://opensupplyhub.atlassian.net/browse/OSDEV-1899) - Switched from using the `latest` tags to static versions for both `bitnami/kafka` and `bitnami/zookeeper`, which resolved compatibility issues during local & CI setup. Using pinned versions ensures stability and prevents unexpected behavior from upstream image changes.

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -24,15 +24,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * Product name: Open Supply Hub
 * Release date: April 5, 2025
 
-### Database changes
-* *Describe high-level database changes.*
-
-#### Migrations:
-* *Describe migrations here.*
-
-#### Schema changes
-* *Describe schema changes here.*
-
 ### Architecture/Environment changes
 * [OSDEV-1899](https://opensupplyhub.atlassian.net/browse/OSDEV-1899) - Switched from using the `latest` tags to static versions for both `bitnami/kafka` and `bitnami/zookeeper`, which resolved compatibility issues during local & CI setup. Using pinned versions ensures stability and prevents unexpected behavior from upstream image changes.
 

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -9,29 +9,13 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * Product name: Open Supply Hub
 * Release date: April 19, 2025
 
-### Database changes
-* *Describe high-level database changes.*
-
-#### Migrations:
-* *Describe migrations here.*
-
-#### Schema changes
-* *Describe schema changes here.*
-
 ### Code/API changes
 * [OSDEV-1201](https://opensupplyhub.atlassian.net/browse/OSDEV-1201) - Added support of `geo_polygon` parameter for GET `v1/production-locations` endpoint.
 
-### Architecture/Environment changes
-* *Describe architecture/environment changes here.*
-
-### Bugfix
-* *Describe bugfix here.*
-
-### What's new
-* *Describe what's new here. The changes that can impact user experience should be listed in this section.*
-
 ### Release instructions:
-* *Provide release instructions here.*
+* Ensure that the following commands are included in the `post_deployment` command:
+    * `migrate`
+    * `reindex_database`
 
 
 ## Release 2.1.0
@@ -63,7 +47,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-1842](https://opensupplyhub.atlassian.net/browse/OSDEV-1842) - Removed the pre-filled information in the `Additional Information` section of the SLC `ProductionLocationInfo` page.
 
 ### Release instructions:
-* *Provide release instructions here.*
+* Ensure that the following commands are included in the `post_deployment` command:
+    * `migrate`
+    * `reindex_database`
 
 
 ## Release 2.0.0

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * *Describe schema changes here.*
 
 ### Code/API changes
-* *Describe code/API changes here.*
+* [OSDEV-1201](https://opensupplyhub.atlassian.net/browse/OSDEV-1201) - Added support of `geo_polygon` parameter for GET `v1/production-locations` endpoint.
 
 ### Architecture/Environment changes
 * [OSDEV-1899](https://opensupplyhub.atlassian.net/browse/OSDEV-1899) - Switched from using the `latest` tags to static versions for both `bitnami/kafka` and `bitnami/zookeeper`, which resolved compatibility issues during local & CI setup. Using pinned versions ensures stability and prevents unexpected behavior from upstream image changes.

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -221,6 +221,7 @@ class APIV1CommonErrorMessages:
         'An unexpected error occurred while processing the request.'
     )
     COMMON_REQ_QUERY_ERROR = 'The request query is invalid.'
+    COMMON_REQ_PARAMETER_ERROR = 'The request parameter is invalid.'
     MAINTENANCE_MODE = (
         'Open Supply Hub is undergoing maintenance and not accepting new data '
         'at the moment. Please try again in a few minutes.'

--- a/src/django/api/serializers/v1/opensearch_common_validators/coordinates_validator.py
+++ b/src/django/api/serializers/v1/opensearch_common_validators/coordinates_validator.py
@@ -9,7 +9,7 @@ class CoordinatesValidator(OpenSearchValidationInterface):
         errors: List[dict] = []
 
         lat = data.get('coordinates_lat')
-        lng = data.get('coordinates_lon')
+        lng = data.get('coordinates_lng')
 
         if ((lat is not None and lng is None) or
                 (lat is None and lng is not None)):

--- a/src/django/api/serializers/v1/opensearch_common_validators/coordinates_validator.py
+++ b/src/django/api/serializers/v1/opensearch_common_validators/coordinates_validator.py
@@ -9,7 +9,7 @@ class CoordinatesValidator(OpenSearchValidationInterface):
         errors: List[dict] = []
 
         lat = data.get('coordinates_lat')
-        lng = data.get('coordinates_lng')
+        lng = data.get('coordinates_lon')
 
         if ((lat is not None and lng is None) or
                 (lat is None and lng is not None)):

--- a/src/django/api/serializers/v1/opensearch_common_validators/geo_polygon_validator.py
+++ b/src/django/api/serializers/v1/opensearch_common_validators/geo_polygon_validator.py
@@ -24,8 +24,8 @@ class GeoPolygonValidator(OpenSearchValidationInterface):
                 errors.append({
                     "field": "geo_polygon",
                     "detail": (
-                        f"Invalid coordinate format: {point}. "
-                        "Must be 'lat,lon' as floats"
+                        f"Invalid coordinate format: {point}, "
+                        "must be 'lat,lon' as floats"
                     )
                 })
                 continue
@@ -38,8 +38,8 @@ class GeoPolygonValidator(OpenSearchValidationInterface):
                 errors.append({
                     "field": "geo_polygon",
                     "detail": (
-                        f"Invalid latitude {lat}. "
-                        "Must be between -90 and 90."
+                        f"Invalid latitude {lat}, "
+                        "must be between -90 and 90."
                     )
                 })
 
@@ -51,8 +51,8 @@ class GeoPolygonValidator(OpenSearchValidationInterface):
                 errors.append({
                     "field": "geo_polygon",
                     "detail": (
-                        f"Invalid longitude {lon}. "
-                        "Must be between -180 and 180."
+                        f"Invalid longitude {lon}, "
+                        "must be between -180 and 180."
                     )
                 })
 

--- a/src/django/api/serializers/v1/opensearch_common_validators/geo_polygon_validator.py
+++ b/src/django/api/serializers/v1/opensearch_common_validators/geo_polygon_validator.py
@@ -3,23 +3,30 @@ from typing import List
 from api.serializers.v1.opensearch_validation_interface import (
     OpenSearchValidationInterface,
 )
+from api.constants import CoordinateLimits
 
 logger = logging.getLogger(__name__)
 
 class GeoPolygonValidator(OpenSearchValidationInterface):
     def validate_opensearch_params(self, data):
         errors: List[dict] = []
-
-        logger.info(f'### data for geo_polygon in validator {data}')
+        geo_polygon_data = data['geo_polygon'][0]
 
         try:
-            lat, lon = map(float, data.split(","))
+            lat, lon = map(float, geo_polygon_data.split(","))
         except ValueError:
-            errors.append(f"Invalid geo_polygon format: {data}. Expected 'lat,lon'.")
+            errors.append({f"Invalid geo_polygon format: {geo_polygon_data}. Expected 'lat,lon'."})
 
-        if not (-90 <= lat <= 90):
-            errors.append(f"Invalid latitude {lat}. Must be between -90 and 90.")
-        if not (-180 <= lon <= 180):
-            errors.append(f"Invalid longitude {lon}. Must be between -180 and 180.")
+        if not (CoordinateLimits.LAT_MIN <= lat <= CoordinateLimits.LAT_MAX):
+            errors.append({
+                "field": "geo_polygon",
+                "detail": f"Invalid latitude {lat}. Must be between -90 and 90."
+            })
+        if not (CoordinateLimits.LNG_MIN <= lon <= CoordinateLimits.LNG_MAX):
+            errors.append({
+                "field": "geo_polygon",
+                "detail": f"Invalid longitude {lon}. Must be between -180 and 180."
+            })
 
+        logger.info(f'$$$ errors {errors}')
         return errors

--- a/src/django/api/serializers/v1/opensearch_common_validators/geo_polygon_validator.py
+++ b/src/django/api/serializers/v1/opensearch_common_validators/geo_polygon_validator.py
@@ -23,20 +23,37 @@ class GeoPolygonValidator(OpenSearchValidationInterface):
             except (ValueError, TypeError):
                 errors.append({
                     "field": "geo_polygon",
-                    "detail": f"Invalid coordinate format: {point}. Must be 'lat,lon' as floats"
+                    "detail": (
+                        f"Invalid coordinate format: {point}. "
+                        "Must be 'lat,lon' as floats"
+                    )
                 })
                 continue
 
-            if not (CoordinateLimits.LAT_MIN <= lat <= CoordinateLimits.LAT_MAX):
+            if not (
+                CoordinateLimits.LAT_MIN <=
+                lat <=
+                CoordinateLimits.LAT_MAX
+            ):
                 errors.append({
                     "field": "geo_polygon",
-                    "detail": f"Invalid latitude {lat}. Must be between -90 and 90."
+                    "detail": (
+                        f"Invalid latitude {lat}. "
+                        "Must be between -90 and 90."
+                    )
                 })
 
-            if not (CoordinateLimits.LNG_MIN <= lon <= CoordinateLimits.LNG_MAX):
+            if not (
+                CoordinateLimits.LNG_MIN <=
+                lon <=
+                CoordinateLimits.LNG_MAX
+            ):
                 errors.append({
                     "field": "geo_polygon",
-                    "detail": f"Invalid longitude {lon}. Must be between -180 and 180."
+                    "detail": (
+                        f"Invalid longitude {lon}. "
+                        "Must be between -180 and 180."
+                    )
                 })
 
         return errors

--- a/src/django/api/serializers/v1/opensearch_common_validators/geo_polygon_validator.py
+++ b/src/django/api/serializers/v1/opensearch_common_validators/geo_polygon_validator.py
@@ -34,7 +34,7 @@ class GeoPolygonValidator(OpenSearchValidationInterface):
                     "field": "geo_polygon",
                     "detail": (
                         f"Invalid coordinate format: {point}, "
-                        "must be 'lat,lon' as floats"
+                        "must be 'lat,lon' as floats."
                     )
                 })
                 continue

--- a/src/django/api/serializers/v1/opensearch_common_validators/geo_polygon_validator.py
+++ b/src/django/api/serializers/v1/opensearch_common_validators/geo_polygon_validator.py
@@ -1,0 +1,25 @@
+import logging
+from typing import List
+from api.serializers.v1.opensearch_validation_interface import (
+    OpenSearchValidationInterface,
+)
+
+logger = logging.getLogger(__name__)
+
+class GeoPolygonValidator(OpenSearchValidationInterface):
+    def validate_opensearch_params(self, data):
+        errors: List[dict] = []
+
+        logger.info(f'### data for geo_polygon in validator {data}')
+
+        try:
+            lat, lon = map(float, data.split(","))
+        except ValueError:
+            errors.append(f"Invalid geo_polygon format: {data}. Expected 'lat,lon'.")
+
+        if not (-90 <= lat <= 90):
+            errors.append(f"Invalid latitude {lat}. Must be between -90 and 90.")
+        if not (-180 <= lon <= 180):
+            errors.append(f"Invalid longitude {lon}. Must be between -180 and 180.")
+
+        return errors

--- a/src/django/api/serializers/v1/opensearch_common_validators/geo_polygon_validator.py
+++ b/src/django/api/serializers/v1/opensearch_common_validators/geo_polygon_validator.py
@@ -1,32 +1,42 @@
-import logging
 from typing import List
 from api.serializers.v1.opensearch_validation_interface import (
     OpenSearchValidationInterface,
 )
 from api.constants import CoordinateLimits
 
-logger = logging.getLogger(__name__)
 
 class GeoPolygonValidator(OpenSearchValidationInterface):
     def validate_opensearch_params(self, data):
         errors: List[dict] = []
-        geo_polygon_data = data['geo_polygon'][0]
 
-        try:
-            lat, lon = map(float, geo_polygon_data.split(","))
-        except ValueError:
-            errors.append({f"Invalid geo_polygon format: {geo_polygon_data}. Expected 'lat,lon'."})
-
-        if not (CoordinateLimits.LAT_MIN <= lat <= CoordinateLimits.LAT_MAX):
+        geo_polygon_data = data.get('geo_polygon', [])
+        if not isinstance(geo_polygon_data, list):
             errors.append({
                 "field": "geo_polygon",
-                "detail": f"Invalid latitude {lat}. Must be between -90 and 90."
+                "detail": "geo_polygon must be a list of coordinates."
             })
-        if not (CoordinateLimits.LNG_MIN <= lon <= CoordinateLimits.LNG_MAX):
-            errors.append({
-                "field": "geo_polygon",
-                "detail": f"Invalid longitude {lon}. Must be between -180 and 180."
-            })
+            return errors
 
-        logger.info(f'$$$ errors {errors}')
+        for point in geo_polygon_data:
+            try:
+                lat, lon = map(float, point.split(","))
+            except (ValueError, TypeError):
+                errors.append({
+                    "field": "geo_polygon",
+                    "detail": f"Invalid coordinate format: {point}. Must be 'lat,lon' as floats"
+                })
+                continue
+
+            if not (CoordinateLimits.LAT_MIN <= lat <= CoordinateLimits.LAT_MAX):
+                errors.append({
+                    "field": "geo_polygon",
+                    "detail": f"Invalid latitude {lat}. Must be between -90 and 90."
+                })
+
+            if not (CoordinateLimits.LNG_MIN <= lon <= CoordinateLimits.LNG_MAX):
+                errors.append({
+                    "field": "geo_polygon",
+                    "detail": f"Invalid longitude {lon}. Must be between -180 and 180."
+                })
+
         return errors

--- a/src/django/api/serializers/v1/opensearch_common_validators/geo_polygon_validator.py
+++ b/src/django/api/serializers/v1/opensearch_common_validators/geo_polygon_validator.py
@@ -17,6 +17,15 @@ class GeoPolygonValidator(OpenSearchValidationInterface):
             })
             return errors
 
+        if geo_polygon_data and len(geo_polygon_data) < 3:
+            errors.append({
+                "field": "geo_polygon",
+                "detail": (
+                    "At least 3 points are required in "
+                    "geo_polygon to form a valid polygon."
+                )
+            })
+
         for point in geo_polygon_data:
             try:
                 lat, lon = map(float, point.split(","))

--- a/src/django/api/serializers/v1/production_locations_serializer.py
+++ b/src/django/api/serializers/v1/production_locations_serializer.py
@@ -65,7 +65,6 @@ class ProductionLocationsSerializer(Serializer):
     geo_bounding_box_bottom = FloatField(required=False)
     geo_bounding_box_right = FloatField(required=False)
     geo_polygon = ListField(
-        # child=CharField(validators=[GeoPolygonValidator().validate_opensearch_params]),
         child=CharField(required=False),
         required=False
     )

--- a/src/django/api/serializers/v1/production_locations_serializer.py
+++ b/src/django/api/serializers/v1/production_locations_serializer.py
@@ -38,7 +38,7 @@ class ProductionLocationsSerializer(Serializer):
     search_after_id = CharField(required=False)
     search_after_value = CharField(required=False)
     coordinates_lat = FloatField(required=False)
-    coordinates_lon = FloatField(required=False)
+    coordinates_lng = FloatField(required=False)
     country = ListField(
         child=CharField(required=False),
         required=False

--- a/src/django/api/serializers/v1/production_locations_serializer.py
+++ b/src/django/api/serializers/v1/production_locations_serializer.py
@@ -22,6 +22,8 @@ from api.serializers.v1.opensearch_common_validators. \
 from api.constants import APIV1CommonErrorMessages
 from api.serializers.v1.opensearch_common_validators.\
     geo_bounding_box_validator import GeoBoundingBoxValidator
+from api.serializers.v1.opensearch_common_validators.\
+    geo_polygon_validator import GeoPolygonValidator
 
 
 class ProductionLocationsSerializer(Serializer):
@@ -36,7 +38,7 @@ class ProductionLocationsSerializer(Serializer):
     search_after_id = CharField(required=False)
     search_after_value = CharField(required=False)
     coordinates_lat = FloatField(required=False)
-    coordinates_lng = FloatField(required=False)
+    coordinates_lon = FloatField(required=False)
     country = ListField(
         child=CharField(required=False),
         required=False
@@ -62,6 +64,11 @@ class ProductionLocationsSerializer(Serializer):
     geo_bounding_box_left = FloatField(required=False)
     geo_bounding_box_bottom = FloatField(required=False)
     geo_bounding_box_right = FloatField(required=False)
+    geo_polygon = ListField(
+        # child=CharField(validators=[GeoPolygonValidator().validate_opensearch_params]),
+        child=CharField(required=False),
+        required=False
+    )
 
     def validate(self, data):
         validators = [
@@ -71,6 +78,7 @@ class ProductionLocationsSerializer(Serializer):
             CoordinatesValidator(),
             CountryValidator(),
             GeoBoundingBoxValidator(),
+            GeoPolygonValidator(),
         ]
 
         error_list_builder = OpenSearchErrorListBuilder(validators)

--- a/src/django/api/tests/test_production_locations_query_builder.py
+++ b/src/django/api/tests/test_production_locations_query_builder.py
@@ -280,3 +280,32 @@ class TestProductionLocationsQueryBuilder(TestCase):
             expected,
             self.builder.query_body['query']['bool']['filter']
         )
+
+    def test_add_geo_polygon(self):
+        values = [
+            "40.7128,-74.0060",
+            "35.7128,-78.0060",
+            "37.7128,-75.0060"
+        ]
+
+        self.builder.add_geo_polygon(values)
+
+        expected = {
+            'geo_polygon': {
+                'coordinates': {
+                    'points': [
+                        {'lat': 40.7128, 'lon': -74.0060},
+                        {'lat': 35.7128, 'lon': -78.0060},
+                        {'lat': 37.7128, 'lon': -75.0060},
+                    ]
+                }
+            }
+        }
+
+        self.assertIn(
+            'filter', self.builder.query_body['query']['bool']
+        )
+        self.assertEqual(
+            expected,
+            self.builder.query_body['query']['bool']['filter']
+        )

--- a/src/django/api/tests/test_production_locations_query_builder.py
+++ b/src/django/api/tests/test_production_locations_query_builder.py
@@ -278,7 +278,7 @@ class TestProductionLocationsQueryBuilder(TestCase):
         )
         self.assertEqual(
             expected,
-            self.builder.query_body['query']['bool']['filter']
+            self.builder.query_body['query']['bool']['filter'][0]
         )
 
     def test_add_geo_polygon(self):
@@ -307,5 +307,5 @@ class TestProductionLocationsQueryBuilder(TestCase):
         )
         self.assertEqual(
             expected,
-            self.builder.query_body['query']['bool']['filter']
+            self.builder.query_body['query']['bool']['filter'][0]
         )

--- a/src/django/api/tests/test_v1_utils.py
+++ b/src/django/api/tests/test_v1_utils.py
@@ -386,6 +386,33 @@ class V1UtilsTests(TestCase):
             error_response['errors'],
         )
 
+    def test_serialize_geo_polygon_not_enough_points(self):
+        query_dict = QueryDict('', mutable=True)
+        query_dict.setlist(
+            'geo_polygon',
+            ['91,45', '-91,100']
+        )
+        _, error_response = serialize_params(
+            ProductionLocationsSerializer,
+            query_dict
+        )
+
+        self.assertIsNotNone(error_response)
+        self.assertEqual(
+            error_response['detail'],
+            "The request query is invalid."
+        )
+        self.assertIn(
+            {
+                'field': 'geo_polygon',
+                'detail': (
+                    'At least 3 points are required in '
+                    'geo_polygon to form a valid polygon.'
+                )
+            },
+            error_response['errors'],
+        )
+
     def test_serialize_geo_polygon_valid(self):
         query_dict = QueryDict('', mutable=True)
         query_dict.setlist(

--- a/src/django/api/tests/test_v1_utils.py
+++ b/src/django/api/tests/test_v1_utils.py
@@ -21,7 +21,7 @@ class V1UtilsTests(TestCase):
             'percent_female_workers[min]': '20',
             'percent_female_workers[max]': '80',
             'coordinates[lat]': '12.34',
-            'coordinates[lng]': '56.78',
+            'coordinates[lon]': '56.78',
         })
         serialized_params, error_response = \
             serialize_params(ProductionLocationsSerializer, query_dict)

--- a/src/django/api/tests/test_v1_utils.py
+++ b/src/django/api/tests/test_v1_utils.py
@@ -323,7 +323,7 @@ class V1UtilsTests(TestCase):
                 'field': 'geo_polygon',
                 'detail': (
                     'Invalid coordinate format: invalid_coordinate, '
-                    "must be 'lat,lon' as floats"
+                    "must be 'lat,lon' as floats."
                 ),
             },
             error_response['errors'],

--- a/src/django/api/tests/test_v1_utils.py
+++ b/src/django/api/tests/test_v1_utils.py
@@ -31,7 +31,7 @@ class V1UtilsTests(TestCase):
         self.assertEqual(serialized_params['percent_female_workers_min'], 20)
         self.assertEqual(serialized_params['percent_female_workers_max'], 80)
         self.assertEqual(serialized_params['coordinates_lat'], 12.34)
-        self.assertEqual(serialized_params['coordinates_lng'], 56.78)
+        self.assertEqual(serialized_params['coordinates_lon'], 56.78)
 
     def test_serialize_params_with_single_values(self):
         query_dict = QueryDict('', mutable=True)

--- a/src/django/api/tests/test_v1_utils.py
+++ b/src/django/api/tests/test_v1_utils.py
@@ -313,7 +313,6 @@ class V1UtilsTests(TestCase):
         )
 
         self.assertIsNotNone(error_response)
-        print(f"### error_response: {error_response['errors']}")
         self.assertEqual(
             error_response['detail'],
             "The request query is invalid."

--- a/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
+++ b/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
@@ -156,5 +156,5 @@ class OpenSearchQueryDirector:
             )
 
         geo_polygon = query_params.getlist(V1_PARAMETERS_LIST.GEO_POLYGON)
-        if geo_polygon:
+        if geo_polygon and hasattr(self.__builder, 'add_geo_polygon'):
             self.__builder.add_geo_polygon(geo_polygon)

--- a/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
+++ b/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
@@ -22,6 +22,7 @@ class OpenSearchQueryDirector:
             V1_PARAMETERS_LIST.AFFILIATIONS: 'terms',
             V1_PARAMETERS_LIST.CERTIFICATIONS_STANDARDS_REGULATIONS: 'terms',
             V1_PARAMETERS_LIST.COORDINATES: 'geo_distance',
+            V1_PARAMETERS_LIST.GEO_POLYGON: 'geo_polygon',
             V1_PARAMETERS_LIST.CONTRIBUTOR_ID: 'terms',
             V1_PARAMETERS_LIST.REQUEST_TYPE: 'terms',
             V1_PARAMETERS_LIST.SOURCE: 'terms',
@@ -64,6 +65,10 @@ class OpenSearchQueryDirector:
             self.__add_range_query(field, query_params)
             return
 
+        if query_type == 'geo_polygon':
+            values = query_params.getlist(field)
+            self.__add_geo_polygon_query(field, values)
+
         if query_type == "geo_distance":
             lat = query_params.get(f"{field}[lat]")
             lng = query_params.get(f"{field}[lng]")
@@ -85,6 +90,9 @@ class OpenSearchQueryDirector:
             self.__builder.add_geo_distance(
                 field, float(lat), float(lng), distance
             )
+
+    def __add_geo_polygon_query(self, field, values):
+        self.__builder.add_geo_polygon(field, values)
 
     def __process_sorting(self, query_params):
         sort_by = query_params.get(V1_PARAMETERS_LIST.SORT_BY)

--- a/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
+++ b/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
@@ -1,6 +1,5 @@
 from api.views.v1.parameters_list import V1_PARAMETERS_LIST
 
-
 class OpenSearchQueryDirector:
     def __init__(self, builder):
         self.__builder = builder
@@ -65,10 +64,6 @@ class OpenSearchQueryDirector:
             self.__add_range_query(field, query_params)
             return
 
-        if query_type == 'geo_polygon':
-            values = query_params.getlist(field)
-            self.__add_geo_polygon_query(field, values)
-
         if query_type == "geo_distance":
             lat = query_params.get(f"{field}[lat]")
             lng = query_params.get(f"{field}[lng]")
@@ -91,8 +86,8 @@ class OpenSearchQueryDirector:
                 field, float(lat), float(lng), distance
             )
 
-    def __add_geo_polygon_query(self, field, values):
-        self.__builder.add_geo_polygon(field, values)
+    def __add_geo_polygon_query(self, values):
+        self.__builder.add_geo_polygon(values)
 
     def __process_sorting(self, query_params):
         sort_by = query_params.get(V1_PARAMETERS_LIST.SORT_BY)
@@ -161,3 +156,7 @@ class OpenSearchQueryDirector:
             self.__builder.add_geo_bounding_box(
                 float(top), float(left), float(bottom), float(right)
             )
+
+        geo_polygon = query_params.getlist(V1_PARAMETERS_LIST.GEO_POLYGON)
+        if geo_polygon:
+            self.__add_geo_polygon_query(geo_polygon)

--- a/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
+++ b/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
@@ -44,6 +44,7 @@ class OpenSearchQueryDirector:
         self.__process_aggregation(query_params)
         self.__process_filter(query_params)
 
+        print(f'@@@ Final query body: {self.__builder.get_final_query_body()}')
         return self.__builder.get_final_query_body()
 
     def __process_template_fields(self, query_params):
@@ -86,9 +87,6 @@ class OpenSearchQueryDirector:
             self.__builder.add_geo_distance(
                 field, float(lat), float(lng), distance
             )
-
-    def __add_geo_polygon_query(self, values):
-        self.__builder.add_geo_polygon(values)
 
     def __process_sorting(self, query_params):
         sort_by = query_params.get(V1_PARAMETERS_LIST.SORT_BY)
@@ -160,4 +158,4 @@ class OpenSearchQueryDirector:
 
         geo_polygon = query_params.getlist(V1_PARAMETERS_LIST.GEO_POLYGON)
         if geo_polygon:
-            self.__add_geo_polygon_query(geo_polygon)
+            self.__builder.add_geo_polygon(geo_polygon)

--- a/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
+++ b/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
@@ -1,5 +1,6 @@
 from api.views.v1.parameters_list import V1_PARAMETERS_LIST
 
+
 class OpenSearchQueryDirector:
     def __init__(self, builder):
         self.__builder = builder

--- a/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
+++ b/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
@@ -44,7 +44,6 @@ class OpenSearchQueryDirector:
         self.__process_aggregation(query_params)
         self.__process_filter(query_params)
 
-        print(f'@@@ Final query body: {self.__builder.get_final_query_body()}')
         return self.__builder.get_final_query_body()
 
     def __process_template_fields(self, query_params):

--- a/src/django/api/views/v1/opensearch_query_builder/production_locations_query_builder.py
+++ b/src/django/api/views/v1/opensearch_query_builder/production_locations_query_builder.py
@@ -143,10 +143,9 @@ class ProductionLocationsQueryBuilder(OpenSearchQueryBuilder):
         }
 
     def add_geo_polygon(self, values):
+        if "filter" not in self.query_body["query"]["bool"]:
+            self.query_body["query"]["bool"]["filter"] = {}
         if len(values) >= 1:
-            if "filter" not in self.query_body:
-                self.query_body["query"] = {"bool": {"filter": {}}}
-
             if "geo_polygon" not in self.query_body["query"]["bool"]["filter"]:
                 self.query_body["query"]["bool"]["filter"]["geo_polygon"] = {"point": {"points": []}}
 

--- a/src/django/api/views/v1/opensearch_query_builder/production_locations_query_builder.py
+++ b/src/django/api/views/v1/opensearch_query_builder/production_locations_query_builder.py
@@ -145,13 +145,17 @@ class ProductionLocationsQueryBuilder(OpenSearchQueryBuilder):
     def add_geo_polygon(self, values):
         if "filter" not in self.query_body["query"]["bool"]:
             self.query_body["query"]["bool"]["filter"] = {}
+
+
         if len(values) >= 1:
             if "geo_polygon" not in self.query_body["query"]["bool"]["filter"]:
-                self.query_body["query"]["bool"]["filter"]["geo_polygon"] = {"point": {"points": []}}
+                self.query_body["query"]["bool"]["filter"]["geo_polygon"] = {
+                    "coordinates": {"points": []}
+                }
 
-            points = self.query_body["query"]["bool"]["filter"]["geo_polygon"]["point"]["points"]
+            query = self.query_body["query"]["bool"]["filter"]["geo_polygon"]
+            points = query["coordinates"]["points"]
 
             for point in values:
                 lat, lon = map(float, point.split(","))
                 points.append({"lat": lat, "lon": lon})
-

--- a/src/django/api/views/v1/opensearch_query_builder/production_locations_query_builder.py
+++ b/src/django/api/views/v1/opensearch_query_builder/production_locations_query_builder.py
@@ -67,6 +67,10 @@ class ProductionLocationsQueryBuilder(OpenSearchQueryBuilder):
             }
         })
 
+    def __init_filter(self):
+        if "filter" not in self.query_body["query"]["bool"]:
+            self.query_body["query"]["bool"]["filter"] = []
+
     def add_terms(self, field, values):
         if not values:
             return self.query_body
@@ -131,8 +135,7 @@ class ProductionLocationsQueryBuilder(OpenSearchQueryBuilder):
         return self.query_body
 
     def add_geo_bounding_box(self, top, left, bottom, right):
-        if "filter" not in self.query_body["query"]["bool"]:
-            self.query_body["query"]["bool"]["filter"] = []
+        self.__init_filter()
 
         self.query_body['query']['bool']['filter'].append({
             'geo_bounding_box': {
@@ -146,8 +149,7 @@ class ProductionLocationsQueryBuilder(OpenSearchQueryBuilder):
         })
 
     def add_geo_polygon(self, values):
-        if "filter" not in self.query_body["query"]["bool"]:
-            self.query_body["query"]["bool"]["filter"] = []
+        self.__init_filter()
 
         geo_polygon_filter = None
         for filter_item in self.query_body["query"]["bool"]["filter"]:

--- a/src/django/api/views/v1/opensearch_query_builder/production_locations_query_builder.py
+++ b/src/django/api/views/v1/opensearch_query_builder/production_locations_query_builder.py
@@ -146,7 +146,6 @@ class ProductionLocationsQueryBuilder(OpenSearchQueryBuilder):
         if "filter" not in self.query_body["query"]["bool"]:
             self.query_body["query"]["bool"]["filter"] = {}
 
-
         if len(values) >= 1:
             if "geo_polygon" not in self.query_body["query"]["bool"]["filter"]:
                 self.query_body["query"]["bool"]["filter"]["geo_polygon"] = {

--- a/src/django/api/views/v1/opensearch_query_builder/production_locations_query_builder.py
+++ b/src/django/api/views/v1/opensearch_query_builder/production_locations_query_builder.py
@@ -141,3 +141,23 @@ class ProductionLocationsQueryBuilder(OpenSearchQueryBuilder):
                 }
             }
         }
+
+    def add_geo_polygon(self, field, values):
+        print(f'@@@ geo_polygon: {values}')
+        pass
+        '''
+        Should be inside filter
+        Should not create new geo_polygon object each time
+        self.query_body['query']['bool']['filter'] = {
+            "geo_polygon": {
+                "point": {
+                    "points": [
+                        { "lat": 74.5627, "lon": 41.8645 },
+                        { "lat": 73.7562, "lon": 42.6526 },
+                        { "lat": 73.3245, "lon": 41.6189 },
+                        { "lat": 74.0060, "lon": 40.7128 }
+                    ]
+                }
+            }
+        }
+        '''

--- a/src/django/api/views/v1/opensearch_query_builder/production_locations_query_builder.py
+++ b/src/django/api/views/v1/opensearch_query_builder/production_locations_query_builder.py
@@ -151,7 +151,7 @@ class ProductionLocationsQueryBuilder(OpenSearchQueryBuilder):
     def add_geo_polygon(self, values):
         self.__init_filter()
 
-        new_geo_polygon = {
+        geo_polygon = {
             "geo_polygon": {
                 "coordinates": {
                     "points": [
@@ -166,11 +166,4 @@ class ProductionLocationsQueryBuilder(OpenSearchQueryBuilder):
             }
         }
 
-        # Remove the existing geo_polygon filter, if present,
-        # to maintain immutability.
-        self.query_body["query"]["bool"]["filter"] = [
-            f for f in self.query_body["query"]["bool"]["filter"]
-            if "geo_polygon" not in f
-        ]
-
-        self.query_body["query"]["bool"]["filter"].append(new_geo_polygon)
+        self.query_body["query"]["bool"]["filter"].append(geo_polygon)

--- a/src/django/api/views/v1/opensearch_query_builder/production_locations_query_builder.py
+++ b/src/django/api/views/v1/opensearch_query_builder/production_locations_query_builder.py
@@ -142,22 +142,17 @@ class ProductionLocationsQueryBuilder(OpenSearchQueryBuilder):
             }
         }
 
-    def add_geo_polygon(self, field, values):
-        print(f'@@@ geo_polygon: {values}')
-        pass
-        '''
-        Should be inside filter
-        Should not create new geo_polygon object each time
-        self.query_body['query']['bool']['filter'] = {
-            "geo_polygon": {
-                "point": {
-                    "points": [
-                        { "lat": 74.5627, "lon": 41.8645 },
-                        { "lat": 73.7562, "lon": 42.6526 },
-                        { "lat": 73.3245, "lon": 41.6189 },
-                        { "lat": 74.0060, "lon": 40.7128 }
-                    ]
-                }
-            }
-        }
-        '''
+    def add_geo_polygon(self, values):
+        if len(values) >= 1:
+            if "filter" not in self.query_body:
+                self.query_body["query"] = {"bool": {"filter": {}}}
+
+            if "geo_polygon" not in self.query_body["query"]["bool"]["filter"]:
+                self.query_body["query"]["bool"]["filter"]["geo_polygon"] = {"point": {"points": []}}
+
+            points = self.query_body["query"]["bool"]["filter"]["geo_polygon"]["point"]["points"]
+
+            for point in values:
+                lat, lon = map(float, point.split(","))
+                points.append({"lat": lat, "lon": lon})
+

--- a/src/django/api/views/v1/parameters_list.py
+++ b/src/django/api/views/v1/parameters_list.py
@@ -34,3 +34,4 @@ class V1_PARAMETERS_LIST:
     AGGREGATION = 'aggregation'
     GEOHEX_GRID_PRECISION = 'geohex_grid_precision'
     GEO_BOUNDING_BOX = 'geo_bounding_box'
+    GEO_POLYGON = 'geo_polygon'

--- a/src/django/api/views/v1/utils.py
+++ b/src/django/api/views/v1/utils.py
@@ -65,7 +65,18 @@ def serialize_params(serializer_class, query_params):
                     print(f'error_data as dict: {error_data}')
                     error_response['errors'].append({
                         'field': field,
-                        'detail': next(iter(error_data.values()))[0]
+                        'detail': (
+                            next(iter(error_data.values()))[0]
+                            if (
+                                error_data and next(
+                                    iter(error_data.values()), []
+                                )
+                            )
+                            else (
+                                APIV1CommonErrorMessages
+                                .COMMON_REQ_PARAMETER_ERROR
+                            )
+                        )
                     })
                 else:
                     error_response['errors'].append({

--- a/src/django/api/views/v1/utils.py
+++ b/src/django/api/views/v1/utils.py
@@ -62,7 +62,6 @@ def serialize_params(serializer_class, query_params):
                         'detail': error_data[0].capitalize()
                     })
                 elif isinstance(error_data, dict):
-                    print(f'error_data as dict: {error_data}')
                     error_response['errors'].append({
                         'field': field,
                         'detail': (
@@ -77,6 +76,11 @@ def serialize_params(serializer_class, query_params):
                                 .COMMON_REQ_PARAMETER_ERROR
                             )
                         )
+                    })
+                elif isinstance(error_data, str):
+                    error_response['errors'].append({
+                        'field': field,
+                        'detail': error_data.capitalize()
                     })
                 else:
                     error_response['errors'].append({

--- a/src/django/api/views/v1/utils.py
+++ b/src/django/api/views/v1/utils.py
@@ -31,11 +31,6 @@ def serialize_params(serializer_class, query_params):
         ]:
             new_key = key.replace(']', '').replace('[', '_')
             flattened_query_params[new_key] = value[0]
-            # Convert multi-value query parameter
-            # TODO: Probably you don't need to do extra serialization here
-            '''
-            elif key in [V1_PARAMETERS_LIST.GEO_POLYGON]:
-            '''
         # Prepare only single params
         elif key in [
             V1_PARAMETERS_LIST.ADDRESS,

--- a/src/django/api/views/v1/utils.py
+++ b/src/django/api/views/v1/utils.py
@@ -31,6 +31,11 @@ def serialize_params(serializer_class, query_params):
         ]:
             new_key = key.replace(']', '').replace('[', '_')
             flattened_query_params[new_key] = value[0]
+            # Convert multi-value query parameter
+            # TODO: Probably you don't need to do extra serialization here
+            '''
+            elif key in [V1_PARAMETERS_LIST.GEO_POLYGON]:
+            '''
         # Prepare only single params
         elif key in [
             V1_PARAMETERS_LIST.ADDRESS,

--- a/src/django/api/views/v1/utils.py
+++ b/src/django/api/views/v1/utils.py
@@ -55,11 +55,25 @@ def serialize_params(serializer_class, query_params):
         if 'detail' not in params.errors and 'errors' not in params.errors:
             error_response['detail'] = \
                 APIV1CommonErrorMessages.COMMON_REQ_QUERY_ERROR
-            for field, error_list in params.errors.items():
-                error_response['errors'].append({
-                    'field': field,
-                    'detail': error_list[0].capitalize()
-                })
+            for field, error_data in params.errors.items():
+                if isinstance(error_data, list):
+                    error_response['errors'].append({
+                        'field': field,
+                        'detail': error_data[0].capitalize()
+                    })
+                elif isinstance(error_data, dict):
+                    print(f'error_data as dict: {error_data}')
+                    error_response['errors'].append({
+                        'field': field,
+                        'detail': next(iter(error_data.values()))[0]
+                    })
+                else:
+                    error_response['errors'].append({
+                        'field': field,
+                        'detail': (
+                            APIV1CommonErrorMessages.COMMON_REQ_PARAMETER_ERROR
+                        )
+                    })
 
         # Handle errors that come from serializers
         detail_errors = params.errors.get('detail')

--- a/src/tests/v1/test_production_locations.py
+++ b/src/tests/v1/test_production_locations.py
@@ -225,3 +225,59 @@ class ProductionLocationsTest(BaseAPITest):
         self.assertEqual(len(result['data']), 1)
         self.assertEqual(result['data'][0]['os_id'], "GL202309INSIDE")
 
+    def test_production_locations_with_more_than_hundred_points(self):
+        query = (
+            "?geo_polygon=71.0,-25.0&geo_polygon=70.5,-22.0&geo_polygon=70.0,-19.0"
+            "&geo_polygon=69.5,-16.0&geo_polygon=69.0,-13.0&geo_polygon=68.5,-10.0"
+            "&geo_polygon=68.0,-7.0&geo_polygon=67.5,-4.0&geo_polygon=67.0,-1.0"
+            "&geo_polygon=66.5,2.0&geo_polygon=66.0,5.0&geo_polygon=65.5,8.0"
+            "&geo_polygon=65.0,11.0&geo_polygon=64.5,14.0&geo_polygon=64.0,17.0"
+            "&geo_polygon=63.5,20.0&geo_polygon=63.0,23.0&geo_polygon=62.5,26.0"
+            "&geo_polygon=62.0,29.0&geo_polygon=61.5,32.0&geo_polygon=61.0,35.0"
+            "&geo_polygon=60.5,38.0&geo_polygon=60.0,41.0&geo_polygon=59.5,44.0"
+            "&geo_polygon=59.0,47.0&geo_polygon=58.5,50.0&geo_polygon=58.0,53.0"
+            "&geo_polygon=57.5,56.0&geo_polygon=57.0,59.0&geo_polygon=56.5,62.0"
+            "&geo_polygon=56.0,65.0&geo_polygon=55.5,68.0&geo_polygon=55.0,71.0"
+            "&geo_polygon=54.5,74.0&geo_polygon=54.0,77.0&geo_polygon=53.5,80.0"
+            "&geo_polygon=53.0,83.0&geo_polygon=52.5,86.0&geo_polygon=52.0,89.0"
+            "&geo_polygon=51.5,92.0&geo_polygon=51.0,95.0&geo_polygon=50.5,98.0"
+            "&geo_polygon=50.0,101.0&geo_polygon=49.5,104.0&geo_polygon=49.0,107.0"
+            "&geo_polygon=48.5,110.0&geo_polygon=48.0,113.0&geo_polygon=47.5,116.0"
+            "&geo_polygon=47.0,119.0&geo_polygon=46.5,122.0&geo_polygon=46.0,125.0"
+            "&geo_polygon=45.5,128.0&geo_polygon=45.0,131.0&geo_polygon=44.5,134.0"
+            "&geo_polygon=44.0,137.0&geo_polygon=43.5,140.0&geo_polygon=43.0,143.0"
+            "&geo_polygon=42.5,146.0&geo_polygon=42.0,149.0&geo_polygon=41.5,152.0"
+            "&geo_polygon=41.0,155.0&geo_polygon=40.5,158.0&geo_polygon=40.0,161.0"
+            "&geo_polygon=39.5,164.0&geo_polygon=39.0,167.0&geo_polygon=38.5,170.0"
+            "&geo_polygon=38.0,173.0&geo_polygon=37.5,176.0&geo_polygon=37.0,179.0"
+            "&geo_polygon=36.5,-178.0&geo_polygon=36.0,-175.0&geo_polygon=35.5,-172.0"
+            "&geo_polygon=35.0,-169.0&geo_polygon=34.5,-166.0&geo_polygon=34.0,-163.0"
+            "&geo_polygon=33.5,-160.0&geo_polygon=33.0,-157.0&geo_polygon=32.5,-154.0"
+            "&geo_polygon=32.0,-151.0&geo_polygon=31.5,-148.0&geo_polygon=31.0,-145.0"
+            "&geo_polygon=30.5,-142.0&geo_polygon=30.0,-139.0&geo_polygon=29.5,-136.0"
+            "&geo_polygon=29.0,-133.0&geo_polygon=28.5,-130.0&geo_polygon=28.0,-127.0"
+            "&geo_polygon=27.5,-124.0&geo_polygon=27.0,-121.0&geo_polygon=26.5,-118.0"
+            "&geo_polygon=26.0,-115.0&geo_polygon=25.5,-112.0&geo_polygon=25.0,-109.0"
+            "&geo_polygon=24.5,-106.0&geo_polygon=24.0,-103.0&geo_polygon=23.5,-100.0"
+            "&geo_polygon=23.0,-97.0&geo_polygon=22.5,-94.0&geo_polygon=22.0,-91.0"
+            "&geo_polygon=21.5,-88.0&geo_polygon=21.0,-85.0&geo_polygon=20.5,-82.0"
+            "&geo_polygon=20.0,-79.0&geo_polygon=19.5,-76.0&geo_polygon=19.0,-73.0"
+            "&geo_polygon=18.5,-70.0&geo_polygon=18.0,-67.0&geo_polygon=17.5,-64.0"
+            "&geo_polygon=17.0,-61.0&geo_polygon=16.5,-58.0&geo_polygon=16.0,-55.0"
+            "&geo_polygon=15.5,-52.0&geo_polygon=15.0,-49.0&geo_polygon=14.5,-46.0"
+            "&geo_polygon=14.0,-43.0&geo_polygon=13.5,-40.0&geo_polygon=13.0,-37.0"
+            "&geo_polygon=12.5,-34.0&geo_polygon=12.0,-31.0&geo_polygon=11.5,-28.0"
+            "&geo_polygon=11.0,-25.0&geo_polygon=10.5,-22.0&geo_polygon=10.0,-19.0"
+        )
+
+        response = requests.get(
+            f"{self.root_url}/api/v1/production-locations/{query}",
+            headers=self.basic_headers,
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        result = response.json()
+        self.assertIsNotNone(result['data'])
+        self.assertGreater(len(result['data']), 0)
+

--- a/src/tests/v1/test_production_locations.py
+++ b/src/tests/v1/test_production_locations.py
@@ -163,11 +163,11 @@ class ProductionLocationsTest(BaseAPITest):
             "sector": ["Retail"],
             "address": "Inside Polygon Address",
             "name": "Inside Polygon Location",
-            "country": {"alpha_2": "US"},
-            "os_id": "US202309INSIDE",
+            "country": {"alpha_2": "GL"},
+            "os_id": "GL202309INSIDE",
             "coordinates": {
-                "lon": -73.3121232,
-                "lat": 40.7667421
+                "lon": -47.0,
+                "lat": 78.0
             },
         }
         
@@ -198,7 +198,7 @@ class ProductionLocationsTest(BaseAPITest):
             index=self.production_locations_index_name
         )
 
-        query = "?geo_polygon=40.8193217,-73.0273466&geo_polygon=40.7667421,-73.3121232&geo_polygon=40.8459614,-73.5528312"
+        query = "?geo_polygon=79.318492,-39.36719&geo_polygon=79.280399,-55.39907&geo_polygon=77.57295,-55.512304&geo_polygon=77.598154,-38.396004"
         response = requests.get(
             f"{self.root_url}/api/v1/production-locations/{query}",
             headers=self.basic_headers,
@@ -207,4 +207,5 @@ class ProductionLocationsTest(BaseAPITest):
         result = response.json()
         self.assertIsNotNone(result['data'])
         self.assertEqual(len(result['data']), 1)
-        self.assertEqual(result['data'][0]['os_id'], "US202309INSIDE")
+        self.assertEqual(result['data'][0]['os_id'], "GL202309INSIDE")
+

--- a/src/tests/v1/test_production_locations.py
+++ b/src/tests/v1/test_production_locations.py
@@ -2,7 +2,6 @@ import requests
 from .base_api_test \
     import BaseAPITest
 
-from rest_framework import status
 
 class ProductionLocationsTest(BaseAPITest):
 
@@ -11,7 +10,7 @@ class ProductionLocationsTest(BaseAPITest):
             f"{self.root_url}/api/v1/production-locations/",
             headers=self.basic_headers,
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, 200)
 
     def test_production_locations_exact(self):
         # Index a document
@@ -276,7 +275,7 @@ class ProductionLocationsTest(BaseAPITest):
             headers=self.basic_headers,
         )
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, 200)
 
         result = response.json()
         self.assertIsNotNone(result['data'])
@@ -294,7 +293,7 @@ class ProductionLocationsTest(BaseAPITest):
             headers=self.basic_headers,
         )
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, 400)
 
         result = response.json()
         self.assertEqual(result['detail'], 'The request query is invalid.')

--- a/src/tests/v1/test_production_locations.py
+++ b/src/tests/v1/test_production_locations.py
@@ -158,6 +158,39 @@ class ProductionLocationsTest(BaseAPITest):
         self.assertEqual(len(result['data']), 1)
         self.assertEqual(result['data'][0]['os_id'], 'US2020052SV22KJ')
 
+    def test_production_locations_geo_polygon_outside(self):
+        outside_polygon = {
+            "sector": ["Retail"],
+            "address": "Outside Polygon Address",
+            "name": "Outside Polygon Location",
+            "country": {"alpha_2": "US"},
+            "os_id": "US202309OUTSIDE",
+            "coordinates": {
+                "lon": -75.000000,
+                "lat": 42.000000
+            },
+        }
+
+        self.open_search_client.index(
+            index=self.production_locations_index_name,
+            body=outside_polygon,
+            id=self.open_search_client.count()
+        )
+
+        self.open_search_client.indices.refresh(
+            index=self.production_locations_index_name
+        )
+
+        query = "?geo_polygon=79.318492,-39.36719&geo_polygon=79.280399,-55.39907&geo_polygon=77.57295,-55.512304&geo_polygon=77.598154,-38.396004"
+        response = requests.get(
+            f"{self.root_url}/api/v1/production-locations/{query}",
+            headers=self.basic_headers,
+        )
+
+        result = response.json()
+        self.assertIsNotNone(result['data'])
+        self.assertEqual(len(result['data']), 0)
+
     def test_production_locations_geo_polygon_inside(self):
         inside_polygon = {
             "sector": ["Retail"],
@@ -191,37 +224,4 @@ class ProductionLocationsTest(BaseAPITest):
         self.assertIsNotNone(result['data'])
         self.assertEqual(len(result['data']), 1)
         self.assertEqual(result['data'][0]['os_id'], "GL202309INSIDE")
-
-    def test_production_locations_geo_polygon_outside(self):
-        outside_polygon = {
-            "sector": ["Retail"],
-            "address": "Outside Polygon Address",
-            "name": "Outside Polygon Location",
-            "country": {"alpha_2": "US"},
-            "os_id": "US202309OUTSIDE",
-            "coordinates": {
-                "lon": -75.000000,
-                "lat": 42.000000
-            },
-        }
-
-        self.open_search_client.index(
-            index=self.production_locations_index_name,
-            body=outside_polygon,
-            id=self.open_search_client.count()
-        )
-
-        self.open_search_client.indices.refresh(
-            index=self.production_locations_index_name
-        )
-
-        query = "?geo_polygon=79.318492,-39.36719&geo_polygon=79.280399,-55.39907&geo_polygon=77.57295,-55.512304&geo_polygon=77.598154,-38.396004"
-        response = requests.get(
-            f"{self.root_url}/api/v1/production-locations/{query}",
-            headers=self.basic_headers,
-        )
-
-        result = response.json()
-        self.assertIsNotNone(result['data'])
-        self.assertEqual(len(result['data']), 0)
 

--- a/src/tests/v1/test_production_locations.py
+++ b/src/tests/v1/test_production_locations.py
@@ -158,7 +158,7 @@ class ProductionLocationsTest(BaseAPITest):
         self.assertEqual(len(result['data']), 1)
         self.assertEqual(result['data'][0]['os_id'], 'US2020052SV22KJ')
 
-    def test_production_locations_geo_polygon(self):
+    def test_production_locations_geo_polygon_inside(self):
         inside_polygon = {
             "sector": ["Retail"],
             "address": "Inside Polygon Address",
@@ -170,30 +170,13 @@ class ProductionLocationsTest(BaseAPITest):
                 "lat": 78.0
             },
         }
-        
-        outside_polygon = {
-            "sector": ["Retail"],
-            "address": "Outside Polygon Address",
-            "name": "Outside Polygon Location",
-            "country": {"alpha_2": "US"},
-            "os_id": "US202309OUTSIDE",
-            "coordinates": {
-                "lon": -75.000000,
-                "lat": 42.000000
-            },
-        }
 
         self.open_search_client.index(
             index=self.production_locations_index_name,
             body=inside_polygon,
             id=self.open_search_client.count()
         )
-        self.open_search_client.index(
-            index=self.production_locations_index_name,
-            body=outside_polygon,
-            id=self.open_search_client.count()
-        )
-        
+
         self.open_search_client.indices.refresh(
             index=self.production_locations_index_name
         )
@@ -208,4 +191,37 @@ class ProductionLocationsTest(BaseAPITest):
         self.assertIsNotNone(result['data'])
         self.assertEqual(len(result['data']), 1)
         self.assertEqual(result['data'][0]['os_id'], "GL202309INSIDE")
+
+    def test_production_locations_geo_polygon_outside(self):
+        outside_polygon = {
+            "sector": ["Retail"],
+            "address": "Outside Polygon Address",
+            "name": "Outside Polygon Location",
+            "country": {"alpha_2": "US"},
+            "os_id": "US202309OUTSIDE",
+            "coordinates": {
+                "lon": -75.000000,
+                "lat": 42.000000
+            },
+        }
+
+        self.open_search_client.index(
+            index=self.production_locations_index_name,
+            body=outside_polygon,
+            id=self.open_search_client.count()
+        )
+
+        self.open_search_client.indices.refresh(
+            index=self.production_locations_index_name
+        )
+
+        query = "?geo_polygon=79.318492,-39.36719&geo_polygon=79.280399,-55.39907&geo_polygon=77.57295,-55.512304&geo_polygon=77.598154,-38.396004"
+        response = requests.get(
+            f"{self.root_url}/api/v1/production-locations/{query}",
+            headers=self.basic_headers,
+        )
+
+        result = response.json()
+        self.assertIsNotNone(result['data'])
+        self.assertEqual(len(result['data']), 0)
 

--- a/src/tests/v1/test_production_locations.py
+++ b/src/tests/v1/test_production_locations.py
@@ -188,6 +188,7 @@ class ProductionLocationsTest(BaseAPITest):
         )
 
         result = response.json()
+        print(result)
         self.assertIsNotNone(result['data'])
         self.assertEqual(len(result['data']), 0)
 

--- a/src/tests/v1/test_production_locations.py
+++ b/src/tests/v1/test_production_locations.py
@@ -2,6 +2,7 @@ import requests
 from .base_api_test \
     import BaseAPITest
 
+from rest_framework import status
 
 class ProductionLocationsTest(BaseAPITest):
 
@@ -10,7 +11,7 @@ class ProductionLocationsTest(BaseAPITest):
             f"{self.root_url}/api/v1/production-locations/",
             headers=self.basic_headers,
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_production_locations_exact(self):
         # Index a document
@@ -275,9 +276,28 @@ class ProductionLocationsTest(BaseAPITest):
             headers=self.basic_headers,
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         result = response.json()
         self.assertIsNotNone(result['data'])
         self.assertGreater(len(result['data']), 0)
+
+    def test_production_locations_with_missed_geo_polygon_value(self):
+        query = (
+            "?geo_polygon=79.318492,-39.36719&"
+            "geo_polygon=79.280399,-55.39907&"
+            "geo_polygon=&geo_polygon="
+        )
+
+        response = requests.get(
+            f"{self.root_url}/api/v1/production-locations/{query}",
+            headers=self.basic_headers,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        result = response.json()
+        self.assertEqual(result['detail'], 'The request query is invalid.')
+        self.assertEqual(result['errors'][0]['field'], 'geo_polygon')
+        self.assertEqual(result['errors'][0]['detail'], 'This field may not be blank.')
 

--- a/src/tests/v1/test_production_locations.py
+++ b/src/tests/v1/test_production_locations.py
@@ -188,9 +188,8 @@ class ProductionLocationsTest(BaseAPITest):
         )
 
         result = response.json()
-        print(result)
-        self.assertIsNotNone(result['data'])
-        self.assertEqual(len(result['data']), 0)
+        os_ids = {item["os_id"] for item in result["data"]}
+        self.assertNotIn("US202309OUTSIDE", os_ids)
 
     def test_production_locations_geo_polygon_inside(self):
         inside_polygon = {


### PR DESCRIPTION
Fix [OSDEV-1201](https://opensupplyhub.atlassian.net/browse/OSDEV-1201)
Added support of `geo_polygon` parameter for GET `v1/production-locations` endpoint.

[OSDEV-1201]: https://opensupplyhub.atlassian.net/browse/OSDEV-1201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ