### PR TITLE
[OSDEV-1830] SLC UAT Bug - Drop down menus under Additional information section do not show all available options

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -3,6 +3,36 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). The format is based on the `RELEASE-NOTES-TEMPLATE.md` file.
 
+## Release 2.1.0
+
+## Introduction
+* Product name: Open Supply Hub
+* Release date: April 5, 2025
+
+### Database changes
+* *Describe high-level database changes.*
+
+#### Migrations:
+* *Describe migrations here.*
+
+#### Schema changes
+* *Describe schema changes here.*
+
+### Code/API changes
+* *Describe code/API changes here.*
+
+### Architecture/Environment changes
+* *Describe architecture/environment changes here.*
+
+### Bugfix
+* [OSDEV-1830](https://opensupplyhub.atlassian.net/browse/OSDEV-1830) - Updated implementation for `Production Location Info` page to input any values for `Location Type` and `Processing Type`, except when the sector is `Apparel` — in that case, enforce taxonomy filters.
+
+### Release instructions:
+* Ensure that the following commands are included in the `post_deployment` command:
+    * `migrate`
+    * `reindex_database`
+
+
 ## Release 2.0.0
 
 ## Introduction

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -32,9 +32,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * *Describe what's new here. The changes that can impact user experience should be listed in this section.*
 
 ### Release instructions:
-* Ensure that the following commands are included in the `post_deployment` command:
-    * `migrate`
-    * `reindex_database`
+* *Provide release instructions here.*
 
 
 ## Release 2.0.0

--- a/src/react/src/__tests__/components/ProductionLocationInfo.test.js
+++ b/src/react/src/__tests__/components/ProductionLocationInfo.test.js
@@ -14,16 +14,19 @@ jest.mock('@material-ui/core/Popper', () => ({ children }) => children);
 jest.mock('@material-ui/core/Portal', () => ({ children }) => children);
 
 jest.mock("../../components/Filters/StyledSelect", () => (props) => {
-    const { options = [], value, onChange, onBlur, placeholder } = props;
+    const { options = [], value, onChange, onBlur, placeholder, name } = props;
+
     return (
         <select
-            data-testid="mocked-select"
+            data-testid={`mocked-select-${name}`}
             value={value ? value.value : ""}
             onChange={(e) => {
                 const selectedOption = options.find(
                     (opt) => opt.value === e.target.value,
                 );
-                onChange(selectedOption);
+                onChange(
+                    name === 'country' ? selectedOption : [selectedOption]
+                );
             }}
             onBlur={onBlur}
         >
@@ -100,7 +103,7 @@ describe("ProductionLocationInfo component, test input fields for POST v1/produc
         expect(addressInput).toBeInTheDocument();
         expect(addressInput).toHaveValue("");
 
-        const countrySelect = getByTestId("mocked-select");
+        const countrySelect = getByTestId("mocked-select-country");
         expect(countrySelect).toBeInTheDocument();
         expect(countrySelect).toHaveValue("");
 
@@ -116,7 +119,7 @@ describe("ProductionLocationInfo component, test input fields for POST v1/produc
 
         const nameInput = getByPlaceholderText("Enter the name");
         const addressInput = getByPlaceholderText("Enter the full address");
-        const countrySelect = getByTestId("mocked-select");
+        const countrySelect = getByTestId("mocked-select-country");
 
         fireEvent.blur(nameInput);
         fireEvent.blur(addressInput);
@@ -137,7 +140,7 @@ describe("ProductionLocationInfo component, test input fields for POST v1/produc
 
         const nameInput = getByPlaceholderText("Enter the name");
         const addressInput = getByPlaceholderText("Enter the full address");
-        const countrySelect = getByTestId("mocked-select");
+        const countrySelect = getByTestId("mocked-select-country");
 
         fireEvent.change(nameInput, { target: { value: "Test Name" } });
         fireEvent.change(addressInput, { target: { value: "Test Address" } });
@@ -184,7 +187,7 @@ describe("ProductionLocationInfo component, test input fields for POST v1/produc
 
         const nameInput = getByPlaceholderText("Enter the name");
         const addressInput = getByPlaceholderText("Enter the full address");
-        const countrySelect = getByTestId("mocked-select");
+        const countrySelect = getByTestId("mocked-select-country");
 
         fireEvent.change(nameInput, { target: { value: "Test Name" } });
         fireEvent.change(addressInput, { target: { value: "Test Address" } });
@@ -267,6 +270,22 @@ describe("ProductionLocationInfo component, test input fields for POST v1/produc
         const noTooltipElementAfter = document.querySelector(`[title="${MAINTENANCE_MESSAGE}"]`);
 
         expect(noTooltipElementAfter).toBeInTheDocument();
+    });
+
+    test("displays select or input for location and processing type fields", () => {
+        const { getByTestId, getByText } = renderComponent();
+
+        const switchButton = getByTestId("switch-additional-info-fields");
+        fireEvent.click(switchButton);
+    
+        expect(getByText("Enter location type(s)")).toBeInTheDocument();
+        expect(getByText("Enter processing type(s)")).toBeInTheDocument();
+
+        const sectorSelect = getByTestId("mocked-select-sector");
+        fireEvent.change(sectorSelect, { target: { value: 'Apparel' } });
+
+        expect(getByText("Select location type(s)")).toBeInTheDocument();
+        expect(getByText("Select processing type(s)")).toBeInTheDocument();
     });
 });
 

--- a/src/react/src/__tests__/components/ProductionLocationInfo.test.js
+++ b/src/react/src/__tests__/components/ProductionLocationInfo.test.js
@@ -158,9 +158,9 @@ describe("ProductionLocationInfo component, test input fields for POST v1/produc
         expect(getByText("Product Type(s)")).toBeInTheDocument();
         expect(getByText("Enter the type of products produced at this location. For example: Shirts, Laptops, Solar Panels.")).toBeInTheDocument();
         expect(getByText("Location Type(s)")).toBeInTheDocument();
-        expect(getByText("Select the location type(s) for this production location. For example: Final Product Assembly, Raw Materials Production or Processing, Office/HQ.")).toBeInTheDocument();
+        expect(getByText("Select or enter the location type(s) for this production location. For example: Final Product Assembly, Raw Materials Production or Processing, Office/HQ.")).toBeInTheDocument();
         expect(getByText("Processing Type(s)")).toBeInTheDocument();
-        expect(getByText("Select the type of processing activities that take place at this location. For example: Printing, Tooling, Assembly.")).toBeInTheDocument();
+        expect(getByText("Select or enter the type of processing activities that take place at this location. For example: Printing, Tooling, Assembly.")).toBeInTheDocument();
         expect(getByText("Number of Workers")).toBeInTheDocument();
         expect(getByText("Enter a number or a range for the number of people employed at the location. For example: 100, 100-150.")).toBeInTheDocument();
         expect(getByText("Parent Company")).toBeInTheDocument();

--- a/src/react/src/components/Contribute/ProductionLocationInfo.jsx
+++ b/src/react/src/components/Contribute/ProductionLocationInfo.jsx
@@ -602,7 +602,7 @@ const ProductionLocationInfo = ({
                         </Typography>
                         <StyledSelect
                             id="country"
-                            name="Country"
+                            name="country"
                             aria-label="Country"
                             options={countriesOptions || []}
                             value={inputCountry}
@@ -705,7 +705,7 @@ const ProductionLocationInfo = ({
 
                                     <StyledSelect
                                         creatable
-                                        name="Product Type"
+                                        name="product-type"
                                         value={productType}
                                         onChange={setProductType}
                                         placeholder="Enter product type(s)"
@@ -736,7 +736,7 @@ const ProductionLocationInfo = ({
                                     {enabledTaxonomy ? (
                                         <StyledSelect
                                             id="location_type"
-                                            name="Location type"
+                                            name="location-type"
                                             aria-label="Location type"
                                             options={mapFacilityTypeOptions(
                                                 facilityProcessingTypeOptions ||
@@ -752,7 +752,7 @@ const ProductionLocationInfo = ({
                                     ) : (
                                         <StyledSelect
                                             creatable
-                                            name="Location type"
+                                            name="location-type"
                                             value={locationType || []}
                                             onChange={setLocationType}
                                             placeholder="Enter location type(s)"
@@ -784,7 +784,7 @@ const ProductionLocationInfo = ({
                                     {enabledTaxonomy ? (
                                         <StyledSelect
                                             id="processing_type"
-                                            name="Processing Type"
+                                            name="processing-type"
                                             aria-label="Processing Type"
                                             options={mapProcessingTypeOptions(
                                                 facilityProcessingTypeOptions ||
@@ -800,7 +800,7 @@ const ProductionLocationInfo = ({
                                     ) : (
                                         <StyledSelect
                                             creatable
-                                            name="Processing Type"
+                                            name="processing-type"
                                             value={processingType || []}
                                             onChange={setProcessingType}
                                             placeholder="Enter processing type(s)"

--- a/src/react/src/components/Contribute/ProductionLocationInfo.jsx
+++ b/src/react/src/components/Contribute/ProductionLocationInfo.jsx
@@ -107,6 +107,7 @@ const ProductionLocationInfo = ({
     const [nameTouched, setNameTouched] = useState(false);
     const [addressTouched, setAddressTouched] = useState(false);
     const [countryTouched, setCountryTouched] = useState(false);
+    const [enabledTaxonomy, setEnabledTaxonomy] = useState(false);
     const [sector, setSector] = useState('');
     const [productType, setProductType] = useState([]);
     const [locationType, setLocationType] = useState(null);
@@ -399,6 +400,12 @@ const ProductionLocationInfo = ({
         singleModerationEventItemError,
         moderationID,
     ]);
+
+    useEffect(() => {
+        setEnabledTaxonomy(
+            sector.length === 1 && sector[0].value === 'Apparel',
+        );
+    }, [sector]);
 
     useEffect(
         () => () => {
@@ -721,25 +728,40 @@ const ProductionLocationInfo = ({
                                         component="h4"
                                         className={classes.subTitleStyles}
                                     >
-                                        Select the location type(s) for this
-                                        production location. For example: Final
-                                        Product Assembly, Raw Materials
+                                        Select or enter the location type(s) for
+                                        this production location. For example:
+                                        Final Product Assembly, Raw Materials
                                         Production or Processing, Office/HQ.
                                     </Typography>
-                                    <StyledSelect
-                                        id="location_type"
-                                        name="Location type"
-                                        aria-label="Location type"
-                                        options={mapFacilityTypeOptions(
-                                            facilityProcessingTypeOptions || [],
-                                            processingType || [],
-                                        )}
-                                        value={locationType}
-                                        onChange={setLocationType}
-                                        styles={getSelectStyles()}
-                                        className={classes.selectStyles}
-                                        placeholder="Select location type(s)"
-                                    />
+                                    {enabledTaxonomy ? (
+                                        <StyledSelect
+                                            id="location_type"
+                                            name="Location type"
+                                            aria-label="Location type"
+                                            options={mapFacilityTypeOptions(
+                                                facilityProcessingTypeOptions ||
+                                                    [],
+                                                processingType || [],
+                                            )}
+                                            value={locationType}
+                                            onChange={setLocationType}
+                                            styles={getSelectStyles()}
+                                            className={classes.selectStyles}
+                                            placeholder="Select location type(s)"
+                                        />
+                                    ) : (
+                                        <StyledSelect
+                                            creatable
+                                            name="Location type"
+                                            value={locationType || []}
+                                            onChange={setLocationType}
+                                            placeholder="Enter location type(s)"
+                                            aria-label="Location type"
+                                            styles={getSelectStyles()}
+                                            className={classes.selectStyles}
+                                            components={customSelectComponents}
+                                        />
+                                    )}
                                 </div>
                                 <div
                                     className={`${classes.inputSectionWrapStyles} ${classes.wrapStyles}`}
@@ -754,23 +776,40 @@ const ProductionLocationInfo = ({
                                         component="h4"
                                         className={classes.subTitleStyles}
                                     >
-                                        Select the type of processing activities
-                                        that take place at this location. For
-                                        example: Printing, Tooling, Assembly.
+                                        Select or enter the type of processing
+                                        activities that take place at this
+                                        location. For example: Printing,
+                                        Tooling, Assembly.
                                     </Typography>
-                                    <StyledSelect
-                                        id="processing_type"
-                                        name="Processing Type"
-                                        aria-label="Processing Type"
-                                        options={mapProcessingTypeOptions(
-                                            facilityProcessingTypeOptions || [],
-                                            locationType || [],
-                                        )}
-                                        value={processingType}
-                                        onChange={setProcessingType}
-                                        styles={getSelectStyles()}
-                                        className={classes.selectStyles}
-                                    />
+                                    {enabledTaxonomy ? (
+                                        <StyledSelect
+                                            id="processing_type"
+                                            name="Processing Type"
+                                            aria-label="Processing Type"
+                                            options={mapProcessingTypeOptions(
+                                                facilityProcessingTypeOptions ||
+                                                    [],
+                                                locationType || [],
+                                            )}
+                                            value={processingType}
+                                            onChange={setProcessingType}
+                                            styles={getSelectStyles()}
+                                            className={classes.selectStyles}
+                                            placeholder="Select processing type(s)"
+                                        />
+                                    ) : (
+                                        <StyledSelect
+                                            creatable
+                                            name="Processing Type"
+                                            value={processingType || []}
+                                            onChange={setProcessingType}
+                                            placeholder="Enter processing type(s)"
+                                            aria-label="Processing Type"
+                                            styles={getSelectStyles()}
+                                            className={classes.selectStyles}
+                                            components={customSelectComponents}
+                                        />
+                                    )}
                                 </div>
                                 <div
                                     className={`${classes.inputSectionWrapStyles} ${classes.wrapStyles}`}


### PR DESCRIPTION
[OSDEV-1830](https://opensupplyhub.atlassian.net/browse/OSDEV-1830) **SLC UAT Bug - Drop down menus under Additional information section do not show all available options**

- Updated implementation to input any values for Location Type and Processing Type, except when the sector is Apparel—in that case, enforce taxonomy filters.
- Updated UI tests for ProductionLocationInfo component to covered recent changes.

[OSDEV-1830]: https://opensupplyhub.atlassian.net/browse/OSDEV-1830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ