### PR TITLE
[OSDEV-1886] Delete Lambda@Edge function before destroying environment

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -36,6 +36,77 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: "eu-west-1"
 
+  destroy_lambda_edge_function:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.deploy-env }}
+    steps:
+      - name: Get Environment Name for ${{ vars.ENV_NAME }}
+        id: get_env_name
+        uses: Entepotenz/change-string-case-action-min-dependencies@v1
+        with:
+          string: ${{ vars.ENV_NAME }}
+
+      - name: Delete Lambda@Edge function
+        run: |
+          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          REGION="us-east-1"
+          LAMBDA_ARN="arn:aws:lambda:$REGION:$ACCOUNT_ID:function:funcOpenSupplyHub${{ vars.ENV_NAME }}RedirectToS3origin"
+          LAMBDA_VERSION=$(aws lambda list-versions-by-function --function-name "$LAMBDA_ARN" --region "$REGION" | jq -r '.Versions | max_by(.Version) | .Version')
+
+          for id in $(aws cloudfront list-distributions --query "DistributionList.Items[*].Id" --output text); do
+              domains=$(aws cloudfront get-distribution-config --id $id --query "DistributionConfig.Aliases.Items" --output text)
+              if [[ "$domains" == "$CLOUDFRONT_DOMAIN" ]]; then
+                  if [ ! -z "$DISTRIBUTION_ID" ]; then
+                      echo "Error: Multiple CloudFront distributions found for domain: $CLOUDFRONT_DOMAIN"
+                      exit 1
+                  fi
+                  echo "Found Distribution ID: $id for Domain: $CLOUDFRONT_DOMAIN"
+                  DISTRIBUTION_ID=$id
+              fi
+          done
+          if [ -z "$DISTRIBUTION_ID" ]; then
+            echo "Error: No CloudFront distribution found for domain: $CLOUDFRONT_DOMAIN"
+            exit 1
+          fi
+
+          echo "Fetching CloudFront distribution configuration..."
+          json=$(aws cloudfront get-distribution-config --id "$DISTRIBUTION_ID")
+          ETAG=$(echo "$json" | jq -r '.ETag')
+          CONFIG=$(echo "$json" | jq '.DistributionConfig')
+
+          CONFIG=$(echo "$CONFIG" | jq 'del(.DefaultCacheBehavior.LambdaFunctionAssociations.Items[] | select(.LambdaFunctionARN == "'$LAMBDA_ARN':'$LAMBDA_VERSION'"))')
+
+          echo "Updating CloudFront distribution to detach Lambda@Edge..."
+          UPDATED_CONFIG=$(echo "$CONFIG" | jq -c '.')
+          aws cloudfront update-distribution --id "$DISTRIBUTION_ID" --if-match "$ETAG" --distribution-config "$UPDATED_CONFIG"
+
+          echo "Waiting for CloudFront distribution deployment..."
+          aws cloudfront wait distribution-deployed --id "$DISTRIBUTION_ID"
+
+          echo "CloudFront distribution updated. Proceeding with Lambda function deletion..."
+
+          VERSIONS=$(aws lambda list-versions-by-function --function-name "$LAMBDA_ARN" --region "$REGION" | jq -r '.Versions[].Version')
+          for version in $VERSIONS; do
+              if [[ "$version" != "\$LATEST" ]]; then
+                  echo "Deleting Lambda version: $version"
+                  aws lambda delete-function --function-name "$LAMBDA_ARN:$version" --region "$REGION"
+              fi
+          done
+
+          echo "Lambda function deletion initiated. Verifying..."
+
+          while true;
+          do
+              if ! aws lambda get-function --function-name "$LAMBDA_ARN" --region "$REGION" 2>/dev/null; then
+                  echo "Lambda function successfully deleted."
+                  break
+              fi
+              echo "Waiting for Lambda function to be deleted..."
+              sleep 5
+          done
+
+          echo "Process completed successfully."
+
   destroy:
     runs-on: ubuntu-latest
     environment: ${{ inputs.deploy-env }}

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -48,6 +48,7 @@ jobs:
 
       - name: Delete Lambda@Edge function
         run: |
+          set -euo pipefail
           ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
           REGION="us-east-1"
           LAMBDA_ARN="arn:aws:lambda:$REGION:$ACCOUNT_ID:function:funcOpenSupplyHub${{ vars.ENV_NAME }}RedirectToS3origin"

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Delete Lambda@Edge function
+      - name: Delete Lambda@Edge function for ${{ vars.ENV_NAME }}
         run: |
           ./deployment/delete_lambda ${{ vars.ENV_NAME }}
         env:

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Delete Lambda@Edge function for ${{ vars.ENV_NAME }}
         run: |
-          ./deployment/delete_lambda ${{ vars.ENV_NAME }}
+          ./deployment/delete_lambda ${{ vars.ENV_NAME }} ${{ vars.CLOUDFRONT_DOMAIN }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -102,7 +102,7 @@ jobs:
                   break
               fi
               echo "Waiting for Lambda function to be deleted..."
-              sleep 5
+              sleep 30
           done
 
           echo "Process completed successfully."

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -46,67 +46,16 @@ jobs:
         with:
           string: ${{ vars.ENV_NAME }}
 
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
       - name: Delete Lambda@Edge function
         run: |
-          set -euo pipefail
-          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-          REGION="us-east-1"
-          LAMBDA_ARN="arn:aws:lambda:$REGION:$ACCOUNT_ID:function:funcOpenSupplyHub${{ vars.ENV_NAME }}RedirectToS3origin"
-          LAMBDA_VERSION=$(aws lambda list-versions-by-function --function-name "$LAMBDA_ARN" --region "$REGION" | jq -r '.Versions | max_by(.Version) | .Version')
-
-          for id in $(aws cloudfront list-distributions --query "DistributionList.Items[*].Id" --output text); do
-              domains=$(aws cloudfront get-distribution-config --id $id --query "DistributionConfig.Aliases.Items" --output text)
-              if [[ "$domains" == "$CLOUDFRONT_DOMAIN" ]]; then
-                  if [ ! -z "$DISTRIBUTION_ID" ]; then
-                      echo "Error: Multiple CloudFront distributions found for domain: $CLOUDFRONT_DOMAIN"
-                      exit 1
-                  fi
-                  echo "Found Distribution ID: $id for Domain: $CLOUDFRONT_DOMAIN"
-                  DISTRIBUTION_ID=$id
-              fi
-          done
-          if [ -z "$DISTRIBUTION_ID" ]; then
-            echo "Error: No CloudFront distribution found for domain: $CLOUDFRONT_DOMAIN"
-            exit 1
-          fi
-
-          echo "Fetching CloudFront distribution configuration..."
-          json=$(aws cloudfront get-distribution-config --id "$DISTRIBUTION_ID")
-          ETAG=$(echo "$json" | jq -r '.ETag')
-          CONFIG=$(echo "$json" | jq '.DistributionConfig')
-
-          CONFIG=$(echo "$CONFIG" | jq 'del(.DefaultCacheBehavior.LambdaFunctionAssociations.Items[] | select(.LambdaFunctionARN == "'$LAMBDA_ARN':'$LAMBDA_VERSION'"))')
-
-          echo "Updating CloudFront distribution to detach Lambda@Edge..."
-          UPDATED_CONFIG=$(echo "$CONFIG" | jq -c '.')
-          aws cloudfront update-distribution --id "$DISTRIBUTION_ID" --if-match "$ETAG" --distribution-config "$UPDATED_CONFIG"
-
-          echo "Waiting for CloudFront distribution deployment..."
-          aws cloudfront wait distribution-deployed --id "$DISTRIBUTION_ID"
-
-          echo "CloudFront distribution updated. Proceeding with Lambda function deletion..."
-
-          VERSIONS=$(aws lambda list-versions-by-function --function-name "$LAMBDA_ARN" --region "$REGION" | jq -r '.Versions[].Version')
-          for version in $VERSIONS; do
-              if [[ "$version" != "\$LATEST" ]]; then
-                  echo "Deleting Lambda version: $version"
-                  aws lambda delete-function --function-name "$LAMBDA_ARN:$version" --region "$REGION"
-              fi
-          done
-
-          echo "Lambda function deletion initiated. Verifying..."
-
-          while true;
-          do
-              if ! aws lambda get-function --function-name "$LAMBDA_ARN" --region "$REGION" 2>/dev/null; then
-                  echo "Lambda function successfully deleted."
-                  break
-              fi
-              echo "Waiting for Lambda function to be deleted..."
-              sleep 30
-          done
-
-          echo "Process completed successfully."
+          ./deployment/delete_lambda ${{ vars.ENV_NAME }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: "us-east-1"
 
   destroy:
     runs-on: ubuntu-latest

--- a/deployment/delete_lambda
+++ b/deployment/delete_lambda
@@ -5,6 +5,7 @@ set -euo pipefail
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 REGION="us-east-1"
 ENV_NAME=$1
+CLOUDFRONT_DOMAIN=$2
 LAMBDA_ARN="arn:aws:lambda:$REGION:$ACCOUNT_ID:function:funcOpenSupplyHub${ENV_NAME}RedirectToS3origin"
 LAMBDA_VERSION=$(aws lambda list-versions-by-function --function-name "$LAMBDA_ARN" --region "$REGION" | jq -r '.Versions | max_by(.Version) | .Version')
 

--- a/deployment/delete_lambda
+++ b/deployment/delete_lambda
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+REGION="us-east-1"
+ENV_NAME=$1
+LAMBDA_ARN="arn:aws:lambda:$REGION:$ACCOUNT_ID:function:funcOpenSupplyHub${ENV_NAME}RedirectToS3origin"
+LAMBDA_VERSION=$(aws lambda list-versions-by-function --function-name "$LAMBDA_ARN" --region "$REGION" | jq -r '.Versions | max_by(.Version) | .Version')
+
+for id in $(aws cloudfront list-distributions --query "DistributionList.Items[*].Id" --output text); do
+  domains=$(aws cloudfront get-distribution-config --id $id --query "DistributionConfig.Aliases.Items" --output text)
+  if [[ "$domains" == "$CLOUDFRONT_DOMAIN" ]]; then
+      if [ ! -z "$DISTRIBUTION_ID" ]; then
+          echo "Error: Multiple CloudFront distributions found for domain: $CLOUDFRONT_DOMAIN"
+          exit 1
+      fi
+      echo "Found Distribution ID: $id for Domain: $CLOUDFRONT_DOMAIN"
+      DISTRIBUTION_ID=$id
+  fi
+done
+if [ -z "$DISTRIBUTION_ID" ]; then
+echo "Error: No CloudFront distribution found for domain: $CLOUDFRONT_DOMAIN"
+exit 1
+fi
+
+echo "Fetching CloudFront distribution configuration..."
+json=$(aws cloudfront get-distribution-config --id "$DISTRIBUTION_ID")
+ETAG=$(echo "$json" | jq -r '.ETag')
+CONFIG=$(echo "$json" | jq '.DistributionConfig')
+
+CONFIG=$(echo "$CONFIG" | jq 'del(.DefaultCacheBehavior.LambdaFunctionAssociations.Items[] | select(.LambdaFunctionARN == "'$LAMBDA_ARN':'$LAMBDA_VERSION'"))')
+
+echo "Updating CloudFront distribution to detach Lambda@Edge..."
+UPDATED_CONFIG=$(echo "$CONFIG" | jq -c '.')
+aws cloudfront update-distribution --id "$DISTRIBUTION_ID" --if-match "$ETAG" --distribution-config "$UPDATED_CONFIG"
+
+echo "Waiting for CloudFront distribution deployment..."
+aws cloudfront wait distribution-deployed --id "$DISTRIBUTION_ID"
+
+echo "CloudFront distribution updated. Proceeding with Lambda function deletion..."
+
+VERSIONS=$(aws lambda list-versions-by-function --function-name "$LAMBDA_ARN" --region "$REGION" | jq -r '.Versions[].Version')
+for version in $VERSIONS; do
+  if [[ "$version" != "\$LATEST" ]]; then
+      echo "Deleting Lambda version: $version"
+      aws lambda delete-function --function-name "$LAMBDA_ARN:$version" --region "$REGION"
+  fi
+done
+
+echo "Lambda function deletion initiated. Verifying..."
+
+while true;
+do
+  if ! aws lambda get-function --function-name "$LAMBDA_ARN" --region "$REGION" 2>/dev/null; then
+      echo "Lambda function successfully deleted."
+      break
+  fi
+  echo "Waiting for Lambda function to be deleted..."
+  sleep 30
+done
+
+echo "Process completed successfully."

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -30,7 +30,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-1830](https://opensupplyhub.atlassian.net/browse/OSDEV-1830) - Updated implementation for `Production Location Info` page to input any values for `Location Type` and `Processing Type`, except when the sector is `Apparel` — in that case, enforce taxonomy filters.
 * [OSDEV-1861](https://opensupplyhub.atlassian.net/browse/OSDEV-1861) - On the `My Claimed Facilities` page, the help text font size was increased to `21px`, and the margin for the `FIND MY PRODUCTION LOCATION` button was increased to `16px` to improve readability.
 
-
 ### What's new
 * [OSDEV-1842](https://opensupplyhub.atlassian.net/browse/OSDEV-1842) - Removed the pre-filled information in the `Additional Information` section of the SLC `ProductionLocationInfo` page.
 

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -26,7 +26,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Bugfix
 * [OSDEV-1747](https://opensupplyhub.atlassian.net/browse/OSDEV-1747) - The pages `My Claimed Facilities`, `Claimed Facility Details`, `My Lists`, and `My Lists/id` are now accessible only to authorized users. Additionally, styles have been refactored, an `InputSelect` component has been moved to the separate file, and input styling on the `Claimed Facility Details` page has been fixed.
-* [OSDEV-1886](https://opensupplyhub.atlassian.net/browse/OSDEV-1886) - Deleting Lambda@Edge function before destroying infrastructure. These changes are necessary so that infrastructure can be deleted using Terraform without receiving an error about a problem deleting a replicated function.
+* [OSDEV-1886](https://opensupplyhub.atlassian.net/browse/OSDEV-1886) - Created the script to run within the Destroy Environment GitHub workflow to delete the Lambda@Edge function before destroying the infrastructure. This ensures that Terraform can remove the infrastructure without encountering errors related to deleting a replicated function.
 * [OSDEV-1830](https://opensupplyhub.atlassian.net/browse/OSDEV-1830) - Updated implementation for `Production Location Info` page to input any values for `Location Type` and `Processing Type`, except when the sector is `Apparel` — in that case, enforce taxonomy filters.
 * [OSDEV-1861](https://opensupplyhub.atlassian.net/browse/OSDEV-1861) - On the `My Claimed Facilities` page, the help text font size was increased to `21px`, and the margin for the `FIND MY PRODUCTION LOCATION` button was increased to `16px` to improve readability.
 

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Bugfix
 * [OSDEV-1747](https://opensupplyhub.atlassian.net/browse/OSDEV-1747) - The pages `My Claimed Facilities`, `Claimed Facility Details`, `My Lists`, and `My Lists/id` are now accessible only to authorized users. Additionally, styles have been refactored, an `InputSelect` component has been moved to the separate file, and input styling on the `Claimed Facility Details` page has been fixed.
+* [OSDEV-1886](https://opensupplyhub.atlassian.net/browse/OSDEV-1886) - Deleting Lambda@Edge function before destroying infrastructure. These changes are necessary so that infrastructure can be deleted using Terraform without receiving an error about a problem deleting a replicated function.
 
 ### What's new
 * *Describe what's new here. The changes that can impact user experience should be listed in this section.*


### PR DESCRIPTION
Delete Lambda@Edge function before deleting infrastructure. These changes are necessary so that infrastructure can be deleted using terraform without receiving an error about a problem deleting a replicated function.