### PR TITLE
[OSDEV-1899] Kafka/Zookeeper Images startup issue

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -22,7 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * *Describe code/API changes here.*
 
 ### Architecture/Environment changes
-* *Describe architecture/environment changes here.*
+* [OSDEV-1899](https://opensupplyhub.atlassian.net/browse/OSDEV-1899) - Switched from using the `latest` tags to static versions for both `bitnami/kafka` and `bitnami/zookeeper`, which resolved compatibility issues during local & CI setup. Using pinned versions ensures stability and prevents unexpected behavior from upstream image changes.
 
 ### Bugfix
 * [OSDEV-1747](https://opensupplyhub.atlassian.net/browse/OSDEV-1747) - The pages `My Claimed Facilities`, `Claimed Facility Details`, `My Lists`, and `My Lists/id` are now accessible only to authorized users. Additionally, styles have been refactored, an `InputSelect` component has been moved to the separate file, and input styling on the `Claimed Facility Details` page has been fixed.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       - proxynet
 
   zookeeper:
-    image: "bitnami/zookeeper:latest"
+    image: "bitnami/zookeeper:3.9"
     ports:
       - "2181:2181"
     environment:
@@ -111,7 +111,7 @@ services:
       - proxynet
 
   kafka:
-    image: "bitnami/kafka:latest"
+    image: "bitnami/kafka:3.9.0"
     ports:
       - "9092:9092"
     environment:


### PR DESCRIPTION
**[OSDEV-1899](https://opensupplyhub.atlassian.net/browse/OSDEV-1899) Kafka/Zookeeper Images startup issue**

- Switched from using the `latest` tags to static versions for both `bitnami/kafka` and `bitnami/zookeeper`, which resolved compatibility issues during local & CI setup. Using pinned versions ensures stability and prevents unexpected behavior from upstream image changes.

[OSDEV-1899]: https://opensupplyhub.atlassian.net/browse/OSDEV-1899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ