### PR TITLE
[OSDEV-2035] Refactor ipv6_cidr_pattern

### DIFF
--- a/deployment/terraform/waf.tf
+++ b/deployment/terraform/waf.tf
@@ -5,23 +5,22 @@ provider "aws" {
 
 locals {
   ipv4_cidr_pattern = "^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"
-  ipv6_cidr_pattern = "^([0-9a-fA-F]{1,4}:){1,7}[0-9a-fA-F]{1,4}/[0-9]{1,3}$"
-
+  ipv6_cidr_pattern = "^[0-9a-fA-F:]+::[0-9a-fA-F:]+/128$"
   ipv4_whitelist = [
     for ip in var.ip_whitelist :
     ip if can(regex(local.ipv4_cidr_pattern, ip)) && can(cidrhost(ip, 0))
   ]
   ipv6_whitelist = [
     for ip in var.ip_whitelist :
-    ip if can(regex(local.ipv6_cidr_pattern, ip)) && can(cidrhost(ip, 0))
+    ip if can(cidrhost(ip, 0)) && length(split(".", split("/", ip)[0])) != 4
   ]
   ipv4_denylist = [
     for ip in var.ip_denylist :
-    ip if can(regex(local.ipv4_cidr_pattern, ip)) && can(cidrhost(ip, 0))
+    ip if can(cidrhost(ip, 0)) && length(split(".", split("/", ip)[0])) == 4
   ]
   ipv6_denylist = [
     for ip in var.ip_denylist :
-    ip if can(regex(local.ipv6_cidr_pattern, ip)) && can(cidrhost(ip, 0))
+    ip if can(cidrhost(ip, 0)) && length(split(".", split("/", ip)[0])) != 4
   ]
   is_whitelist_enabled = length(local.ipv4_whitelist) > 0 || length(local.ipv6_whitelist) > 0
   is_denylist_enabled  = length(local.ipv4_denylist)  > 0 || length(local.ipv6_denylist)  > 0


### PR DESCRIPTION
Follow-up fix for [OSDEV-2035](https://opensupplyhub.atlassian.net/browse/OSDEV-2035)
Previous `ipv6_cidr_pattern` didn't work properly for Better Stack IPv6 addresses.