### PR TITLE
[OSDEV-1895] FIX: Address pen test results of Cookies without HTTP-only

### DIFF
--- a/src/react/src/util/apiRequest.js
+++ b/src/react/src/util/apiRequest.js
@@ -20,8 +20,8 @@ apiRequest.interceptors.request.use(config => {
         ...config.headers,
         'X-OAR-Client-Key': window.ENVIRONMENT.OAR_CLIENT_KEY,
         'X-CSRFToken':
-            config.headers['X-CSRFToken'] ||
             window.localStorage.getItem(CSRF_TOKEN_KEY) ||
+            config.headers['X-CSRFToken'] ||
             undefined,
     };
 


### PR DESCRIPTION
[OSDEV-1895](https://opensupplyhub.atlassian.net/browse/OSDEV-1895) **FIX: [RBA Pen Test] Address pen test results of Cookies without HTTP-only**

- Fixed issue when in axios headers stored old csrf token but new valid csrf token was already generated and saved in local storage.

[OSDEV-1895]: https://opensupplyhub.atlassian.net/browse/OSDEV-1895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ