### PR TITLE
[OSDEV-1896](https://opensupplyhub.atlassian.net/browse/OSDEV-1896) [RBA Pen Test] Address pen test results of Insufficient Session Timeout

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -3,6 +3,37 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). The format is based on the `RELEASE-NOTES-TEMPLATE.md` file.
 
+## Release 2.2.0
+
+## Introduction
+* Product name: Open Supply Hub
+* Release date: April 19, 2025
+
+### Database changes
+* *Describe high-level database changes.*
+
+#### Migrations:
+* *Describe migrations here.*
+
+#### Schema changes
+* *Describe schema changes here.*
+
+### Code/API changes
+* *Describe code/API changes here.*
+
+### Architecture/Environment changes
+* [OSDEV-1896](https://opensupplyhub.atlassian.net/browse/OSDEV-1896) - The session cookie is limited to 24 hours. After this period, the user session expires, and the user needs to log in again.
+
+### Bugfix
+* *Describe bugfix changes here.*
+
+### What's new
+* *Describe what's new changes here.*
+
+### Release instructions:
+* *Provide release instructions here.*
+
+
 ## Release 2.1.0
 
 ## Introduction

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -144,6 +144,8 @@ ACCOUNT_EMAIL_VERIFICATION = 'mandatory'
 ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS = 3
 ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION = False
 ACCOUNT_EMAIL_SUBJECT_PREFIX = ''
+# https://docs.djangoproject.com/en/3.2/ref/settings/#session-cookie-age
+SESSION_COOKIE_AGE = 86400 # 24 hours in seconds
 
 AUTH_USER_MODEL = 'api.User'
 


### PR DESCRIPTION
[OSDEV-1896](https://opensupplyhub.atlassian.net/browse/OSDEV-1896) **[RBA Pen Test] Address pen test results of Insufficient Session Timeout**

- The session cookie is limited to 24 hours. After this period, the user session expires, and the user needs to log in again.