### PR TITLE
[OSDEV-1895] [RBA Pen Test] Address pen test results of Cookies without HTTP-only

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Architecture/Environment changes
 * [OSDEV-1896](https://opensupplyhub.atlassian.net/browse/OSDEV-1896) - The session cookie is limited to 24 hours. After this period, the user session expires, and the user needs to log in again.
+* [OSDEV-1895](https://opensupplyhub.atlassian.net/browse/OSDEV-1895) - Updated the rules to send the `csrftoken` cookie with the `HttpOnly` flag to the user. Implemented logic to retrieve the `csrftoken` upon user login and save it to `localStorage`. Added functionality to set the `csrftoken` from `localStorage` in Axios headers.
 
 ### Bugfix
 * *Describe bugfix changes here.*

--- a/src/django/api/views/auth/login_to_oar_client.py
+++ b/src/django/api/views/auth/login_to_oar_client.py
@@ -3,6 +3,7 @@ from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.response import Response
 from rest_auth.views import LoginView
 from django.contrib.auth import authenticate, login
+from django.middleware.csrf import get_token
 
 from ...serializers.user.user_serializer import UserSerializer
 
@@ -36,8 +37,12 @@ class LoginToOARClient(LoginView):
                 'Your account is not verified. '
                 'Check your email for a confirmation link.'
             )
+        
+        serialized_data = UserSerializer(user).data
+        csrf_token = get_token(request)
+        serialized_data['csrfToken'] = csrf_token
 
-        return Response(UserSerializer(user).data)
+        return Response(serialized_data)
 
     def get(self, request, *args, **kwargs):
         if not request.user.is_active:

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -152,6 +152,9 @@ AUTH_USER_MODEL = 'api.User'
 CSRF_COOKIE_SECURE = True
 SESSION_COOKIE_SECURE = True
 
+# https://docs.djangoproject.com/en/5.1/ref/settings/#csrf-cookie-httponly
+CSRF_COOKIE_HTTPONLY = True
+
 REST_AUTH_SERIALIZERS = {
     'USER_DETAILS_SERIALIZER': 'api.serializers.UserSerializer',
     'PASSWORD_RESET_SERIALIZER': 'api.serializers.UserPasswordResetSerializer',

--- a/src/react/src/reducers/ProfileReducer.js
+++ b/src/react/src/reducers/ProfileReducer.js
@@ -128,7 +128,11 @@ const completeGettingAPIToken = (state, payload) =>
         },
     });
 
-const handleLogin = (state, { id, email }) => {
+const handleLogin = (state, { id, email, csrfToken }) => {
+    if (csrfToken) {
+        window.localStorage.setItem('csrfToken', csrfToken);
+    }
+
     if (id !== state.profile.id) {
         return state;
     }
@@ -136,6 +140,17 @@ const handleLogin = (state, { id, email }) => {
     return update(state, {
         profile: {
             email: { $set: email },
+        },
+    });
+};
+
+const handleLogout = state => {
+    window.localStorage.removeItem('csrfToken');
+
+    return update(state, {
+        profile: {
+            email: { $set: initialState.profile.email },
+            password: { $set: initialState.profile.password },
         },
     });
 };
@@ -166,13 +181,7 @@ export default createReducer(
             }),
         [completeSessionLogin]: handleLogin,
         [completeSubmitLoginForm]: handleLogin,
-        [completeSubmitLogOut]: state =>
-            update(state, {
-                profile: {
-                    email: { $set: initialState.profile.email },
-                    password: { $set: initialState.profile.password },
-                },
-            }),
+        [completeSubmitLogOut]: handleLogout,
         [startFetchUserProfile]: state =>
             update(state, {
                 fetching: { $set: true },

--- a/src/react/src/util/apiRequest.js
+++ b/src/react/src/util/apiRequest.js
@@ -11,12 +11,18 @@ const apiRequest = axios.create({
 
 // Not related to CSRF protection, but this is the appropriate place to set the
 // client key header used to authenticate anonymous API requests.
-apiRequest.interceptors.request.use(config =>
-    Object.assign({}, config, {
-        headers: Object.assign({}, config.headers, {
-            'X-OAR-Client-Key': window.ENVIRONMENT.OAR_CLIENT_KEY,
-        }),
-    }),
-);
+apiRequest.interceptors.request.use(config => {
+    const headers = { ...config.headers };
+    headers['X-OAR-Client-Key'] = window.ENVIRONMENT.OAR_CLIENT_KEY;
+
+    if (!headers['X-CSRFToken']) {
+        const csrfToken = window.localStorage.getItem('csrfToken');
+        if (csrfToken) {
+            headers['X-CSRFToken'] = csrfToken;
+        }
+    }
+
+    return { ...config, headers };
+});
 
 export default apiRequest;


### PR DESCRIPTION
[OSDEV-1895](https://opensupplyhub.atlassian.net/browse/OSDEV-1895) **[RBA Pen Test] Address pen test results of Cookies without HTTP-only**

- Updated the rules to send the `csrftoken` cookie with the `HttpOnly` flag to the user. 
- Implemented logic to retrieve the `csrftoken` upon user login and save it to `localStorage`. 
- Added functionality to set the `csrftoken` from `localStorage` in Axios headers.