### PR TITLE
Enable AWS WAF for RBA instance

### DIFF
--- a/deployment/environments/terraform-rba.tfvars
+++ b/deployment/environments/terraform-rba.tfvars
@@ -68,3 +68,5 @@ app_logstash_fargate_cpu = 256
 app_logstash_fargate_memory = 2048
 
 export_csv_enabled = false
+
+waf_enabled = true

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-1949](https://opensupplyhub.atlassian.net/browse/OSDEV-1949) - Attached whitelist rules and deny rules and infrastructure changes: 
     - Bump Terraform version from 1.4.0 to 1.5.0
     - Made `waf_enabled` terraform flag variable.
+    - Enabled AWS WAF for all environments, including RBA.
     - Created a separate job `detach-waf-if-needed` in Deploy to AWS action. This is needed to prevent Terraform race condition when it tries to delete the AWS WAF before AWS has fully detached it from the CloudFront distribution, even though `web_acl_id` is set to`null`.
     - Applied validation in the `init-and-plan` action if `ip_denylist` and `ip_whitelist` are present. Only whitelist or denylist should be defined per environment.
 * [OSDEV-1746](https://opensupplyhub.atlassian.net/browse/OSDEV-1746) - Implemented auto-scaling to dynamically adjust the Django instance count based on load metrics for cost-efficient resource utilization and high availability.


### PR DESCRIPTION
Follow-up fix for [OSDEV-1949](https://opensupplyhub.atlassian.net/browse/OSDEV-1949) to prevent [error](https://github.com/opensupplyhub/open-supply-hub/actions/runs/14935552716/job/41963829599) while destroying environment.

```
│ Error: Provider configuration not present
│ 
│ To work with aws_wafv2_ip_set.ip_denylist[0] (orphan) its original provider
│ configuration at provider["registry.terraform.io/hashicorp/aws"].us-east-1
│ is required, but it has been removed. This occurs when a provider
│ configuration is removed while objects created by that provider still exist
│ in the state. Re-add the provider configuration to destroy
│ aws_wafv2_ip_set.ip_denylist[0] (orphan), after which you can remove the
│ provider configuration again.
```