### PR TITLE
[OSDEV-1926] Modify the error message for the invalid `duns_id`.

### DIFF
--- a/src/django/contricleaner/lib/serializers/row_serializers/row_additional_ids_serializer.py
+++ b/src/django/contricleaner/lib/serializers/row_serializers/row_additional_ids_serializer.py
@@ -32,7 +32,7 @@ class RowAdditionalIdsSerializer(RowSerializer):
                 current['errors'].append(
                     {
                         'message': f'Invalid `duns_id`: {value}. '
-                        'It should be a 9-digit number.',
+                        'It should be a string of 9 digits.',
                         'field': key,
                         'type': 'ValueError',
                     }

--- a/src/django/contricleaner/tests/test_row_additional_ids_serializer.py
+++ b/src/django/contricleaner/tests/test_row_additional_ids_serializer.py
@@ -60,7 +60,7 @@ class RowAdditionalIdsSerializerTest(TestCase):
         self.assertEqual(len(result["errors"]), 1)
         self.assertEqual(
             result["errors"][0]["message"],
-            "Invalid `duns_id`: 12345678. It should be a 9-digit number.",
+            "Invalid `duns_id`: 12345678. It should be a string of 9 digits.",
         )
         self.assertEqual(result["errors"][0]["field"], "duns_id")
         self.assertEqual(result["errors"][0]["type"], "ValueError")


### PR DESCRIPTION
[OSDEV-1926](https://opensupplyhub.atlassian.net/browse/OSDEV-1926) - [RBA Data Model] Allow submission of additional identifiers through the API.

In this PR was modified the error message for the invalid `duns_id` value.

[OSDEV-1926]: https://opensupplyhub.atlassian.net/browse/OSDEV-1926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ