### PR TITLE
[OSDEV-1935] Grant Vanta auditor access to AWS account

### DIFF
--- a/deployment/terraform/vanta-iam-role/vanta-readonly-role.tf
+++ b/deployment/terraform/vanta-iam-role/vanta-readonly-role.tf
@@ -22,12 +22,12 @@ data "aws_iam_policy_document" "assume_role" {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
     principals {
-      identifiers = ["arn:aws:iam::956993596390:role/scanner"]
-      type = "AWS"
+      identifiers = var.vanta_assumed_role_principals
+      type        = "AWS"
     }
     condition {
-      test = "StringEquals"
-      values = ["6B0581B993278C8"]
+      test     = "StringEquals"
+      values   = var.vanta_assumed_role_external_ids
       variable = "sts:ExternalId"
     }
   }

--- a/deployment/terraform/vanta-iam-role/vanta-readonly-role.tf
+++ b/deployment/terraform/vanta-iam-role/vanta-readonly-role.tf
@@ -1,0 +1,54 @@
+resource "aws_iam_policy" "VantaAdditionalPermissions" {
+  name        = "VantaAdditionalPermissions"
+  description = "Custom Vanta Policy"
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Deny",
+        "Action" : [
+          "datapipeline:EvaluateExpression",
+          "datapipeline:QueryObjects",
+          "rds:DownloadDBLogFilePortion"
+        ],
+        "Resource" : "*"
+      }
+    ]
+  })
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      identifiers = ["arn:aws:iam::956993596390:role/scanner"]
+      type = "AWS"
+    }
+    condition {
+      test = "StringEquals"
+      values = ["6B0581B993278C8"]
+      variable = "sts:ExternalId"
+    }
+  }
+}
+
+resource "aws_iam_role" "vanta-auditor" {
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  name               = "vanta-auditor"
+}
+
+resource "aws_iam_role_policy_attachment" "VantaSecurityAudit" {
+  role       = aws_iam_role.vanta-auditor.name
+  policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
+}
+
+resource "aws_iam_role_policy_attachment" "VantaAdditionalPermissions" {
+  role       = aws_iam_role.vanta-auditor.name
+  policy_arn = aws_iam_policy.VantaAdditionalPermissions.arn
+}
+
+output "vanta-auditor-arn" {
+  description = "The arn from the Terraform created role that you need to input into the Vanta UI at the end of the AWS connection steps."
+  value       = aws_iam_role.vanta-auditor.arn
+}

--- a/deployment/terraform/vanta-iam-role/variables.tf
+++ b/deployment/terraform/vanta-iam-role/variables.tf
@@ -1,9 +1,11 @@
 variable "vanta_assumed_role_external_ids" {
-  type    = list(any)
-  default = []
+  type      = list
+  default   = []
+  sensitive = true
 }
 
 variable "vanta_assumed_role_principals" {
-  type    = list(any)
-  default = []
+  type      = list
+  default   = []
+  sensitive = true
 }

--- a/deployment/terraform/vanta-iam-role/variables.tf
+++ b/deployment/terraform/vanta-iam-role/variables.tf
@@ -1,0 +1,9 @@
+variable "vanta_assumed_role_external_ids" {
+  type    = list(any)
+  default = []
+}
+
+variable "vanta_assumed_role_principals" {
+  type    = list(any)
+  default = []
+}

--- a/deployment/terraform/vanta.tf
+++ b/deployment/terraform/vanta.tf
@@ -2,4 +2,7 @@ module "vanta" {
   count = var.environment == "Test" || var.environment == "Production" ? 1 : 0
 
   source = "./vanta-iam-role"
+
+  vanta_assumed_role_principals   = var.vanta_assumed_role_principals
+  vanta_assumed_role_external_ids = var.vanta_assumed_role_external_ids
 }

--- a/deployment/terraform/vanta.tf
+++ b/deployment/terraform/vanta.tf
@@ -1,0 +1,5 @@
+module "vanta" {
+  count = var.environment == "Test" || var.environment == "Production" ? 1 : 0
+
+  source = "./vanta-iam-role"
+}

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -698,3 +698,13 @@ variable "google_drive_shared_directory_id" {
   sensitive   = true
   description = "The ID of the shared directory in Google Drive"
 }
+
+variable "vanta_assumed_role_external_ids" {
+  type    = list
+  default = []
+}
+
+variable "vanta_assumed_role_principals" {
+  type    = list
+  default = []
+}

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -700,11 +700,13 @@ variable "google_drive_shared_directory_id" {
 }
 
 variable "vanta_assumed_role_external_ids" {
-  type    = list
-  default = []
+  type      = list
+  default   = []
+  sensitive = true
 }
 
 variable "vanta_assumed_role_principals" {
-  type    = list
-  default = []
+  type      = list
+  default   = []
+  sensitive = true
 }

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -22,7 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * *Describe code/API changes here.*
 
 ### Architecture/Environment changes
-* *Describe architecture/environment changes here.*
+* [OSDEV-1935](https://opensupplyhub.atlassian.net/browse/OSDEV-1935) - Added terraform module for creating IAM roles in production and test AWS accounts to enable integration with Vanta auditor.
 
 ### Bugfix
 * *Describe bugfix here.*


### PR DESCRIPTION
The changes in this pull request create an IAM role in the AWS account to enable integration with the Vanta auditor.
This integration is required for SOC 2 certification.

Since we have two AWS accounts, the changes apply only to the production and testing environments.