### PR TITLE
[OSDEV-1981] GET v1/production-locations/{os_id}/ endpoint doesn't return additional identifiers "duns_id", "lei_id", "rba_id"

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -3,6 +3,30 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). The format is based on the `RELEASE-NOTES-TEMPLATE.md` file.
 
+## Release 2.5.0
+
+## Introduction
+* Product name: Open Supply Hub
+* Release date: May 31, 2025
+
+### Code/API changes
+* *Describe Code/API changes*
+
+### Architecture/Environment changes
+* *Describe Architecture/Environment changes*
+
+### Bugfix
+* [OSDEV-1981](https://opensupplyhub.atlassian.net/browse/OSDEV-1981) - Fixed an issue where the `updated_at` field in the `api_facility` table was not modified when related dependency data changed, resulting in outdated or invalid data being stored in `OpenSearch`.
+
+### What's new
+* *Describe What's new*
+
+### Release instructions:
+* Ensure that the following commands are included in the `post_deployment` command:
+    * `migrate`
+    * `reindex_database`
+
+
 ## Release 2.4.0
 
 ## Introduction

--- a/src/django/api/moderation_event_actions/approval/event_approval_template.py
+++ b/src/django/api/moderation_event_actions/approval/event_approval_template.py
@@ -137,6 +137,8 @@ class EventApprovalTemplate(ABC):
             'Moderation Event updated.'
         )
 
+        self._update_facility_updated_at(item.facility.id)
+
         return item
 
     @staticmethod
@@ -323,4 +325,9 @@ class EventApprovalTemplate(ABC):
     @staticmethod
     def _create_new_facility(item: FacilityListItem, facility_id: str) -> None:
         """Hook method to create a new facility."""
+        pass
+
+    @staticmethod
+    def _update_facility_updated_at(facility_id: str) -> None:
+        """Hook method to update a facility updated_at field."""
         pass

--- a/src/django/api/moderation_event_actions/approval/update_production_location.py
+++ b/src/django/api/moderation_event_actions/approval/update_production_location.py
@@ -44,7 +44,7 @@ class UpdateProductionLocation(EventApprovalTemplate):
 
     def _get_action_type(self):
         return ModerationEvent.ActionType.MATCHED
-    
+
     @staticmethod
     def _update_facility_updated_at(facility_id: str) -> None:
         Facility.update_facility_updated_at_field(facility_id)

--- a/src/django/api/moderation_event_actions/approval/update_production_location.py
+++ b/src/django/api/moderation_event_actions/approval/update_production_location.py
@@ -6,6 +6,7 @@ from api.constants import (
 )
 from api.models.facility.facility_list_item import FacilityListItem
 from api.models.facility.facility_match import FacilityMatch
+from api.models.facility.facility import Facility
 from api.models.moderation_event import ModerationEvent
 from api.models.user import User
 from api.moderation_event_actions.approval.event_approval_template import (
@@ -43,3 +44,7 @@ class UpdateProductionLocation(EventApprovalTemplate):
 
     def _get_action_type(self):
         return ModerationEvent.ActionType.MATCHED
+    
+    @staticmethod
+    def _update_facility_updated_at(facility_id: str) -> None:
+        Facility.update_facility_updated_at_field(facility_id)

--- a/src/django/api/tests/test_facility_history_endpoint.py
+++ b/src/django/api/tests/test_facility_history_endpoint.py
@@ -120,6 +120,16 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
         self.facility_two_history_url = "/api/facilities/{}/history/".format(
             self.facility_two.id
         )
+    
+    def filter_out_manual_updated_at_action(self, data):
+        # Filter out action where we manually trigger 
+        # 'updated_at' field in 'api_facility' table
+        # by using update_facility_updated_at_field method
+        return [
+            item for item in data
+            if not (item.get("action") == "OTHER"
+                    and item.get("changes") == {})
+        ]
 
     @override_flag(FeatureGroups.CAN_GET_FACILITY_HISTORY, active=True)
     def test_serializes_deleted_facility_history(self):
@@ -495,13 +505,15 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
 
         data = json.loads(confirmed_match_response.content)
 
+        filtered_data = self.filter_out_manual_updated_at_action(data)
+
         self.assertEqual(
-            data[0]["action"],
+            filtered_data[0]["action"],
             "ASSOCIATE",
         )
 
         self.assertEqual(
-            data[0]["detail"],
+            filtered_data[0]["detail"],
             "Associate facility {} with {} via list {}".format(
                 self.facility_two.id,
                 self.contributor.name,
@@ -510,7 +522,7 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
         )
 
         self.assertEqual(
-            len(data),
+            len(filtered_data),
             3,
         )
 
@@ -525,8 +537,10 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
 
         data = json.loads(confirmed_match_response.content)
 
+        filtered_data = self.filter_out_manual_updated_at_action(data)
+
         self.assertEqual(
-            data[0]["detail"],
+            filtered_data[0]["detail"],
             "Associate facility {} with an Other".format(
                 self.facility_two.id,
             ),
@@ -572,13 +586,15 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
 
         data = json.loads(removed_match_response.content)
 
+        filtered_data = self.filter_out_manual_updated_at_action(data)
+
         self.assertEqual(
-            data[0]["action"],
+            filtered_data[0]["action"],
             "DISSOCIATE",
         )
 
         self.assertEqual(
-            data[0]["detail"],
+            filtered_data[0]["detail"],
             "Dissociate facility {} from {} via list {}".format(
                 self.facility_two.id,
                 self.contributor.name,
@@ -587,7 +603,7 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
         )
 
         self.assertEqual(
-            len(data),
+            len(filtered_data),
             4,
         )
 
@@ -602,8 +618,10 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
 
         data = json.loads(confirmed_match_response.content)
 
+        filtered_data = self.filter_out_manual_updated_at_action(data)
+
         self.assertEqual(
-            data[0]["detail"],
+            filtered_data[0]["detail"],
             "Dissociate facility {} from an Other".format(
                 self.facility_two.id,
             ),
@@ -702,12 +720,13 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
             200,
         )
         data = json.loads(history_response.content)
+        filtered_data = self.filter_out_manual_updated_at_action(data)
         self.assertEqual(
-            data[0]["action"],
+            filtered_data[0]["action"],
             "DISSOCIATE",
         )
         self.assertEqual(
-            data[0]["detail"],
+            filtered_data[0]["detail"],
             "Dissociate facility {} from {} via list {}".format(
                 self.facility_two.id,
                 self.contributor.name,

--- a/src/django/api/tests/test_facility_history_endpoint.py
+++ b/src/django/api/tests/test_facility_history_endpoint.py
@@ -120,9 +120,9 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
         self.facility_two_history_url = "/api/facilities/{}/history/".format(
             self.facility_two.id
         )
-    
+
     def filter_out_manual_updated_at_action(self, data):
-        # Filter out action where we manually trigger 
+        # Filter out action where we manually trigger
         # 'updated_at' field in 'api_facility' table
         # by using update_facility_updated_at_field method
         return [

--- a/src/django/api/tests/test_moderation_events_update_production_location.py
+++ b/src/django/api/tests/test_moderation_events_update_production_location.py
@@ -162,11 +162,17 @@ class ModerationEventsUpdateProductionLocationTest(
 
     def test_successful_update_production_location(self):
         self.login_as_superuser()
+        old_updated_at = self.facility_one.updated_at
+
         response = self.client.patch(
             self.get_url(),
             data=json.dumps({"os_id": self.os_id}),
             content_type="application/json",
         )
+
+        self.facility_one.refresh_from_db()
+        new_updated_at = self.facility_one.updated_at
+        self.assertGreater(new_updated_at, old_updated_at)
 
         email = mail.outbox[0]
         self.assertEqual(email.subject, "Great News: your OS ID is ready!")

--- a/src/django/api/views/facility/facilities_view_set.py
+++ b/src/django/api/views/facility/facilities_view_set.py
@@ -1598,8 +1598,6 @@ class FacilitiesViewSet(ListModelMixin,
 
         context = {'request': request}
 
-        Facility.update_facility_updated_at_field(facility.id)
-
         facility_index = FacilityIndex.objects.get(id=facility.id)
         facility_data = FacilityIndexDetailsSerializer(
             facility_index, context=context).data

--- a/src/django/api/views/facility/facilities_view_set.py
+++ b/src/django/api/views/facility/facilities_view_set.py
@@ -1597,6 +1597,9 @@ class FacilitiesViewSet(ListModelMixin,
                     match.save()
 
         context = {'request': request}
+
+        Facility.update_facility_updated_at_field(facility.id)
+
         facility_index = FacilityIndex.objects.get(id=facility.id)
         facility_data = FacilityIndexDetailsSerializer(
             facility_index, context=context).data
@@ -1652,6 +1655,8 @@ class FacilitiesViewSet(ListModelMixin,
             ) from exc
 
         facility_activity_report.save()
+
+        Facility.update_facility_updated_at_field(facility.id)
 
         serializer = FacilityActivityReportSerializer(facility_activity_report)
         return Response(serializer.data)

--- a/src/django/api/views/facility/facilities_view_set.py
+++ b/src/django/api/views/facility/facilities_view_set.py
@@ -1597,7 +1597,6 @@ class FacilitiesViewSet(ListModelMixin,
                     match.save()
 
         context = {'request': request}
-
         facility_index = FacilityIndex.objects.get(id=facility.id)
         facility_data = FacilityIndexDetailsSerializer(
             facility_index, context=context).data

--- a/src/django/api/views/facility/facilities_view_set.py
+++ b/src/django/api/views/facility/facilities_view_set.py
@@ -1596,6 +1596,8 @@ class FacilitiesViewSet(ListModelMixin,
                             facility)
                     match.save()
 
+        Facility.update_facility_updated_at_field(facility.id)
+
         context = {'request': request}
         facility_index = FacilityIndex.objects.get(id=facility.id)
         facility_data = FacilityIndexDetailsSerializer(

--- a/src/django/api/views/facility/facility_match_view_set.py
+++ b/src/django/api/views/facility/facility_match_view_set.py
@@ -191,7 +191,6 @@ class FacilityMatchViewSet(RetrieveModelMixin, GenericViewSet):
 
         response_data = FacilityListItemSerializer(facility_list_item).data
 
-
         if facility_list_item.source.source_type == Source.LIST:
             response_data['list_statuses'] = (
                 facility_list_item

--- a/src/django/api/views/facility/facility_match_view_set.py
+++ b/src/django/api/views/facility/facility_match_view_set.py
@@ -191,6 +191,13 @@ class FacilityMatchViewSet(RetrieveModelMixin, GenericViewSet):
 
         response_data = FacilityListItemSerializer(facility_list_item).data
 
+        # Call `update` rather than use `save` to make sure that
+        # django-simple-history won't log the changes
+        facility_query = Facility.objects.filter(
+            pk=facility_match.facility.id
+        )
+        facility_query.update(updated_at=timezone.now())
+
         if facility_list_item.source.source_type == Source.LIST:
             response_data['list_statuses'] = (
                 facility_list_item

--- a/src/django/api/views/facility/facility_match_view_set.py
+++ b/src/django/api/views/facility/facility_match_view_set.py
@@ -192,7 +192,9 @@ class FacilityMatchViewSet(RetrieveModelMixin, GenericViewSet):
         response_data = FacilityListItemSerializer(facility_list_item).data
 
         # Call `update` rather than use `save` to make sure that
-        # django-simple-history won't log the changes
+        # django-simple-history won't log the changes as we
+        # only need it to trigger Logstash sql sync and don't
+        # want to break confirm match association history logic
         facility_query = Facility.objects.filter(
             pk=facility_match.facility.id
         )

--- a/src/django/api/views/facility/facility_match_view_set.py
+++ b/src/django/api/views/facility/facility_match_view_set.py
@@ -191,14 +191,7 @@ class FacilityMatchViewSet(RetrieveModelMixin, GenericViewSet):
 
         response_data = FacilityListItemSerializer(facility_list_item).data
 
-        # Call `update` rather than use `save` to make sure that
-        # django-simple-history won't log the changes as we
-        # only need it to trigger Logstash sql sync and don't
-        # want to break confirm match association history logic
-        facility_query = Facility.objects.filter(
-            pk=facility_match.facility.id
-        )
-        facility_query.update(updated_at=timezone.now())
+        Facility.update_facility_updated_at_field(facility_match.facility.id)
 
         if facility_list_item.source.source_type == Source.LIST:
             response_data['list_statuses'] = (

--- a/src/django/api/views/facility/facility_match_view_set.py
+++ b/src/django/api/views/facility/facility_match_view_set.py
@@ -191,9 +191,6 @@ class FacilityMatchViewSet(RetrieveModelMixin, GenericViewSet):
 
         response_data = FacilityListItemSerializer(facility_list_item).data
 
-        Facility.update_facility_updated_at_field(
-            facility_list_item.facility_id
-        )
 
         if facility_list_item.source.source_type == Source.LIST:
             response_data['list_statuses'] = (

--- a/src/django/api/views/facility/facility_match_view_set.py
+++ b/src/django/api/views/facility/facility_match_view_set.py
@@ -191,6 +191,8 @@ class FacilityMatchViewSet(RetrieveModelMixin, GenericViewSet):
 
         response_data = FacilityListItemSerializer(facility_list_item).data
 
+        Facility.update_facility_updated_at_field(facility_list_item.facility_id)
+
         if facility_list_item.source.source_type == Source.LIST:
             response_data['list_statuses'] = (
                 facility_list_item

--- a/src/django/api/views/facility/facility_match_view_set.py
+++ b/src/django/api/views/facility/facility_match_view_set.py
@@ -191,7 +191,9 @@ class FacilityMatchViewSet(RetrieveModelMixin, GenericViewSet):
 
         response_data = FacilityListItemSerializer(facility_list_item).data
 
-        Facility.update_facility_updated_at_field(facility_list_item.facility_id)
+        Facility.update_facility_updated_at_field(
+            facility_list_item.facility_id
+        )
 
         if facility_list_item.source.source_type == Source.LIST:
             response_data['list_statuses'] = (

--- a/src/django/api/views/v1/moderation_events.py
+++ b/src/django/api/views/v1/moderation_events.py
@@ -217,6 +217,4 @@ class ModerationEvents(ViewSet):
         if event.source == ModerationEvent.Source.SLC:
             send_slc_contribution_approval_email(request, event, item)
 
-        Facility.update_facility_updated_at_field(item.facility_id)
-
         return Response({"os_id": item.facility_id}, status=status.HTTP_200_OK)

--- a/src/django/api/views/v1/moderation_events.py
+++ b/src/django/api/views/v1/moderation_events.py
@@ -16,6 +16,7 @@ from api.constants import (
     APIV1ModerationEventErrorMessages
 )
 from api.models.moderation_event import ModerationEvent
+from api.models.facility.facility import Facility
 from api.moderation_event_actions.approval.add_production_location \
     import AddProductionLocation
 from api.moderation_event_actions.approval.update_production_location \
@@ -215,5 +216,7 @@ class ModerationEvents(ViewSet):
 
         if event.source == ModerationEvent.Source.SLC:
             send_slc_contribution_approval_email(request, event, item)
+
+        Facility.update_facility_updated_at_field(item.facility_id)
 
         return Response({"os_id": item.facility_id}, status=status.HTTP_200_OK)

--- a/src/django/api/views/v1/moderation_events.py
+++ b/src/django/api/views/v1/moderation_events.py
@@ -16,7 +16,6 @@ from api.constants import (
     APIV1ModerationEventErrorMessages
 )
 from api.models.moderation_event import ModerationEvent
-from api.models.facility.facility import Facility
 from api.moderation_event_actions.approval.add_production_location \
     import AddProductionLocation
 from api.moderation_event_actions.approval.update_production_location \


### PR DESCRIPTION
[OSDEV-1981](https://opensupplyhub.atlassian.net/browse/OSDEV-1981) **GET v1/production-locations/{os_id}/ endpoint doesn't return additional identifiers "duns_id", "lei_id", "rba_id"**

- Fixed an issue where the `updated_at` field in the `api_facility` table was not modified when related dependency data changed, resulting in outdated or invalid data being stored in `OpenSearch`.
- Updated unit test case to cover changes with `api_facility` field `updated_at`.

[OSDEV-1981]: https://opensupplyhub.atlassian.net/browse/OSDEV-1981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ