### PR TITLE
Refinde readme, set EC2 VPN to RBA only

### DIFF
--- a/.github/workflows/deploy_to_aws.yml
+++ b/.github/workflows/deploy_to_aws.yml
@@ -55,7 +55,6 @@ jobs:
           repository: 'opensupplyhub/ci-deployment'
           path: 'terraform-config'
           token: ${{ secrets.PAT }}
-          ref: 'refs/pull/33/head'
 
       - name: Copy tfvars for ${{ vars.ENV_NAME }}
         run: |
@@ -115,7 +114,6 @@ jobs:
           repository: 'opensupplyhub/ci-deployment'
           path: 'terraform-config'
           token: ${{ secrets.PAT }}
-          ref: 'refs/pull/33/head'
 
       - name: Copy tfvars for ${{ vars.ENV_NAME }}
         run: |

--- a/deployment/terraform/vpn-ec2.tf
+++ b/deployment/terraform/vpn-ec2.tf
@@ -108,14 +108,6 @@ resource "aws_security_group" "vpn_sg" {
   }
 
   ingress {
-    from_port   = 51821
-    to_port     = 51821
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-    description = "WireGuard management access (WebUI)"
-  }
-
-  ingress {
     from_port       = 22
     to_port         = 22
     protocol        = "tcp"

--- a/deployment/terraform/vpn-ec2.tf
+++ b/deployment/terraform/vpn-ec2.tf
@@ -40,15 +40,15 @@ resource "aws_iam_instance_profile" "vpn_instance" {
 }
 
 data "template_file" "wireguard_compose" {
-  count    = var.environment == "Test" ? 1 : 0
+  count    = var.environment == "Rba" ? 1 : 0
   template = file("${path.module}/wireguard/docker-compose.yml")
   vars = {
-    wg_host = var.environment == "Test" ? aws_eip.vpn_eip[0].public_ip : ""
+    wg_host = var.environment == "Rba" ? aws_eip.vpn_eip[0].public_ip : ""
   }
 }
 
 resource "aws_instance" "vpn_ec2" {
-  count         = var.environment == "Test" ? 1 : 0
+  count         = var.environment == "Rba" ? 1 : 0
   ami           = data.aws_ami.aws_ami_vpn_ec2.id
   instance_type = "t4g.nano"
   subnet_id     = module.vpc.public_subnet_ids[count.index]
@@ -138,7 +138,7 @@ resource "aws_security_group" "vpn_sg" {
 }
 
 resource "aws_eip" "vpn_eip" {
-  count  = var.environment == "Test" ? 1 : 0
+  count  = var.environment == "Rba" ? 1 : 0
   domain = "vpc"
   tags = {
     Name        = "vpn-eip-${var.environment}"
@@ -148,7 +148,7 @@ resource "aws_eip" "vpn_eip" {
 }
 
 resource "aws_eip_association" "eip_assoc" {
-  count         = var.environment == "Test" ? 1 : 0
+  count         = var.environment == "Rba" ? 1 : 0
   instance_id   = aws_instance.vpn_ec2[0].id
   allocation_id = aws_eip.vpn_eip[0].id
 }

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -9,18 +9,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * Product name: Open Supply Hub
 * Release date: May 31, 2025
 
-### Database changes
-* *Describe high-level database changes.*
-
-#### Migrations:
-* *Describe migrations here.*
-
-#### Schema changes
-* *Describe schema changes here.*
-
-### Code/API changes
-* *Describe code/API changes here.*
-
 ### Architecture/Environment changes
 * [OSDEV-1992](https://opensupplyhub.atlassian.net/browse/OSDEV-1992) - Provisioned a dedicated EC2 instance to host WireGuard VPN service, enabling authorized users to bypass AWS WAF when accessing the RBA instance.
 


### PR DESCRIPTION
Pre-code freeze PR for release `v.2.5.0`
1.  Set EC2 VPN to RBA instance only.
2. No longer refer to the test PR https://github.com/opensupplyhub/ci-deployment/pull/33 while Deploy to AWS
3. Remove empty sections from Release notes.
4. Disabled open access to the WireGuard WebUI.