### PR TITLE
[OSDEV-1904] Update the  instructions link on the List upload page.

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-1886](https://opensupplyhub.atlassian.net/browse/OSDEV-1886) - Created the script to run within the Destroy Environment GitHub workflow to delete the Lambda@Edge function before destroying the infrastructure. This ensures that Terraform can remove the infrastructure without encountering errors related to deleting a replicated function.
 * [OSDEV-1830](https://opensupplyhub.atlassian.net/browse/OSDEV-1830) - Updated implementation for `Production Location Info` page to input any values for `Location Type` and `Processing Type`, except when the sector is `Apparel` — in that case, enforce taxonomy filters.
 * [OSDEV-1861](https://opensupplyhub.atlassian.net/browse/OSDEV-1861) - On the `My Claimed Facilities` page, the help text font size was increased to `21px`, and the margin for the `FIND MY PRODUCTION LOCATION` button was increased to `16px` to improve readability.
+* [OSDEV-1904](https://opensupplyhub.atlassian.net/browse/OSDEV-1904) - The `step-by step` instructions link on the List upload page has been updated to `/resources/preparing-data`.
 
 ### What's new
 * [OSDEV-1842](https://opensupplyhub.atlassian.net/browse/OSDEV-1842) - Removed the pre-filled information in the `Additional Information` section of the SLC `ProductionLocationInfo` page.

--- a/src/react/src/components/Contribute.jsx
+++ b/src/react/src/components/Contribute.jsx
@@ -44,7 +44,7 @@ function ContributeList({ userHasSignedIn, fetchingSessionSignIn }) {
 
                         <p>
                             <a
-                                href={`${InfoLink}/${InfoPaths.contribute}`}
+                                href={`${InfoLink}/${InfoPaths.preparingData}`}
                                 target="_blank"
                                 rel="noreferrer"
                             >

--- a/src/react/src/util/constants.jsx
+++ b/src/react/src/util/constants.jsx
@@ -24,6 +24,7 @@ export const InfoPaths = {
     storiesResources: 'stories-resources',
     privacyPolicy: 'privacy-policy',
     contribute: 'data-cleaning-service',
+    preparingData: 'resources/preparing-data',
     dataQuality: 'resources/a-free-universal-id-matching-algorithm',
     claimedFacilities: 'stories-resources/claim-a-facility',
     termsOfService: 'terms-of-service',


### PR DESCRIPTION
 [OSDEV-1904](https://opensupplyhub.atlassian.net/browse/OSDEV-1904) - The `step-by step` instructions link on the List upload page has been updated to `/resources/preparing-data`.

[OSDEV-1904]: https://opensupplyhub.atlassian.net/browse/OSDEV-1904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ