### PR TITLE
[OSDEV-2035] Remove waf_enabled variables for all envs

### DIFF
--- a/deployment/environments/terraform-development.tfvars
+++ b/deployment/environments/terraform-development.tfvars
@@ -68,5 +68,3 @@ opensearch_instance_type = "t3.small.search"
 
 app_logstash_fargate_cpu = 256
 app_logstash_fargate_memory = 2048
-
-waf_enabled = true

--- a/deployment/environments/terraform-preprod.tfvars
+++ b/deployment/environments/terraform-preprod.tfvars
@@ -69,4 +69,3 @@ opensearch_instance_type = "m6g.large.search"
 app_logstash_fargate_cpu = 256
 app_logstash_fargate_memory = 2048
 
-waf_enabled = true

--- a/deployment/environments/terraform-production.tfvars
+++ b/deployment/environments/terraform-production.tfvars
@@ -67,4 +67,3 @@ opensearch_instance_type = "m6g.large.search"
 app_logstash_fargate_cpu = 256
 app_logstash_fargate_memory = 2048
 
-waf_enabled = true

--- a/deployment/environments/terraform-rba.tfvars
+++ b/deployment/environments/terraform-rba.tfvars
@@ -69,4 +69,3 @@ app_logstash_fargate_memory = 2048
 
 export_csv_enabled = false
 
-waf_enabled = true

--- a/deployment/environments/terraform-staging.tfvars
+++ b/deployment/environments/terraform-staging.tfvars
@@ -65,4 +65,3 @@ opensearch_instance_type = "t3.small.search"
 app_logstash_fargate_cpu = 256
 app_logstash_fargate_memory = 2048
 
-waf_enabled = true

--- a/deployment/environments/terraform-test.tfvars
+++ b/deployment/environments/terraform-test.tfvars
@@ -73,4 +73,3 @@ opensearch_instance_type = "t3.small.search"
 app_logstash_fargate_cpu = 256
 app_logstash_fargate_memory = 2048
 
-waf_enabled = true


### PR DESCRIPTION
Removed `waf_enabled` variables from this repo and introduce them in **ci-deployment** (See: https://github.com/opensupplyhub/ci-deployment/pull/37)