### PR TITLE
[OSDEV-1998] Update OS Hub platform header and footer.

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -28,7 +28,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-1882](https://opensupplyhub.atlassian.net/browse/OSDEV-1882) - Fixed an issue where the scroll position was not resetting to the top when navigating to the `Upload` page related to the list upload functionality.
 
 ### What's new
-* *Describe what's new here. The changes that can impact user experience should be listed in this section.*
+* [OSDEV-1998](https://opensupplyhub.atlassian.net/browse/OSDEV-1998) - The following changes were made:
+    * Added an additional "Data Cleaning Service" subheader to the "How It Works" > "Premium Features" section.
+    * Updated the list of supported languages/countries under the "globe" icon (added support for Chinese and changed the order).
+    * Removed the Twitter icon from the social media icons/links in the footer.
 
 ### Release instructions:
 * Ensure that the following commands are included in the `post_deployment` command:

--- a/src/react/src/__tests__/components/Footer.test.js
+++ b/src/react/src/__tests__/components/Footer.test.js
@@ -52,5 +52,5 @@ test('Footer component', () => {
     expect(youtubeLink.parentElement).toHaveAttribute('href', 'https://www.youtube.com/channel/UCy-66mcBwX2wlUM6kvKUrGw');
 
     const githubLink = screen.getByText('Github');
-    expect(githubLink.parentElement).toHaveAttribute('href', 'https://github.com/opensupplyhub/pyoshub');
+    expect(githubLink.parentElement).toHaveAttribute('href', 'https://github.com/opensupplyhub/open-supply-hub');
 });

--- a/src/react/src/__tests__/components/Footer.test.js
+++ b/src/react/src/__tests__/components/Footer.test.js
@@ -48,9 +48,6 @@ test('Footer component', () => {
     const linkedinLink = screen.getByText('LinkedIn');
     expect(linkedinLink.parentElement).toHaveAttribute('href', 'https://www.linkedin.com/company/open-supply-hub/');
 
-    const twitterLink = screen.getByText('Twitter');
-    expect(twitterLink.parentElement).toHaveAttribute('href', 'https://twitter.com/OpenSupplyHub');
-
     const youtubeLink = screen.getByText('YouTube');
     expect(youtubeLink.parentElement).toHaveAttribute('href', 'https://www.youtube.com/channel/UCy-66mcBwX2wlUM6kvKUrGw');
 

--- a/src/react/src/components/AddLocationData.jsx
+++ b/src/react/src/components/AddLocationData.jsx
@@ -118,7 +118,7 @@ function AddLocationData({ classes, userHasSignedIn, fetchingSessionSignIn }) {
                                 className={classes.secondaryButton}
                                 onClick={() =>
                                     openInNewTab(
-                                        `${InfoLink}/${InfoPaths.contribute}`,
+                                        `${InfoLink}/${InfoPaths.dataCleaningService}`,
                                     )
                                 }
                             >

--- a/src/react/src/components/Navbar/InternationalMenu.jsx
+++ b/src/react/src/components/Navbar/InternationalMenu.jsx
@@ -49,6 +49,13 @@ function Submenu() {
                     <span>বাংলা</span>
                 </a>
                 <a
+                    className="nav-submenu__link nav-submenu__link--lighter-font-weight"
+                    href="https://info.opensupplyhub.org/facilities-chinese"
+                    target=""
+                >
+                    <span>简体中文</span>
+                </a>
+                <a
                     className="nav-submenu__link nav-submenu__link"
                     href="https://info.opensupplyhub.org/india"
                     target=""
@@ -60,21 +67,14 @@ function Submenu() {
                     href="https://info.opensupplyhub.org/brasil"
                     target=""
                 >
-                    <span>Portuguese</span>
+                    <span>Português</span>
                 </a>
                 <a
                     className="nav-submenu__link "
                     href="https://info.opensupplyhub.org/turkey"
                     target=""
                 >
-                    <span>Türkiye</span>
-                </a>
-                <a
-                    className="nav-submenu__link "
-                    href="https://info.opensupplyhub.org/vietnam"
-                    target=""
-                >
-                    <span>Tiếng Việt</span>
+                    <span>Türkçe</span>
                 </a>
             </div>
         </div>

--- a/src/react/src/components/Navbar/MobileInternationalMenu.jsx
+++ b/src/react/src/components/Navbar/MobileInternationalMenu.jsx
@@ -59,6 +59,15 @@ export default function MobileInternationalMenu({
                 <div className="mobile-nav__item">
                     <a
                         className="mobile-nav-link mobile-nav-link--lighter-font-weight"
+                        href="https://info.opensupplyhub.org/facilities-chinese"
+                        target=""
+                    >
+                        简体中文
+                    </a>
+                </div>
+                <div className="mobile-nav__item">
+                    <a
+                        className="mobile-nav-link mobile-nav-link--lighter-font-weight"
                         href="https://info.opensupplyhub.org/india"
                         target=""
                     >
@@ -71,7 +80,7 @@ export default function MobileInternationalMenu({
                         href="https://info.opensupplyhub.org/brasil"
                         target=""
                     >
-                        Portuguese
+                        Português
                     </a>
                 </div>
                 <div className="mobile-nav__item">
@@ -80,16 +89,7 @@ export default function MobileInternationalMenu({
                         href="https://info.opensupplyhub.org/turkey"
                         target=""
                     >
-                        Türkiye
-                    </a>
-                </div>
-                <div className="mobile-nav__item">
-                    <a
-                        className="mobile-nav-link "
-                        href="https://info.opensupplyhub.org/vietnam"
-                        target=""
-                    >
-                        Tiếng Việt
+                        Türkçe
                     </a>
                 </div>
             </div>

--- a/src/react/src/util/constants.jsx
+++ b/src/react/src/util/constants.jsx
@@ -976,24 +976,6 @@ export const SocialMediaLinks = [
         href: 'https://www.linkedin.com/company/open-supply-hub/',
     },
     {
-        label: 'Twitter',
-        Icon: () => (
-            <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="20"
-                height="17"
-                viewBox="0 0 20 17"
-            >
-                <path
-                    d="M17.944 4.048c.013.178.013.356.013.533 0 5.419-4.124 11.663-11.663 11.663-2.322 0-4.48-.673-6.294-1.84.33.038.647.05.99.05a8.21 8.21 0 0 0 5.089-1.75A4.106 4.106 0 0 1 2.246 9.86c.254.038.508.064.774.064.368 0 .736-.05 1.079-.14A4.1 4.1 0 0 1 .812 5.761v-.05c.546.304 1.18.495 1.853.52A4.096 4.096 0 0 1 .838 2.817c0-.761.203-1.46.558-2.068a11.651 11.651 0 0 0 8.452 4.29 4.627 4.627 0 0 1-.102-.94A4.097 4.097 0 0 1 13.846 0a4.09 4.09 0 0 1 2.994 1.294 8.07 8.07 0 0 0 2.602-.99 4.088 4.088 0 0 1-1.802 2.26A8.217 8.217 0 0 0 20 1.928a8.811 8.811 0 0 1-2.056 2.12Z"
-                    fill="#FFF"
-                    fillRule="nonzero"
-                />
-            </svg>
-        ),
-        href: 'https://twitter.com/OpenSupplyHub',
-    },
-    {
         label: 'YouTube',
         Icon: () => (
             <svg
@@ -1027,7 +1009,7 @@ export const SocialMediaLinks = [
                 />
             </svg>
         ),
-        href: 'https://github.com/opensupplyhub/pyoshub',
+        href: 'https://github.com/opensupplyhub/open-supply-hub',
     },
 ];
 

--- a/src/react/src/util/constants.jsx
+++ b/src/react/src/util/constants.jsx
@@ -25,7 +25,7 @@ export const CSRF_TOKEN_KEY = 'csrfToken';
 export const InfoPaths = {
     storiesResources: 'stories-resources',
     privacyPolicy: 'privacy-policy',
-    contribute: 'data-cleaning-service',
+    dataCleaningService: 'data-cleaning-service',
     preparingData: 'resources/preparing-data',
     dataQuality: 'resources/a-free-universal-id-matching-algorithm',
     claimedFacilities: 'stories-resources/claim-a-facility',
@@ -821,6 +821,11 @@ export const NavbarItems = [
                             type: 'link',
                             label: 'API',
                             href: `${InfoLink}/${InfoPaths.api}`,
+                        },
+                        {
+                            type: 'link',
+                            label: 'Data Cleaning Service',
+                            href: `${InfoLink}/${InfoPaths.dataCleaningService}`,
                         },
                         {
                             type: 'link',


### PR DESCRIPTION
[OSDEV-1998](https://opensupplyhub.atlassian.net/browse/OSDEV-1998) - [FE] Update OS Hub platform header & footer.

Changes made:
- Added an additional "Data Cleaning Service" subheader to the "How It Works" > "Premium Features" section.
- Updated the list of supported languages/countries under the "globe" icon (added support for Chinese and changed the order).
- Removed the Twitter icon from the social media icons/links in the footer.

![Screenshot from 2025-05-13 17-36-02](https://github.com/user-attachments/assets/35b7733f-a0a8-4df5-b10f-5e86c5ebf3d0)
![Screenshot from 2025-05-13 17-36-08](https://github.com/user-attachments/assets/1511c9d9-d898-4781-a2f2-6cf4b045abee)

[OSDEV-1998]: https://opensupplyhub.atlassian.net/browse/OSDEV-1998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ