### PR TITLE
[OSDEV-1943] Eliminate brief red border flicker on pre-filled fields in the SLC form .

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -25,7 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * *Describe architecture/environment changes here.*
 
 ### Bugfix
-* *Describe bugfix here.*
+* [OSDEV-1943](https://opensupplyhub.atlassian.net/browse/OSDEV-1943) - Fixed flickering behavior when opening the SLC form to contribute to an existing production location by marking fields as touched if they match the fetched data, ensuring smoother UI during re-renders.
 
 ### What's new
 * *Describe what's new here. The changes that can impact user experience should be listed in this section.*

--- a/src/react/src/components/Contribute/ProductionLocationInfo.jsx
+++ b/src/react/src/components/Contribute/ProductionLocationInfo.jsx
@@ -199,16 +199,43 @@ const ProductionLocationInfo = ({
                       }
                     : null,
             });
-            contributionForm.setTouched(
-                {
-                    name: true,
-                    address: true,
-                    country: true,
-                },
-                false,
-            );
         }
     }, [singleProductionLocationData, osID]);
+
+    useEffect(() => {
+        if (singleProductionLocationData && osID) {
+            const { name, address, country } = singleProductionLocationData;
+            const {
+                name: formName,
+                address: formAddress,
+                country: formCountry,
+            } = contributionForm.values;
+
+            const isSame =
+                formName === name &&
+                formAddress === address &&
+                formCountry?.value === country?.alpha_2;
+
+            if (isSame) {
+                /*
+                If the current form values match the fetched data, manually
+                mark these fields as touched to ensure UI updates behave
+                correctly and prevent flicker from Formik revalidation on
+                rerenders.
+                */
+                contributionForm.setTouched(
+                    { name: true, address: true, country: true },
+                    false,
+                );
+            }
+        }
+    }, [
+        contributionForm.values.name,
+        contributionForm.values.address,
+        contributionForm.values.country,
+        singleProductionLocationData,
+        osID,
+    ]);
 
     const prevModerationIDRef = useRef();
     useEffect(() => {


### PR DESCRIPTION
[OSDEV-1943](https://opensupplyhub.atlassian.net/browse/OSDEV-1943) - Fixed flickering behavior when opening the SLC form to contribute to an existing production location by marking fields as touched if they match the fetched data, ensuring smoother UI during re-renders.

[OSDEV-1943]: https://opensupplyhub.atlassian.net/browse/OSDEV-1943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ