### PR TITLE
[OSDEV-1951] Fix the issue when script can't mark rows red

### DIFF
--- a/deployment/terraform/batch.tf
+++ b/deployment/terraform/batch.tf
@@ -368,6 +368,10 @@ resource "aws_batch_compute_environment" "direct_data_load" {
     type      = "FARGATE"
     max_vcpus = var.batch_direct_data_load_ce_max_vcpus
     subnets   = module.vpc.private_subnet_ids
+
+    security_group_ids = [
+      aws_security_group.batch.id,
+    ]
   }
 }
 

--- a/src/django/api/management/commands/direct_data_load.py
+++ b/src/django/api/management/commands/direct_data_load.py
@@ -314,7 +314,7 @@ class Command(BaseCommand):
                 break
 
             if ec_result.errors:
-                __mark_row(
+                _mark_row(
                     service=service,
                     spreadsheet_id=sheet_id,
                     tab_id=options["tab_id"],
@@ -336,7 +336,7 @@ class Command(BaseCommand):
                 )
                 continue
             elif "error" in record and record["error"]:
-                __mark_row(
+                _mark_row(
                     service=service,
                     spreadsheet_id=sheet_id,
                     tab_id=options["tab_id"],
@@ -375,10 +375,10 @@ class Command(BaseCommand):
                 logger.error(
                     f"Error processing row '{row_idx}': '{str(error)}'"
                 )
-                break
+                raise
 
 
-def __mark_row(
+def _mark_row(
         service,
         spreadsheet_id,
         tab_id,


### PR DESCRIPTION
Change the name from `__mark_row` to `_mark_row` because the script was failing during the execution. Also re-thrown the error from database insert instead of just breaking the loop.