### PR TITLE
[OSDEV-1895] FIX: Address pen test results of Cookies without HTTP-only

### DIFF
--- a/src/django/api/views/user/submit_new_user_form.py
+++ b/src/django/api/views/user/submit_new_user_form.py
@@ -2,7 +2,7 @@ from allauth.account.utils import complete_signup
 from rest_framework.exceptions import ValidationError
 from rest_framework.generics import CreateAPIView
 from rest_framework.response import Response
-from rest_framework.status import HTTP_204_NO_CONTENT
+from rest_framework.status import HTTP_200_OK
 from django.db import transaction
 
 from ...models import Contributor, User
@@ -61,4 +61,12 @@ class SubmitNewUserForm(CreateAPIView):
 
             complete_signup(self.request._request, user, 'optional', None)
 
-            return Response(status=HTTP_204_NO_CONTENT)
+            # Adding the CSRF token to the response to store it
+            # in local storage for future use and include it in request headers,
+            # as access to cookies has been restricted by the HttpOnly flag.
+            csrf_token = request.META["CSRF_COOKIE"]
+            response_data = {
+                "csrfToken": csrf_token
+            }
+
+            return Response(response_data, status=HTTP_200_OK)

--- a/src/react/src/reducers/ProfileReducer.js
+++ b/src/react/src/reducers/ProfileReducer.js
@@ -35,7 +35,6 @@ import {
     registrationFieldsEnum,
     profileFieldsEnum,
     profileSummaryFieldsEnum,
-    CSRF_TOKEN_KEY,
 } from '../util/constants';
 
 const initialState = Object.freeze({
@@ -129,11 +128,7 @@ const completeGettingAPIToken = (state, payload) =>
         },
     });
 
-const handleLogin = (state, { id, email, csrfToken }) => {
-    if (csrfToken) {
-        window.localStorage.setItem(CSRF_TOKEN_KEY, csrfToken);
-    }
-
+const handleLogin = (state, { id, email }) => {
     if (id !== state.profile.id) {
         return state;
     }
@@ -145,16 +140,13 @@ const handleLogin = (state, { id, email, csrfToken }) => {
     });
 };
 
-const handleLogout = state => {
-    window.localStorage.removeItem(CSRF_TOKEN_KEY);
-
-    return update(state, {
+const handleLogout = state =>
+    update(state, {
         profile: {
             email: { $set: initialState.profile.email },
             password: { $set: initialState.profile.password },
         },
     });
-};
 
 export default createReducer(
     {


### PR DESCRIPTION
[OSDEV-1895](https://opensupplyhub.atlassian.net/browse/OSDEV-1895) **FIX: Address pen test results of Cookies without HTTP-only**

- Added implementation to pass `csrftoken` to response & then in local storage for signup endpoint