### PR TITLE
[OSDEV-1914] Add match_phrase query support for fields with long string values

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -25,7 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-1935](https://opensupplyhub.atlassian.net/browse/OSDEV-1935) - Added terraform module for creating IAM roles in production and test AWS accounts to enable integration with Vanta auditor.
 
 ### Bugfix
-* [OSDEV-1914](https://opensupplyhub.atlassian.net/browse/OSDEV-1914) - Fixed an issue with fuzzy search on fields containing long text. Replaced the `match` query with `match_phrase` for such cases to improve accuracy. Replaced regular text with a toast component to display server errors for fetched potential matches.
+* [OSDEV-1914](https://opensupplyhub.atlassian.net/browse/OSDEV-1914) - Fixed an issue with fuzzy search on fields containing long text. Replaced the `match` query with `match_phrase` (with configurable `slop` parameter) for such cases to improve accuracy. Replaced regular text with a toast component to display server errors for fetched potential matches.
 * [OSDEV-1943](https://opensupplyhub.atlassian.net/browse/OSDEV-1943) - Fixed flickering behavior when opening the SLC form to contribute to an existing production location by marking fields as touched if they match the fetched data, ensuring smoother UI during re-renders.
 
 ### What's new

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -25,8 +25,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-1935](https://opensupplyhub.atlassian.net/browse/OSDEV-1935) - Added terraform module for creating IAM roles in production and test AWS accounts to enable integration with Vanta auditor.
 
 ### Bugfix
-* [OSDEV-1914](https://opensupplyhub.atlassian.net/browse/OSDEV-1914) - Fixed an issue with fuzzy search on fields containing long text. Replaced the `match` query with `match_phrase` (with configurable `slop` parameter) for such cases to improve accuracy. Replaced regular text with a toast component to display server errors for fetched potential matches.
-* [OSDEV-1943](https://opensupplyhub.atlassian.net/browse/OSDEV-1943) - The following changes have been made:
+* [OSDEV-1943](https://opensupplyhub.atlassian.net/browse/OSDEV-1943) - Fixed flickering behavior when opening the SLC form to contribute to an existing production location by marking fields as touched if they match the fetched data, ensuring smoother UI during re-renders.
+* [OSDEV-1914](https://opensupplyhub.atlassian.net/browse/OSDEV-1914) - The following changes have been made:
     * Fixed an issue with fuzzy search on fields containing long text. Replaced the `match` query with `match_phrase` (with a configurable `slop` parameter) for such cases to improve accuracy for the GET `/api/v1/production-locations/` endpoint.
     * Replaced regular text with a toast component to display server errors when fetching potential matches on the Contribution Record page of the Moderation queue dashboard.
 

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Introduction
 * Product name: Open Supply Hub
-* Release date: May 03, 2025
+* Release date: May 3, 2025
 
 ### Database changes
 * *Describe high-level database changes.*

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -26,7 +26,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Bugfix
 * [OSDEV-1914](https://opensupplyhub.atlassian.net/browse/OSDEV-1914) - Fixed an issue with fuzzy search on fields containing long text. Replaced the `match` query with `match_phrase` (with configurable `slop` parameter) for such cases to improve accuracy. Replaced regular text with a toast component to display server errors for fetched potential matches.
-* [OSDEV-1943](https://opensupplyhub.atlassian.net/browse/OSDEV-1943) - Fixed flickering behavior when opening the SLC form to contribute to an existing production location by marking fields as touched if they match the fetched data, ensuring smoother UI during re-renders.
+* [OSDEV-1943](https://opensupplyhub.atlassian.net/browse/OSDEV-1943) - The following changes have been made:
+    * Fixed an issue with fuzzy search on fields containing long text. Replaced the `match` query with `match_phrase` (with a configurable `slop` parameter) for such cases to improve accuracy for the GET `/api/v1/production-locations/` endpoint.
+    * Replaced regular text with a toast component to display server errors when fetching potential matches on the Contribution Record page of the Moderation queue dashboard.
 
 ### What's new
 * *Describe what's new here. The changes that can impact user experience should be listed in this section.*

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -3,6 +3,39 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). The format is based on the `RELEASE-NOTES-TEMPLATE.md` file.
 
+## Release 2.3.0
+
+## Introduction
+* Product name: Open Supply Hub
+* Release date: May 03, 2025
+
+### Database changes
+* *Describe high-level database changes.*
+
+#### Migrations:
+* *Describe migrations here.*
+
+#### Schema changes
+* *Describe schema changes here.*
+
+### Code/API changes
+* *Describe code/API changes here.*
+
+### Architecture/Environment changes
+* *Describe architecture/environment changes here.*
+
+### Bugfix
+* [OSDEV-1914](https://opensupplyhub.atlassian.net/browse/OSDEV-1914) - Fixed an issue with fuzzy search on fields containing long text. Replaced the `match` query with `match_phrase` for such cases to improve accuracy.
+
+### What's new
+* *Describe what's new here. The changes that can impact user experience should be listed in this section.*
+
+### Release instructions:
+* Ensure that the following commands are included in the `post_deployment` command:
+    * `migrate`
+    * `reindex_database`
+
+
 ## Release 2.2.0
 
 ## Introduction

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -25,7 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * *Describe architecture/environment changes here.*
 
 ### Bugfix
-* [OSDEV-1914](https://opensupplyhub.atlassian.net/browse/OSDEV-1914) - Fixed an issue with fuzzy search on fields containing long text. Replaced the `match` query with `match_phrase` for such cases to improve accuracy.
+* [OSDEV-1914](https://opensupplyhub.atlassian.net/browse/OSDEV-1914) - Fixed an issue with fuzzy search on fields containing long text. Replaced the `match` query with `match_phrase` for such cases to improve accuracy. Replaced regular text with a toast component to display server errors for fetched potential matches.
 
 ### What's new
 * *Describe what's new here. The changes that can impact user experience should be listed in this section.*

--- a/src/django/api/tests/test_production_locations_query_builder.py
+++ b/src/django/api/tests/test_production_locations_query_builder.py
@@ -25,6 +25,25 @@ class TestProductionLocationsQueryBuilder(TestCase):
             self.builder.query_body['query']['bool']['must']
             )
 
+    def test_add_match_phrase(self):
+        self.builder.add_match_phrase(
+            'address',
+            'Land plot number 115, map sheet number 03, Cadastral map of Son Ha commune, Son Ha commune, Nho Quan district, Ninh Binh province, Vietnam',
+            slop=4
+        )
+        expected = {
+            "match_phrase": {
+            "address": {
+                    "query": "Land plot number 115, map sheet number 03, Cadastral map of Son Ha commune, Son Ha commune, Nho Quan district, Ninh Binh province, Vietnam",
+                    "slop": 4
+                }
+            }
+        }
+        self.assertIn(
+            expected,
+            self.builder.query_body['query']['bool']['must']
+            )
+
     def test_add_terms_for_standard_field(self):
         self.builder.add_terms('country', ['US', 'CA'])
         expected = {'terms': {'country.alpha_2': ['US', 'CA']}}

--- a/src/django/api/tests/test_production_locations_query_builder.py
+++ b/src/django/api/tests/test_production_locations_query_builder.py
@@ -23,18 +23,28 @@ class TestProductionLocationsQueryBuilder(TestCase):
         self.assertIn(
             expected,
             self.builder.query_body['query']['bool']['must']
-            )
+        )
 
     def test_add_match_phrase(self):
         self.builder.add_match_phrase(
             'address',
-            'Land plot number 115, map sheet number 03, Cadastral map of Son Ha commune, Son Ha commune, Nho Quan district, Ninh Binh province, Vietnam',
+            (
+                'Land plot number 115, map sheet number 03'
+                ', Cadastral map of '
+                'Son Ha commune, Son Ha commune, Nho Quan district, '
+                'Ninh Binh province, Vietnam'
+            ),
             slop=4
         )
         expected = {
             "match_phrase": {
-            "address": {
-                    "query": "Land plot number 115, map sheet number 03, Cadastral map of Son Ha commune, Son Ha commune, Nho Quan district, Ninh Binh province, Vietnam",
+                "address": {
+                    "query": (
+                        'Land plot number 115, map sheet number 03'
+                        ', Cadastral map of '
+                        'Son Ha commune, Son Ha commune, Nho Quan district, '
+                        'Ninh Binh province, Vietnam'
+                    ),
                     "slop": 4
                 }
             }
@@ -42,7 +52,7 @@ class TestProductionLocationsQueryBuilder(TestCase):
         self.assertIn(
             expected,
             self.builder.query_body['query']['bool']['must']
-            )
+        )
 
     def test_add_terms_for_standard_field(self):
         self.builder.add_terms('country', ['US', 'CA'])
@@ -145,7 +155,7 @@ class TestProductionLocationsQueryBuilder(TestCase):
         self.assertIn(
             expected,
             self.builder.query_body['query']['bool']['must']
-            )
+        )
 
     def test_add_range_for_percent_female_workers(self):
         self.builder.add_range(
@@ -165,7 +175,7 @@ class TestProductionLocationsQueryBuilder(TestCase):
         self.assertIn(
             expected,
             self.builder.query_body['query']['bool']['must']
-            )
+        )
 
     def test_add_geo_distance(self):
         self.builder.add_geo_distance('location', 40.7128, -74.0060, '10km')
@@ -178,7 +188,7 @@ class TestProductionLocationsQueryBuilder(TestCase):
         self.assertIn(
             expected,
             self.builder.query_body['query']['bool']['must']
-            )
+        )
 
     def test_add_sort(self):
         self.builder.add_sort('name', 'desc')

--- a/src/django/api/views/v1/opensearch_query_builder/opensearch_query_builder.py
+++ b/src/django/api/views/v1/opensearch_query_builder/opensearch_query_builder.py
@@ -21,6 +21,12 @@ class OpenSearchQueryBuilder(ABC):
         }
         self.query_body['query']['bool']['must'].append(match_query)
 
+    def add_match_phrase(self, field, value, slop):
+        match_query = {
+            'match_phrase': {field: {'query': value, 'slop': slop}}
+        }
+        self.query_body['query']['bool']['must'].append(match_query)
+
     def add_range(self, field, query_params):
         if field in {
             V1_PARAMETERS_LIST.NUMBER_OF_WORKERS,

--- a/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
+++ b/src/django/api/views/v1/opensearch_query_builder/opensearch_query_director.py
@@ -73,7 +73,11 @@ class OpenSearchQueryDirector:
 
     def __add_match_query(self, field, value):
         if value:
-            self.__builder.add_match(field, value, fuzziness='2')
+            tokens = value.split()
+            if len(tokens) > 12 or len(value) > 180:
+                self.__builder.add_match_phrase(field, value, slop=3)
+            else:
+                self.__builder.add_match(field, value, fuzziness=2)
 
     def __add_terms_query(self, field, values):
         self.__builder.add_terms(field, values)

--- a/src/react/src/components/Dashboard/DashboardContributionRecord.jsx
+++ b/src/react/src/components/Dashboard/DashboardContributionRecord.jsx
@@ -1,3 +1,4 @@
+/* eslint no-unused-vars: 0 */
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
@@ -31,6 +32,7 @@ import {
     updateSingleModerationEvent,
     createProductionLocationFromModerationEvent,
     confirmPotentialMatchFromModerationEvent,
+    cleanupContributionRecord,
 } from '../../actions/dashboardContributionRecord';
 import { makeClaimFacilityLink, makeFacilityDetailLink } from '../../util/util';
 import DialogTooltip from './../Contribute/DialogTooltip';
@@ -84,6 +86,7 @@ const DashboardContributionRecord = ({
     fetchMatches,
     moderationEventFetching,
     fetchPotentialMatchError,
+    handleCleanupContributionRecord,
 }) => {
     const prevSingleModerationEventItemRef = useRef();
     const [showBackdrop, setShowBackdrop] = useState(false);
@@ -132,6 +135,12 @@ const DashboardContributionRecord = ({
     }, []);
 
     useEffect(() => {
+        if (fetchPotentialMatchError) {
+            toast(fetchPotentialMatchError);
+        }
+    }, [fetchPotentialMatchError]);
+
+    useEffect(() => {
         if (!isEmpty(singleModerationEventItem) && hasPrefetchedData) {
             if (moderationEventFetching) {
                 setShowBackdrop(true);
@@ -165,6 +174,13 @@ const DashboardContributionRecord = ({
             });
         }
     }, [productionLocationName, countryCode, productionLocationAddress, osId]);
+
+    useEffect(
+        () => () => {
+            handleCleanupContributionRecord();
+        },
+        [],
+    );
 
     const handleRejectContribution = () => {
         setRejectModerationEventDialogIsOpen(true);
@@ -257,9 +273,6 @@ const DashboardContributionRecord = ({
                 Potential Matches ({potentialMatchCount})
             </Typography>
 
-            {fetchPotentialMatchError && (
-                <Typography>{fetchPotentialMatchError}</Typography>
-            )}
             <div className={classes.potentialMatchesBlock}>
                 <Divider className={classes.dividerStyle} />
 
@@ -505,6 +518,8 @@ const mapDispatchToProps = (
     confirmPotentialMatch: osId =>
         dispatch(confirmPotentialMatchFromModerationEvent(moderationID, osId)),
     fetchMatches: data => dispatch(fetchPotentialMatches(data)),
+    handleCleanupContributionRecord: () =>
+        dispatch(cleanupContributionRecord()),
 });
 
 export default connect(

--- a/src/react/src/components/Dashboard/DashboardContributionRecord.jsx
+++ b/src/react/src/components/Dashboard/DashboardContributionRecord.jsx
@@ -1,4 +1,3 @@
-/* eslint no-unused-vars: 0 */
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
@@ -468,6 +467,7 @@ DashboardContributionRecord.propTypes = {
     classes: object.isRequired,
     fetchModerationEventError: string,
     fetchPotentialMatchError: string,
+    handleCleanupContributionRecord: func.isRequired,
 };
 
 const mapStateToProps = ({

--- a/src/react/src/reducers/DashboardContributionRecordReducer.js
+++ b/src/react/src/reducers/DashboardContributionRecordReducer.js
@@ -72,7 +72,7 @@ export default createReducer(
             update(state, {
                 potentialMatches: {
                     fetching: { $set: initialState.potentialMatches.fetching },
-                    error: { $set: error },
+                    error: { $set: Array.isArray(error) ? error[0] : error },
                 },
             }),
         [completeFetchPotentialMatches]: (state, payload) =>

--- a/src/tests/opensearch/test_opensearch.py
+++ b/src/tests/opensearch/test_opensearch.py
@@ -59,3 +59,47 @@ class OpenSearchTest(OpenSearchIntegrationTestCase):
             body=query
         )
         self.assertGreater(response['hits']['total']['value'], 0)
+
+    def test_search_document_with_long_address(self):
+        doc = {
+            "sector": [
+                "Apparel"
+            ],
+            "address": "Land plot number 115, map sheet number 03, Cadastral map of Son Ha commune, Son Ha commune, Nho Quan district, Ninh Binh province, Vietnam",
+            "name": "HAI VINH VN CO., LTD - NINH BINH BRANCH",
+            "country": {
+                "alpha_2": "VN"
+            },
+            "os_id": "VN2025093077Q64",
+            "coordinates": {
+                "lon": 105.8701316,
+                "lat": 29.202120893
+            },
+        }
+        self.client.index(
+            index=self.production_locations_index_name,
+            body=doc,
+            id=self.client.count()
+        )
+        self.client.indices.refresh(index=self.production_locations_index_name)
+
+        query = {
+            'query': {
+                'match_phrase': {
+                    'address': {
+                        'query': (
+                            'Land plot number 115, map sheet number 03'
+                            ', Cadastral map of '
+                            'Son Ha commune, Son Ha commune, Nho Quan district, '
+                            'Ninh Binh province, Vietnam'
+                        ),
+                        'slop': 4
+                    }
+                }
+            }
+        }
+        response = self.client.search(
+            index=self.production_locations_index_name,
+            body=query
+        )
+        self.assertGreater(response['hits']['total']['value'], 0)


### PR DESCRIPTION
[OSDEV-1914](https://opensupplyhub.atlassian.net/browse/OSDEV-1914)
 * Fixed an issue with fuzzy search on fields containing long text. Replaced the `match` query with `match_phrase` (with a configurable `slop` parameter) for such cases to improve accuracy for the GET `/api/v1/production-locations/` endpoint.
 * Replaced regular text with a toast component to display server errors when fetching potential matches on the Contribution Record page of the Moderation queue dashboard.

Error UI example:
![fetch-potential-matches-error](https://github.com/user-attachments/assets/eedecceb-75ff-4f1a-b502-d8f947c9917f)



[OSDEV-1914]: https://opensupplyhub.atlassian.net/browse/OSDEV-1914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ