### PR TITLE
FIX-2: [OSDEV-2019] OS Hub DB. Add source column to tables for tracking origin of records

### DIFF
--- a/deployment/environments/terraform-development.tfvars
+++ b/deployment/environments/terraform-development.tfvars
@@ -68,3 +68,5 @@ opensearch_instance_type = "t3.small.search"
 
 app_logstash_fargate_cpu = 256
 app_logstash_fargate_memory = 2048
+
+instance_source= "os_hub"

--- a/deployment/environments/terraform-preprod.tfvars
+++ b/deployment/environments/terraform-preprod.tfvars
@@ -69,3 +69,5 @@ opensearch_instance_type = "m6g.large.search"
 app_logstash_fargate_cpu = 256
 app_logstash_fargate_memory = 2048
 
+instance_source= "os_hub"
+

--- a/deployment/environments/terraform-production.tfvars
+++ b/deployment/environments/terraform-production.tfvars
@@ -67,3 +67,5 @@ opensearch_instance_type = "m6g.large.search"
 app_logstash_fargate_cpu = 256
 app_logstash_fargate_memory = 2048
 
+instance_source= "os_hub"
+

--- a/deployment/environments/terraform-rba.tfvars
+++ b/deployment/environments/terraform-rba.tfvars
@@ -69,3 +69,5 @@ app_logstash_fargate_memory = 2048
 
 export_csv_enabled = false
 
+instance_source= "rba"
+

--- a/deployment/environments/terraform-staging.tfvars
+++ b/deployment/environments/terraform-staging.tfvars
@@ -65,3 +65,5 @@ opensearch_instance_type = "t3.small.search"
 app_logstash_fargate_cpu = 256
 app_logstash_fargate_memory = 2048
 
+instance_source= "os_hub"
+

--- a/deployment/environments/terraform-test.tfvars
+++ b/deployment/environments/terraform-test.tfvars
@@ -73,3 +73,5 @@ opensearch_instance_type = "t3.small.search"
 app_logstash_fargate_cpu = 256
 app_logstash_fargate_memory = 2048
 
+instance_source= "os_hub"
+

--- a/deployment/terraform/container_service.tf
+++ b/deployment/terraform/container_service.tf
@@ -245,6 +245,7 @@ data "template_file" "app" {
     opensearch_port                  = var.opensearch_port
     opensearch_ssl                   = var.opensearch_ssl
     opensearch_ssl_cert_verification = var.opensearch_ssl_cert_verification
+    instance_source                  = var.instance_source
   }
 }
 
@@ -300,6 +301,7 @@ data "template_file" "app_cli" {
     opensearch_port                  = var.opensearch_port
     opensearch_ssl                   = var.opensearch_ssl
     opensearch_ssl_cert_verification = var.opensearch_ssl_cert_verification
+    instance_source                  = var.instance_source
   }
 }
 
@@ -351,6 +353,7 @@ data "template_file" "app_dd" {
     dedupe_hub_live                  = var.dedupe_hub_live
     dedupe_hub_name                  = var.dedupe_hub_name
     dedupe_hub_version               = var.dedupe_hub_version
+    instance_source                  = var.instance_source
   }
 }
 

--- a/deployment/terraform/job-definitions/default.json
+++ b/deployment/terraform/job-definitions/default.json
@@ -30,7 +30,8 @@
       { "name": "OPENSEARCH_HOST", "value": "${opensearch_host}" },
       { "name": "OPENSEARCH_PORT", "value": "${opensearch_port}" },
       { "name": "OPENSEARCH_SSL", "value": "${opensearch_ssl}" },
-      { "name": "OPENSEARCH_SSL_CERT_VERIFICATION", "value": "${opensearch_ssl_cert_verification}" }
+      { "name": "OPENSEARCH_SSL_CERT_VERIFICATION", "value": "${opensearch_ssl_cert_verification}" },
+      { "name": "INSTANCE_SOURCE", "value": "${instance_source}" }
   ],
   "logConfiguration": {
       "logDriver": "awslogs",

--- a/deployment/terraform/job-definitions/direct_data_load.json
+++ b/deployment/terraform/job-definitions/direct_data_load.json
@@ -47,7 +47,8 @@
       { "name": "OPENSEARCH_HOST", "value": "${opensearch_host}" },
       { "name": "OPENSEARCH_PORT", "value": "${opensearch_port}" },
       { "name": "OPENSEARCH_SSL", "value": "${opensearch_ssl}" },
-      { "name": "OPENSEARCH_SSL_CERT_VERIFICATION", "value": "${opensearch_ssl_cert_verification}" }
+      { "name": "OPENSEARCH_SSL_CERT_VERIFICATION", "value": "${opensearch_ssl_cert_verification}" },
+      { "name": "INSTANCE_SOURCE", "value": "${instance_source}" }
   ],
   "logConfiguration": {
       "logDriver": "awslogs",

--- a/deployment/terraform/job-definitions/export_csv.json
+++ b/deployment/terraform/job-definitions/export_csv.json
@@ -20,7 +20,8 @@
       { "name": "OAR_CLIENT_KEY", "value": "${oar_client_key}" },
       { "name": "EXTERNAL_DOMAIN", "value": "${external_domain}" },
       { "name": "GOOGLE_SERVICE_ACCOUNT_CREDS_BASE64", "value": "${google_service_account_creds_base64}" },
-      { "name": "GOOGLE_DRIVE_SHARED_DIRECTORY_ID", "value": "${google_drive_shared_directory_id}" }
+      { "name": "GOOGLE_DRIVE_SHARED_DIRECTORY_ID", "value": "${google_drive_shared_directory_id}" },
+      { "name": "INSTANCE_SOURCE", "value": "${instance_source}" }
   ],
   "logConfiguration": {
       "logDriver": "awslogs",

--- a/deployment/terraform/job-definitions/notifications.json
+++ b/deployment/terraform/job-definitions/notifications.json
@@ -30,7 +30,8 @@
       { "name": "OPENSEARCH_HOST", "value": "${opensearch_host}" },
       { "name": "OPENSEARCH_PORT", "value": "${opensearch_port}" },
       { "name": "OPENSEARCH_SSL", "value": "${opensearch_ssl}" },
-      { "name": "OPENSEARCH_SSL_CERT_VERIFICATION", "value": "${opensearch_ssl_cert_verification}" }
+      { "name": "OPENSEARCH_SSL_CERT_VERIFICATION", "value": "${opensearch_ssl_cert_verification}" },
+      { "name": "INSTANCE_SOURCE", "value": "${instance_source}" }
   ],
   "logConfiguration": {
       "logDriver": "awslogs",

--- a/deployment/terraform/task-definitions/app.json
+++ b/deployment/terraform/task-definitions/app.json
@@ -46,7 +46,8 @@
         { "name": "OPENSEARCH_HOST", "value": "${opensearch_host}" },
         { "name": "OPENSEARCH_PORT", "value": "${opensearch_port}" },
         { "name": "OPENSEARCH_SSL", "value": "${opensearch_ssl}" },
-        { "name": "OPENSEARCH_SSL_CERT_VERIFICATION", "value": "${opensearch_ssl_cert_verification}" }
+        { "name": "OPENSEARCH_SSL_CERT_VERIFICATION", "value": "${opensearch_ssl_cert_verification}" },
+        { "name": "INSTANCE_SOURCE", "value": "${instance_source}" }
     ],
     "portMappings": [
       {

--- a/deployment/terraform/task-definitions/app_cli.json
+++ b/deployment/terraform/task-definitions/app_cli.json
@@ -35,7 +35,8 @@
         { "name": "OPENSEARCH_HOST", "value": "${opensearch_host}" },
         { "name": "OPENSEARCH_PORT", "value": "${opensearch_port}" },
         { "name": "OPENSEARCH_SSL", "value": "${opensearch_ssl}" },
-        { "name": "OPENSEARCH_SSL_CERT_VERIFICATION", "value": "${opensearch_ssl_cert_verification}" }
+        { "name": "OPENSEARCH_SSL_CERT_VERIFICATION", "value": "${opensearch_ssl_cert_verification}" },
+        { "name": "INSTANCE_SOURCE", "value": "${instance_source}" }
     ],
     "logConfiguration": {
         "logDriver": "awslogs",

--- a/deployment/terraform/task-definitions/app_dd.json
+++ b/deployment/terraform/task-definitions/app_dd.json
@@ -29,7 +29,8 @@
         { "name": "SECURITY_PROTOCOL", "value": "${security_protocol}" },
         { "name": "DEDUPE_HUB_LIVE", "value": "${dedupe_hub_live}" },
         { "name": "DEDUPE_HUB_NAME", "value": "${dedupe_hub_name}" },
-        { "name": "DEDUPE_HUB_VERSION", "value": "${dedupe_hub_version}" }
+        { "name": "DEDUPE_HUB_VERSION", "value": "${dedupe_hub_version}" },
+        { "name": "INSTANCE_SOURCE", "value": "${instance_source}" }
     ],
     "logConfiguration": {
         "logDriver": "awslogs",

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -564,6 +564,9 @@ variable "dedupe_hub_name" {
 }
 variable "dedupe_hub_version" {
 }
+variable "instance_source" {
+  default = "os_hub"
+}
 
 variable "opensearch_instance_type" {
   type    = string

--- a/src/dedupe-hub/api/app/config.py
+++ b/src/dedupe-hub/api/app/config.py
@@ -13,7 +13,7 @@ class Settings(BaseSettings):
     topic_dedupe_basic_name: str
     # Environment
     env: str
-    instance_source: str
+    instance_source: str = "os_hub"
     # Rollbar SS AT
     rollbar_server_side_access_token: str
     # Postgres

--- a/src/dedupe-hub/api/app/database/signals/origin_source.py
+++ b/src/dedupe-hub/api/app/database/signals/origin_source.py
@@ -12,4 +12,4 @@ for model in models:
     @event.listens_for(model, 'before_insert')
     def set_origin_source(mapper, connection, target):
         if not target.origin_source:
-            target.origin_source = settings.instance_source or 'os_hub'
+            target.origin_source = settings.instance_source

--- a/src/django/api/fixtures/contributors.json
+++ b/src/django/api/fixtures/contributors.json
@@ -11,7 +11,8 @@
             "other_contrib_type": null,
             "created_at": "2020-03-09T14:25:18+00:00",
             "updated_at": "2020-03-13T17:47:08.934203+00:00",
-            "embed_level": 3
+            "embed_level": 3,
+            "origin_source": "os_hub"
         }
     },
     {
@@ -26,7 +27,8 @@
             "other_contrib_type": null,
             "created_at": "2020-03-08T18:27:40+00:00",
             "updated_at": "2020-03-13T17:47:08.839090+00:00",
-            "embed_level": 2
+            "embed_level": 2,
+            "origin_source": "os_hub"
         }
     },
     {
@@ -41,7 +43,8 @@
             "other_contrib_type": null,
             "created_at": "2020-03-09T14:34:09+00:00",
             "updated_at": "2020-03-13T17:47:08.847584+00:00",
-            "embed_level": 1
+            "embed_level": 1,
+            "origin_source": "os_hub"
         }
     },
     {
@@ -55,7 +58,8 @@
             "contrib_type": "Factory / Facility",
             "other_contrib_type": null,
             "created_at": "2020-03-09T12:54:27+00:00",
-            "updated_at": "2020-03-13T17:47:08.187347+00:00"
+            "updated_at": "2020-03-13T17:47:08.187347+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -69,7 +73,8 @@
             "contrib_type": "Service Provider",
             "other_contrib_type": null,
             "created_at": "2020-03-08T03:35:38+00:00",
-            "updated_at": "2020-03-13T17:47:08.667328+00:00"
+            "updated_at": "2020-03-13T17:47:08.667328+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -83,7 +88,8 @@
             "contrib_type": "Auditor",
             "other_contrib_type": null,
             "created_at": "2020-03-06T21:16:40+00:00",
-            "updated_at": "2020-03-13T17:47:08.179940+00:00"
+            "updated_at": "2020-03-13T17:47:08.179940+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -97,7 +103,8 @@
             "contrib_type": "Civil Society Organization",
             "other_contrib_type": null,
             "created_at": "2020-03-11T15:19:04+00:00",
-            "updated_at": "2020-03-13T17:47:08.385298+00:00"
+            "updated_at": "2020-03-13T17:47:08.385298+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -111,7 +118,8 @@
             "contrib_type": "Manufacturing Group / Supplier / Vendor",
             "other_contrib_type": null,
             "created_at": "2020-03-13T15:09:21+00:00",
-            "updated_at": "2020-03-13T17:47:08.735275+00:00"
+            "updated_at": "2020-03-13T17:47:08.735275+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -125,7 +133,8 @@
             "contrib_type": "Union",
             "other_contrib_type": null,
             "created_at": "2020-03-09T12:28:03+00:00",
-            "updated_at": "2020-03-13T17:47:08.239366+00:00"
+            "updated_at": "2020-03-13T17:47:08.239366+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -139,7 +148,8 @@
             "contrib_type": "Service Provider",
             "other_contrib_type": null,
             "created_at": "2020-03-06T23:19:59+00:00",
-            "updated_at": "2020-03-13T17:47:08.556681+00:00"
+            "updated_at": "2020-03-13T17:47:08.556681+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -153,7 +163,8 @@
             "contrib_type": "Manufacturing Group / Supplier / Vendor",
             "other_contrib_type": null,
             "created_at": "2020-03-11T05:06:20+00:00",
-            "updated_at": "2020-03-13T17:47:08.613198+00:00"
+            "updated_at": "2020-03-13T17:47:08.613198+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -167,7 +178,8 @@
             "contrib_type": "Researcher / Academic",
             "other_contrib_type": null,
             "created_at": "2020-03-13T04:15:59+00:00",
-            "updated_at": "2020-03-13T17:47:08.913197+00:00"
+            "updated_at": "2020-03-13T17:47:08.913197+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -181,7 +193,8 @@
             "contrib_type": "Service Provider",
             "other_contrib_type": null,
             "created_at": "2020-03-06T10:44:08+00:00",
-            "updated_at": "2020-03-13T17:47:08.625690+00:00"
+            "updated_at": "2020-03-13T17:47:08.625690+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -195,7 +208,8 @@
             "contrib_type": "Manufacturing Group / Supplier / Vendor",
             "other_contrib_type": null,
             "created_at": "2020-03-08T07:01:23+00:00",
-            "updated_at": "2020-03-13T17:47:08.679122+00:00"
+            "updated_at": "2020-03-13T17:47:08.679122+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -209,7 +223,8 @@
             "contrib_type": "Brand/Retailer",
             "other_contrib_type": null,
             "created_at": "2020-03-10T13:19:54+00:00",
-            "updated_at": "2020-03-13T17:47:08.694509+00:00"
+            "updated_at": "2020-03-13T17:47:08.694509+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -223,7 +238,8 @@
             "contrib_type": "Researcher / Academic",
             "other_contrib_type": null,
             "created_at": "2020-03-06T11:09:17+00:00",
-            "updated_at": "2020-03-13T17:47:08.650227+00:00"
+            "updated_at": "2020-03-13T17:47:08.650227+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -237,7 +253,8 @@
             "contrib_type": "Manufacturing Group / Supplier / Vendor",
             "other_contrib_type": null,
             "created_at": "2020-03-07T01:02:59+00:00",
-            "updated_at": "2020-03-13T17:47:08.321450+00:00"
+            "updated_at": "2020-03-13T17:47:08.321450+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -251,7 +268,8 @@
             "contrib_type": "Brand/Retailer",
             "other_contrib_type": null,
             "created_at": "2020-03-08T13:41:46+00:00",
-            "updated_at": "2020-03-13T17:47:08.066004+00:00"
+            "updated_at": "2020-03-13T17:47:08.066004+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -265,7 +283,8 @@
             "contrib_type": "Service Provider",
             "other_contrib_type": null,
             "created_at": "2020-03-12T10:44:04+00:00",
-            "updated_at": "2020-03-13T17:47:08.345140+00:00"
+            "updated_at": "2020-03-13T17:47:08.345140+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -279,7 +298,8 @@
             "contrib_type": "Researcher / Academic",
             "other_contrib_type": null,
             "created_at": "2020-03-08T15:39:18+00:00",
-            "updated_at": "2020-03-13T17:47:08.981229+00:00"
+            "updated_at": "2020-03-13T17:47:08.981229+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -293,7 +313,8 @@
             "contrib_type": "Service Provider",
             "other_contrib_type": null,
             "created_at": "2020-03-08T22:25:49+00:00",
-            "updated_at": "2020-03-13T17:47:08.052932+00:00"
+            "updated_at": "2020-03-13T17:47:08.052932+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -307,7 +328,8 @@
             "contrib_type": "Factory / Facility",
             "other_contrib_type": null,
             "created_at": "2020-03-06T11:18:01+00:00",
-            "updated_at": "2020-03-13T17:47:08.697916+00:00"
+            "updated_at": "2020-03-13T17:47:08.697916+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -321,7 +343,8 @@
             "contrib_type": "Manufacturing Group / Supplier / Vendor",
             "other_contrib_type": null,
             "created_at": "2020-03-07T13:52:27+00:00",
-            "updated_at": "2020-03-13T17:47:08.358903+00:00"
+            "updated_at": "2020-03-13T17:47:08.358903+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -335,7 +358,8 @@
             "contrib_type": "Factory / Facility",
             "other_contrib_type": null,
             "created_at": "2020-03-12T03:20:32+00:00",
-            "updated_at": "2020-03-13T17:47:08.414803+00:00"
+            "updated_at": "2020-03-13T17:47:08.414803+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -349,7 +373,8 @@
             "contrib_type": "Service Provider",
             "other_contrib_type": null,
             "created_at": "2020-03-11T22:43:18+00:00",
-            "updated_at": "2020-03-13T17:47:08.603986+00:00"
+            "updated_at": "2020-03-13T17:47:08.603986+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -363,7 +388,8 @@
             "contrib_type": "Brand/Retailer",
             "other_contrib_type": null,
             "created_at": "2020-03-08T02:16:50+00:00",
-            "updated_at": "2020-03-13T17:47:08.088623+00:00"
+            "updated_at": "2020-03-13T17:47:08.088623+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -377,7 +403,8 @@
             "contrib_type": "Researcher / Academic",
             "other_contrib_type": null,
             "created_at": "2020-03-09T16:02:13+00:00",
-            "updated_at": "2020-03-13T17:47:08.281395+00:00"
+            "updated_at": "2020-03-13T17:47:08.281395+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -391,7 +418,8 @@
             "contrib_type": "Factory / Facility",
             "other_contrib_type": null,
             "created_at": "2020-03-07T12:08:56+00:00",
-            "updated_at": "2020-03-13T17:47:08.156909+00:00"
+            "updated_at": "2020-03-13T17:47:08.156909+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -405,7 +433,8 @@
             "contrib_type": "Civil Society Organization",
             "other_contrib_type": null,
             "created_at": "2020-03-10T00:46:52+00:00",
-            "updated_at": "2020-03-13T17:47:08.909589+00:00"
+            "updated_at": "2020-03-13T17:47:08.909589+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -419,7 +448,8 @@
             "contrib_type": "Service Provider",
             "other_contrib_type": null,
             "created_at": "2020-03-10T20:29:54+00:00",
-            "updated_at": "2020-03-13T17:47:08.361567+00:00"
+            "updated_at": "2020-03-13T17:47:08.361567+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -433,7 +463,8 @@
             "contrib_type": "Multi Stakeholder Initiative",
             "other_contrib_type": null,
             "created_at": "2020-03-05T07:23:26+00:00",
-            "updated_at": "2020-03-13T17:47:08.538751+00:00"
+            "updated_at": "2020-03-13T17:47:08.538751+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -447,7 +478,8 @@
             "contrib_type": "Union",
             "other_contrib_type": null,
             "created_at": "2020-03-10T06:46:12+00:00",
-            "updated_at": "2020-03-13T17:47:08.590143+00:00"
+            "updated_at": "2020-03-13T17:47:08.590143+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -461,7 +493,8 @@
             "contrib_type": "Factory / Facility",
             "other_contrib_type": null,
             "created_at": "2020-03-05T17:20:14+00:00",
-            "updated_at": "2020-03-13T17:47:08.358237+00:00"
+            "updated_at": "2020-03-13T17:47:08.358237+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -475,7 +508,8 @@
             "contrib_type": "Union",
             "other_contrib_type": null,
             "created_at": "2020-03-11T17:44:08+00:00",
-            "updated_at": "2020-03-13T17:47:08.259904+00:00"
+            "updated_at": "2020-03-13T17:47:08.259904+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -489,7 +523,8 @@
             "contrib_type": "Manufacturing Group / Supplier / Vendor",
             "other_contrib_type": null,
             "created_at": "2020-03-06T04:43:12+00:00",
-            "updated_at": "2020-03-13T17:47:08.554256+00:00"
+            "updated_at": "2020-03-13T17:47:08.554256+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -503,7 +538,8 @@
             "contrib_type": "Civil Society Organization",
             "other_contrib_type": null,
             "created_at": "2020-03-12T08:29:44+00:00",
-            "updated_at": "2020-03-13T17:47:08.455299+00:00"
+            "updated_at": "2020-03-13T17:47:08.455299+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -517,7 +553,8 @@
             "contrib_type": "Union",
             "other_contrib_type": null,
             "created_at": "2020-03-10T00:03:32+00:00",
-            "updated_at": "2020-03-13T17:47:08.883114+00:00"
+            "updated_at": "2020-03-13T17:47:08.883114+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -531,7 +568,8 @@
             "contrib_type": "Manufacturing Group / Supplier / Vendor",
             "other_contrib_type": null,
             "created_at": "2020-03-05T01:11:01+00:00",
-            "updated_at": "2020-03-13T17:47:08.924213+00:00"
+            "updated_at": "2020-03-13T17:47:08.924213+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -545,7 +583,8 @@
             "contrib_type": "Factory / Facility",
             "other_contrib_type": null,
             "created_at": "2020-03-09T00:16:58+00:00",
-            "updated_at": "2020-03-13T17:47:08.799658+00:00"
+            "updated_at": "2020-03-13T17:47:08.799658+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -559,7 +598,8 @@
             "contrib_type": "Researcher / Academic",
             "other_contrib_type": null,
             "created_at": "2020-03-06T20:39:50+00:00",
-            "updated_at": "2020-03-13T17:47:08.860265+00:00"
+            "updated_at": "2020-03-13T17:47:08.860265+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -573,7 +613,8 @@
             "contrib_type": "Researcher / Academic",
             "other_contrib_type": null,
             "created_at": "2020-03-05T11:34:30+00:00",
-            "updated_at": "2020-03-13T17:47:08.279711+00:00"
+            "updated_at": "2020-03-13T17:47:08.279711+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -587,7 +628,8 @@
             "contrib_type": "Researcher / Academic",
             "other_contrib_type": null,
             "created_at": "2020-03-06T01:29:28+00:00",
-            "updated_at": "2020-03-13T17:47:08.327317+00:00"
+            "updated_at": "2020-03-13T17:47:08.327317+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -601,7 +643,8 @@
             "contrib_type": "Service Provider",
             "other_contrib_type": null,
             "created_at": "2020-03-04T20:08:55+00:00",
-            "updated_at": "2020-03-13T17:47:08.425619+00:00"
+            "updated_at": "2020-03-13T17:47:08.425619+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -615,7 +658,8 @@
             "contrib_type": "Brand/Retailer",
             "other_contrib_type": null,
             "created_at": "2020-03-08T04:51:26+00:00",
-            "updated_at": "2020-03-13T17:47:08.841805+00:00"
+            "updated_at": "2020-03-13T17:47:08.841805+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -629,7 +673,8 @@
             "contrib_type": "Service Provider",
             "other_contrib_type": null,
             "created_at": "2020-03-09T00:13:14+00:00",
-            "updated_at": "2020-03-13T17:47:08.227842+00:00"
+            "updated_at": "2020-03-13T17:47:08.227842+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -643,7 +688,8 @@
             "contrib_type": "Service Provider",
             "other_contrib_type": null,
             "created_at": "2020-03-10T16:13:51+00:00",
-            "updated_at": "2020-03-13T17:47:08.752770+00:00"
+            "updated_at": "2020-03-13T17:47:08.752770+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -657,7 +703,8 @@
             "contrib_type": "Researcher / Academic",
             "other_contrib_type": null,
             "created_at": "2020-03-09T18:44:33+00:00",
-            "updated_at": "2020-03-13T17:47:08.687950+00:00"
+            "updated_at": "2020-03-13T17:47:08.687950+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -671,7 +718,8 @@
             "contrib_type": "Union",
             "other_contrib_type": null,
             "created_at": "2020-03-13T09:08:37+00:00",
-            "updated_at": "2020-03-13T17:47:08.503443+00:00"
+            "updated_at": "2020-03-13T17:47:08.503443+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -685,7 +733,8 @@
             "contrib_type": "Union",
             "other_contrib_type": null,
             "created_at": "2020-03-10T23:05:08+00:00",
-            "updated_at": "2020-03-13T17:47:08.690951+00:00"
+            "updated_at": "2020-03-13T17:47:08.690951+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -699,7 +748,8 @@
             "contrib_type": "Researcher / Academic",
             "other_contrib_type": null,
             "created_at": "2020-03-13T07:22:20+00:00",
-            "updated_at": "2020-03-13T17:47:08.036744+00:00"
+            "updated_at": "2020-03-13T17:47:08.036744+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -713,7 +763,8 @@
             "contrib_type": "Service Provider",
             "other_contrib_type": null,
             "created_at": "2020-03-08T08:52:43+00:00",
-            "updated_at": "2020-03-13T17:47:08.776690+00:00"
+            "updated_at": "2020-03-13T17:47:08.776690+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -727,7 +778,8 @@
             "contrib_type": "Manufacturing Group / Supplier / Vendor",
             "other_contrib_type": null,
             "created_at": "2020-03-09T20:17:50+00:00",
-            "updated_at": "2020-03-13T17:47:08.458804+00:00"
+            "updated_at": "2020-03-13T17:47:08.458804+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -741,7 +793,8 @@
             "contrib_type": "Service Provider",
             "other_contrib_type": null,
             "created_at": "2020-03-09T13:41:27+00:00",
-            "updated_at": "2020-03-13T17:47:08.847205+00:00"
+            "updated_at": "2020-03-13T17:47:08.847205+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -755,7 +808,8 @@
             "contrib_type": "Factory / Facility",
             "other_contrib_type": null,
             "created_at": "2020-03-06T10:53:20+00:00",
-            "updated_at": "2020-03-13T17:47:08.210449+00:00"
+            "updated_at": "2020-03-13T17:47:08.210449+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -769,7 +823,8 @@
             "contrib_type": "Union",
             "other_contrib_type": null,
             "created_at": "2020-03-08T14:06:29+00:00",
-            "updated_at": "2020-03-13T17:47:08.186011+00:00"
+            "updated_at": "2020-03-13T17:47:08.186011+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -783,7 +838,8 @@
             "contrib_type": "Multi Stakeholder Initiative",
             "other_contrib_type": null,
             "created_at": "2020-03-13T02:56:50+00:00",
-            "updated_at": "2020-03-13T17:47:08.430059+00:00"
+            "updated_at": "2020-03-13T17:47:08.430059+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -797,7 +853,8 @@
             "contrib_type": "Factory / Facility",
             "other_contrib_type": null,
             "created_at": "2020-03-13T06:13:18+00:00",
-            "updated_at": "2020-03-13T17:47:08.448925+00:00"
+            "updated_at": "2020-03-13T17:47:08.448925+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -811,7 +868,8 @@
             "contrib_type": "Civil Society Organization",
             "other_contrib_type": null,
             "created_at": "2020-03-09T17:55:17+00:00",
-            "updated_at": "2020-03-13T17:47:08.534106+00:00"
+            "updated_at": "2020-03-13T17:47:08.534106+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -825,7 +883,8 @@
             "contrib_type": "Civil Society Organization",
             "other_contrib_type": null,
             "created_at": "2020-03-08T07:16:24+00:00",
-            "updated_at": "2020-03-13T17:47:08.846720+00:00"
+            "updated_at": "2020-03-13T17:47:08.846720+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -839,7 +898,8 @@
             "contrib_type": "Factory / Facility",
             "other_contrib_type": null,
             "created_at": "2020-03-07T19:50:46+00:00",
-            "updated_at": "2020-03-13T17:47:08.602741+00:00"
+            "updated_at": "2020-03-13T17:47:08.602741+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -853,7 +913,8 @@
             "contrib_type": "Union",
             "other_contrib_type": null,
             "created_at": "2020-03-12T18:57:49+00:00",
-            "updated_at": "2020-03-13T17:47:08.882100+00:00"
+            "updated_at": "2020-03-13T17:47:08.882100+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -867,7 +928,8 @@
             "contrib_type": "Factory / Facility",
             "other_contrib_type": null,
             "created_at": "2020-03-13T13:30:31+00:00",
-            "updated_at": "2020-03-13T17:47:08.905296+00:00"
+            "updated_at": "2020-03-13T17:47:08.905296+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -881,7 +943,8 @@
             "contrib_type": "Brand/Retailer",
             "other_contrib_type": null,
             "created_at": "2020-03-05T03:16:59+00:00",
-            "updated_at": "2020-03-13T17:47:08.785745+00:00"
+            "updated_at": "2020-03-13T17:47:08.785745+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -895,7 +958,8 @@
             "contrib_type": "Manufacturing Group / Supplier / Vendor",
             "other_contrib_type": null,
             "created_at": "2020-03-09T03:41:12+00:00",
-            "updated_at": "2020-03-13T17:47:08.931215+00:00"
+            "updated_at": "2020-03-13T17:47:08.931215+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -909,7 +973,8 @@
             "contrib_type": "Auditor",
             "other_contrib_type": null,
             "created_at": "2020-03-09T08:06:50+00:00",
-            "updated_at": "2020-03-13T17:47:08.372069+00:00"
+            "updated_at": "2020-03-13T17:47:08.372069+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -923,7 +988,8 @@
             "contrib_type": "Brand/Retailer",
             "other_contrib_type": null,
             "created_at": "2020-03-05T04:54:38+00:00",
-            "updated_at": "2020-03-13T17:47:08.823232+00:00"
+            "updated_at": "2020-03-13T17:47:08.823232+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -937,7 +1003,8 @@
             "contrib_type": "Researcher / Academic",
             "other_contrib_type": null,
             "created_at": "2020-03-12T08:05:18+00:00",
-            "updated_at": "2020-03-13T17:47:08.450923+00:00"
+            "updated_at": "2020-03-13T17:47:08.450923+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -951,7 +1018,8 @@
             "contrib_type": "Union",
             "other_contrib_type": null,
             "created_at": "2020-03-13T05:33:06+00:00",
-            "updated_at": "2020-03-13T17:47:08.347132+00:00"
+            "updated_at": "2020-03-13T17:47:08.347132+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -965,7 +1033,8 @@
             "contrib_type": "Researcher / Academic",
             "other_contrib_type": null,
             "created_at": "2020-03-05T22:46:27+00:00",
-            "updated_at": "2020-03-13T17:47:08.296225+00:00"
+            "updated_at": "2020-03-13T17:47:08.296225+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -979,7 +1048,8 @@
             "contrib_type": "Union",
             "other_contrib_type": null,
             "created_at": "2020-03-06T23:01:01+00:00",
-            "updated_at": "2020-03-13T17:47:08.443571+00:00"
+            "updated_at": "2020-03-13T17:47:08.443571+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -993,7 +1063,8 @@
             "contrib_type": "Union",
             "other_contrib_type": null,
             "created_at": "2020-03-06T18:05:38+00:00",
-            "updated_at": "2020-03-13T17:47:08.939568+00:00"
+            "updated_at": "2020-03-13T17:47:08.939568+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1007,7 +1078,8 @@
             "contrib_type": "Auditor",
             "other_contrib_type": null,
             "created_at": "2020-03-05T07:39:46+00:00",
-            "updated_at": "2020-03-13T17:47:08.067499+00:00"
+            "updated_at": "2020-03-13T17:47:08.067499+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1021,7 +1093,8 @@
             "contrib_type": "Multi Stakeholder Initiative",
             "other_contrib_type": null,
             "created_at": "2020-03-11T10:46:00+00:00",
-            "updated_at": "2020-03-13T17:47:08.172283+00:00"
+            "updated_at": "2020-03-13T17:47:08.172283+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1035,7 +1108,8 @@
             "contrib_type": "Researcher / Academic",
             "other_contrib_type": null,
             "created_at": "2020-03-11T10:36:29+00:00",
-            "updated_at": "2020-03-13T17:47:08.736899+00:00"
+            "updated_at": "2020-03-13T17:47:08.736899+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1049,7 +1123,8 @@
             "contrib_type": "Manufacturing Group / Supplier / Vendor",
             "other_contrib_type": null,
             "created_at": "2020-03-09T18:06:40+00:00",
-            "updated_at": "2020-03-13T17:47:08.574940+00:00"
+            "updated_at": "2020-03-13T17:47:08.574940+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1063,7 +1138,8 @@
             "contrib_type": "Union",
             "other_contrib_type": null,
             "created_at": "2020-03-12T23:50:41+00:00",
-            "updated_at": "2020-03-13T17:47:08.563170+00:00"
+            "updated_at": "2020-03-13T17:47:08.563170+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1077,7 +1153,8 @@
             "contrib_type": "Civil Society Organization",
             "other_contrib_type": null,
             "created_at": "2020-03-06T20:26:04+00:00",
-            "updated_at": "2020-03-13T17:47:08.424001+00:00"
+            "updated_at": "2020-03-13T17:47:08.424001+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1091,7 +1168,8 @@
             "contrib_type": "Multi Stakeholder Initiative",
             "other_contrib_type": null,
             "created_at": "2020-03-13T08:05:37+00:00",
-            "updated_at": "2020-03-13T17:47:08.824355+00:00"
+            "updated_at": "2020-03-13T17:47:08.824355+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1105,7 +1183,8 @@
             "contrib_type": "Service Provider",
             "other_contrib_type": null,
             "created_at": "2020-03-06T08:50:32+00:00",
-            "updated_at": "2020-03-13T17:47:08.620583+00:00"
+            "updated_at": "2020-03-13T17:47:08.620583+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1119,7 +1198,8 @@
             "contrib_type": "Factory / Facility",
             "other_contrib_type": null,
             "created_at": "2020-03-06T06:55:22+00:00",
-            "updated_at": "2020-03-13T17:47:08.320946+00:00"
+            "updated_at": "2020-03-13T17:47:08.320946+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1133,7 +1213,8 @@
             "contrib_type": "Auditor",
             "other_contrib_type": null,
             "created_at": "2020-03-12T06:33:31+00:00",
-            "updated_at": "2020-03-13T17:47:08.521030+00:00"
+            "updated_at": "2020-03-13T17:47:08.521030+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1147,7 +1228,8 @@
             "contrib_type": "Service Provider",
             "other_contrib_type": null,
             "created_at": "2020-03-05T02:05:58+00:00",
-            "updated_at": "2020-03-13T17:47:08.583357+00:00"
+            "updated_at": "2020-03-13T17:47:08.583357+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1161,7 +1243,8 @@
             "contrib_type": "Manufacturing Group / Supplier / Vendor",
             "other_contrib_type": null,
             "created_at": "2020-03-10T01:55:51+00:00",
-            "updated_at": "2020-03-13T17:47:08.426563+00:00"
+            "updated_at": "2020-03-13T17:47:08.426563+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1175,7 +1258,8 @@
             "contrib_type": "Manufacturing Group / Supplier / Vendor",
             "other_contrib_type": null,
             "created_at": "2020-03-08T15:21:25+00:00",
-            "updated_at": "2020-03-13T17:47:08.486376+00:00"
+            "updated_at": "2020-03-13T17:47:08.486376+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1189,7 +1273,8 @@
             "contrib_type": "Auditor",
             "other_contrib_type": null,
             "created_at": "2020-03-13T13:44:56+00:00",
-            "updated_at": "2020-03-13T17:47:08.473587+00:00"
+            "updated_at": "2020-03-13T17:47:08.473587+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1203,7 +1288,8 @@
             "contrib_type": "Multi Stakeholder Initiative",
             "other_contrib_type": null,
             "created_at": "2020-03-06T03:07:23+00:00",
-            "updated_at": "2020-03-13T17:47:08.631812+00:00"
+            "updated_at": "2020-03-13T17:47:08.631812+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1217,7 +1303,8 @@
             "contrib_type": "Service Provider",
             "other_contrib_type": null,
             "created_at": "2020-03-11T00:44:13+00:00",
-            "updated_at": "2020-03-13T17:47:08.899999+00:00"
+            "updated_at": "2020-03-13T17:47:08.899999+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1231,7 +1318,8 @@
             "contrib_type": "Brand/Retailer",
             "other_contrib_type": null,
             "created_at": "2020-03-05T11:43:52+00:00",
-            "updated_at": "2020-03-13T17:47:08.922553+00:00"
+            "updated_at": "2020-03-13T17:47:08.922553+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1245,7 +1333,8 @@
             "contrib_type": "Brand/Retailer",
             "other_contrib_type": null,
             "created_at": "2020-03-09T20:35:35+00:00",
-            "updated_at": "2020-03-13T17:47:08.181649+00:00"
+            "updated_at": "2020-03-13T17:47:08.181649+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1259,7 +1348,8 @@
             "contrib_type": "Brand/Retailer",
             "other_contrib_type": null,
             "created_at": "2020-03-11T12:21:26+00:00",
-            "updated_at": "2020-03-13T17:47:08.313215+00:00"
+            "updated_at": "2020-03-13T17:47:08.313215+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1273,7 +1363,8 @@
             "contrib_type": "Union",
             "other_contrib_type": null,
             "created_at": "2020-03-08T03:38:46+00:00",
-            "updated_at": "2020-03-13T17:47:08.056164+00:00"
+            "updated_at": "2020-03-13T17:47:08.056164+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1287,7 +1378,8 @@
             "contrib_type": "Brand/Retailer",
             "other_contrib_type": null,
             "created_at": "2020-03-12T15:06:42+00:00",
-            "updated_at": "2020-03-13T17:47:08.126531+00:00"
+            "updated_at": "2020-03-13T17:47:08.126531+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1301,7 +1393,8 @@
             "contrib_type": "Manufacturing Group / Supplier / Vendor",
             "other_contrib_type": null,
             "created_at": "2020-03-07T01:40:12+00:00",
-            "updated_at": "2020-03-13T17:47:08.651509+00:00"
+            "updated_at": "2020-03-13T17:47:08.651509+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1315,7 +1408,8 @@
             "contrib_type": "Factory / Facility",
             "other_contrib_type": null,
             "created_at": "2020-03-10T18:48:13+00:00",
-            "updated_at": "2020-03-13T17:47:08.953629+00:00"
+            "updated_at": "2020-03-13T17:47:08.953629+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1329,7 +1423,8 @@
             "contrib_type": "Service Provider",
             "other_contrib_type": null,
             "created_at": "2020-03-08T09:34:46+00:00",
-            "updated_at": "2020-03-13T17:47:08.296410+00:00"
+            "updated_at": "2020-03-13T17:47:08.296410+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1343,7 +1438,8 @@
             "contrib_type": "Service Provider",
             "other_contrib_type": null,
             "created_at": "2020-03-06T13:28:07+00:00",
-            "updated_at": "2020-03-13T17:47:08.386359+00:00"
+            "updated_at": "2020-03-13T17:47:08.386359+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1357,7 +1453,8 @@
             "contrib_type": "Service Provider",
             "other_contrib_type": null,
             "created_at": "2020-03-13T07:24:18+00:00",
-            "updated_at": "2020-03-13T17:47:08.559679+00:00"
+            "updated_at": "2020-03-13T17:47:08.559679+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1371,7 +1468,8 @@
             "contrib_type": "Manufacturing Group / Supplier / Vendor",
             "other_contrib_type": null,
             "created_at": "2020-03-10T16:31:53+00:00",
-            "updated_at": "2020-03-13T17:47:08.261903+00:00"
+            "updated_at": "2020-03-13T17:47:08.261903+00:00",
+            "origin_source": "os_hub"
         }
     }
 ]

--- a/src/django/api/fixtures/facilities_index.json
+++ b/src/django/api/fixtures/facilities_index.json
@@ -8,7 +8,11 @@
             "country_code": "US",
             "location": "POINT (0.0 0.0)",
             "contributors_count": 3,
-            "contributors_id": [1, 2, 3],
+            "contributors_id": [
+                1,
+                2,
+                3
+            ],
             "approved_claim_ids": [],
             "is_closed": false,
             "has_inexact_coordinates": false,
@@ -40,21 +44,37 @@
                     "should_display_associations": true
                 }
             ],
-            "sector": ["Test sector"],
+            "sector": [
+                "Test sector"
+            ],
             "lists": [],
             "custom_text": [],
-            "number_of_workers": ["Less than 1000"],
-            "facility_type": ["First Facility Type"],
-            "processing_type": ["Processing Type"],
-            "product_type": ["Product Type"],
-            "parent_company_name": ["Parent Company Name"],
+            "number_of_workers": [
+                "Less than 1000"
+            ],
+            "facility_type": [
+                "First Facility Type"
+            ],
+            "processing_type": [
+                "Processing Type"
+            ],
+            "product_type": [
+                "Product Type"
+            ],
+            "parent_company_name": [
+                "Parent Company Name"
+            ],
             "native_language_name": [],
             "parent_company_id": [],
-            "facility_names": ["Test Facility"],
+            "facility_names": [
+                "Test Facility"
+            ],
             "facility_list_items": [],
             "facility_locations": [],
             "approved_claim": null,
-            "facility_addresses": ["First Facility Address"],
+            "facility_addresses": [
+                "First Facility Address"
+            ],
             "claim_info": [],
             "custom_field_info": [
                 {
@@ -68,7 +88,9 @@
                 {
                     "id": 101,
                     "value": {
-                        "raw_values": ["Product Type Service Provider A"]
+                        "raw_values": [
+                            "Product Type Service Provider A"
+                        ]
                     },
                     "field_name": "product_type",
                     "contributor": {
@@ -128,7 +150,10 @@
                 },
                 {
                     "id": 104,
-                    "value": { "max": 1, "min": 1 },
+                    "value": {
+                        "max": 1,
+                        "min": 1
+                    },
                     "field_name": "number_of_workers",
                     "contributor": {
                         "id": 1,
@@ -149,7 +174,11 @@
                 },
                 {
                     "id": 106,
-                    "value": { "raw_values": ["Product Type Factory A"] },
+                    "value": {
+                        "raw_values": [
+                            "Product Type Factory A"
+                        ]
+                    },
                     "field_name": "product_type",
                     "contributor": {
                         "id": 2,
@@ -196,7 +225,10 @@
                 },
                 {
                     "id": 109,
-                    "value": { "max": 500, "min": 101 },
+                    "value": {
+                        "max": 500,
+                        "min": 101
+                    },
                     "field_name": "number_of_workers",
                     "contributor": {
                         "id": 2,
@@ -217,7 +249,6 @@
                 }
             ],
             "created_from_info": {
-                
                 "created_at": "2022-05-18T07:45:25+00:00"
             },
             "activity_reports_info": [],
@@ -225,7 +256,8 @@
             "claim_sectors": [],
             "created_at": "2023-07-25T11:23:57.019Z",
             "updated_at": "2023-11-04T16:07:57.887Z",
-            "custom_text_search": ""
+            "custom_text_search": "",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -237,8 +269,14 @@
             "country_code": "IN",
             "location": "POINT (0.0 0.0)",
             "contributors_count": 2,
-            "contributors_id": [1, 2, 3],
-            "approved_claim_ids": [11],
+            "contributors_id": [
+                1,
+                2,
+                3
+            ],
+            "approved_claim_ids": [
+                11
+            ],
             "is_closed": false,
             "has_inexact_coordinates": false,
             "contrib_types": [
@@ -269,34 +307,54 @@
                     "should_display_associations": true
                 }
             ],
-            "sector": ["Test sector"],
+            "sector": [
+                "Test sector"
+            ],
             "lists": [],
             "custom_text": [],
-            "number_of_workers": ["Less than 1000"],
-            "facility_type": ["Second Facility Type"],
-            "processing_type": ["Processing Type"],
-            "product_type": ["Product Type"],
-            "parent_company_name": ["Parent Company Name"],
+            "number_of_workers": [
+                "Less than 1000"
+            ],
+            "facility_type": [
+                "Second Facility Type"
+            ],
+            "processing_type": [
+                "Processing Type"
+            ],
+            "product_type": [
+                "Product Type"
+            ],
+            "parent_company_name": [
+                "Parent Company Name"
+            ],
             "native_language_name": [],
             "parent_company_id": [],
-            "facility_names": ["Test Facility"],
+            "facility_names": [
+                "Test Facility"
+            ],
             "facility_list_items": [],
             "facility_locations": [],
             "approved_claim": {
                 "id": 11,
                 "contributor_id": 2,
-                "contributor": { "name": "Factory A" },
+                "contributor": {
+                    "name": "Factory A"
+                },
                 "facility_name_english": "Second Facility Name English",
                 "facility_id": "2"
             },
-            "facility_addresses": ["Second Facility Address"],
+            "facility_addresses": [
+                "Second Facility Address"
+            ],
             "claim_info": [],
             "custom_field_info": [],
             "extended_fields": [
                 {
                     "id": 111,
                     "value": {
-                        "raw_values": ["Product Type Service Provider A"]
+                        "raw_values": [
+                            "Product Type Service Provider A"
+                        ]
                     },
                     "field_name": "product_type",
                     "contributor": {
@@ -356,7 +414,10 @@
                 },
                 {
                     "id": 114,
-                    "value": { "max": 1, "min": 1 },
+                    "value": {
+                        "max": 1,
+                        "min": 1
+                    },
                     "field_name": "number_of_workers",
                     "contributor": {
                         "id": 1,
@@ -377,7 +438,11 @@
                 },
                 {
                     "id": 116,
-                    "value": { "raw_values": ["Product Type Factory A"] },
+                    "value": {
+                        "raw_values": [
+                            "Product Type Factory A"
+                        ]
+                    },
                     "field_name": "product_type",
                     "contributor": {
                         "id": 2,
@@ -424,7 +489,10 @@
                 },
                 {
                     "id": 119,
-                    "value": { "max": 500, "min": 101 },
+                    "value": {
+                        "max": 500,
+                        "min": 101
+                    },
                     "field_name": "number_of_workers",
                     "contributor": {
                         "id": 2,
@@ -452,7 +520,8 @@
             "claim_sectors": [],
             "created_at": "2023-07-25T11:23:57.019Z",
             "updated_at": "2023-11-04T16:07:57.887Z",
-            "custom_text_search": ""
+            "custom_text_search": "",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -464,11 +533,19 @@
             "country_code": "CN",
             "location": "POINT (0.0 0.0)",
             "contributors_count": 2,
-            "contributors_id": [1, 2],
-            "approved_claim_ids": [12],
+            "contributors_id": [
+                1,
+                2
+            ],
+            "approved_claim_ids": [
+                12
+            ],
             "is_closed": false,
             "has_inexact_coordinates": false,
-            "contrib_types": ["Service Provider", "Factory / Facility"],
+            "contrib_types": [
+                "Service Provider",
+                "Factory / Facility"
+            ],
             "contributors": [
                 {
                     "id": 1,
@@ -485,34 +562,54 @@
                     "should_display_associations": false
                 }
             ],
-            "sector": ["Test sector"],
+            "sector": [
+                "Test sector"
+            ],
             "lists": [],
             "custom_text": [],
-            "number_of_workers": ["Less than 1000"],
-            "facility_type": ["Third Facility Type"],
-            "processing_type": ["Processing Type"],
-            "product_type": ["Product Type"],
-            "parent_company_name": ["Parent Company Name"],
+            "number_of_workers": [
+                "Less than 1000"
+            ],
+            "facility_type": [
+                "Third Facility Type"
+            ],
+            "processing_type": [
+                "Processing Type"
+            ],
+            "product_type": [
+                "Product Type"
+            ],
+            "parent_company_name": [
+                "Parent Company Name"
+            ],
             "native_language_name": [],
             "parent_company_id": [],
-            "facility_names": ["Third Facility"],
+            "facility_names": [
+                "Third Facility"
+            ],
             "facility_list_items": [],
             "facility_locations": [],
             "approved_claim": {
                 "id": 12,
                 "contributor_id": 2,
-                "contributor": { "name": "Factory A" },
+                "contributor": {
+                    "name": "Factory A"
+                },
                 "facility_name_english": null,
                 "facility_id": "2"
             },
-            "facility_addresses": ["Third Facility Address"],
+            "facility_addresses": [
+                "Third Facility Address"
+            ],
             "claim_info": [],
             "custom_field_info": [],
             "extended_fields": [
                 {
                     "id": 121,
                     "value": {
-                        "raw_values": ["Product Type Service Provider A"]
+                        "raw_values": [
+                            "Product Type Service Provider A"
+                        ]
                     },
                     "field_name": "product_type",
                     "contributor": {
@@ -572,7 +669,10 @@
                 },
                 {
                     "id": 124,
-                    "value": { "max": 1, "min": 1 },
+                    "value": {
+                        "max": 1,
+                        "min": 1
+                    },
                     "field_name": "number_of_workers",
                     "contributor": {
                         "id": 1,
@@ -600,7 +700,8 @@
             "claim_sectors": [],
             "created_at": "2023-07-25T11:23:57.019Z",
             "updated_at": "2023-11-04T16:07:57.887Z",
-            "custom_text_search": ""
+            "custom_text_search": "",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -641,7 +742,8 @@
             "claim_sectors": [],
             "created_at": "2023-07-25T11:23:57.019Z",
             "updated_at": "2023-11-04T16:07:57.887Z",
-            "custom_text_search": ""
+            "custom_text_search": "",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -682,7 +784,8 @@
             "claim_sectors": [],
             "created_at": "2023-07-25T11:23:57.019Z",
             "updated_at": "2023-11-04T16:07:57.887Z",
-            "custom_text_search": ""
+            "custom_text_search": "",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -723,7 +826,8 @@
             "claim_sectors": [],
             "created_at": "2023-07-25T11:23:57.019Z",
             "updated_at": "2023-11-04T16:07:57.887Z",
-            "custom_text_search": ""
+            "custom_text_search": "",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -764,7 +868,8 @@
             "claim_sectors": [],
             "created_at": "2023-07-25T11:23:57.019Z",
             "updated_at": "2023-11-04T16:07:57.887Z",
-            "custom_text_search": ""
+            "custom_text_search": "",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -805,7 +910,8 @@
             "claim_sectors": [],
             "created_at": "2023-07-25T11:23:57.019Z",
             "updated_at": "2023-11-04T16:07:57.887Z",
-            "custom_text_search": ""
+            "custom_text_search": "",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -846,7 +952,8 @@
             "claim_sectors": [],
             "created_at": "2023-07-25T11:23:57.019Z",
             "updated_at": "2023-11-04T16:07:57.887Z",
-            "custom_text_search": ""
+            "custom_text_search": "",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -887,7 +994,8 @@
             "claim_sectors": [],
             "created_at": "2023-07-25T11:23:57.019Z",
             "updated_at": "2023-11-04T16:07:57.887Z",
-            "custom_text_search": ""
+            "custom_text_search": "",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -928,7 +1036,8 @@
             "claim_sectors": [],
             "created_at": "2023-07-25T11:23:57.019Z",
             "updated_at": "2023-11-04T16:07:57.887Z",
-            "custom_text_search": ""
+            "custom_text_search": "",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -969,7 +1078,8 @@
             "claim_sectors": [],
             "created_at": "2023-07-25T11:23:57.019Z",
             "updated_at": "2023-11-04T16:07:57.887Z",
-            "custom_text_search": ""
+            "custom_text_search": "",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1010,7 +1120,8 @@
             "claim_sectors": [],
             "created_at": "2023-07-25T11:23:57.019Z",
             "updated_at": "2023-11-04T16:07:57.887Z",
-            "custom_text_search": ""
+            "custom_text_search": "",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1051,7 +1162,8 @@
             "claim_sectors": [],
             "created_at": "2023-07-25T11:23:57.019Z",
             "updated_at": "2023-11-04T16:07:57.887Z",
-            "custom_text_search": ""
+            "custom_text_search": "",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1092,7 +1204,8 @@
             "claim_sectors": [],
             "created_at": "2023-07-25T11:23:57.019Z",
             "updated_at": "2023-11-04T16:07:57.887Z",
-            "custom_text_search": ""
+            "custom_text_search": "",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1133,7 +1246,8 @@
             "claim_sectors": [],
             "created_at": "2023-07-25T11:23:57.019Z",
             "updated_at": "2023-11-04T16:07:57.887Z",
-            "custom_text_search": ""
+            "custom_text_search": "",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1174,7 +1288,8 @@
             "claim_sectors": [],
             "created_at": "2023-07-25T11:23:57.019Z",
             "updated_at": "2023-11-04T16:07:57.887Z",
-            "custom_text_search": ""
+            "custom_text_search": "",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1215,7 +1330,8 @@
             "claim_sectors": [],
             "created_at": "2023-07-25T11:23:57.019Z",
             "updated_at": "2023-11-04T16:07:57.887Z",
-            "custom_text_search": ""
+            "custom_text_search": "",
+            "origin_source": "os_hub"
         }
     }
 ]

--- a/src/django/api/fixtures/facility_lists.json
+++ b/src/django/api/fixtures/facility_lists.json
@@ -9,7 +9,8 @@
             "header": "country,name,address,sector,lat,lng",
             "created_at": "2019-09-29T20:57:00+00:00",
             "updated_at": "2019-10-02T17:27:43.727479+00:00",
-            "file": "api/fixtures/list_files/Summer 2019 Compliance List.csv"
+            "file": "api/fixtures/list_files/Summer 2019 Compliance List.csv",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -22,7 +23,8 @@
             "header": "country,name,address,sector,lat,lng",
             "created_at": "2019-09-24T03:29:15+00:00",
             "updated_at": "2019-10-02T17:27:43.276293+00:00",
-            "file": "api/fixtures/list_files/Winter 2017 Affiliate List.csv"
+            "file": "api/fixtures/list_files/Winter 2017 Affiliate List.csv",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -35,7 +37,8 @@
             "header": "country,name,address,sector,lat,lng",
             "created_at": "2019-09-28T00:49:06+00:00",
             "updated_at": "2019-10-02T17:27:43.226583+00:00",
-            "file": "api/fixtures/list_files/Summer 2019 Affiliate List.csv"
+            "file": "api/fixtures/list_files/Summer 2019 Affiliate List.csv",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -48,7 +51,8 @@
             "header": "country,name,address,sector,lat,lng",
             "created_at": "2019-09-30T11:20:54+00:00",
             "updated_at": "2019-10-02T17:27:43.630615+00:00",
-            "file": "api/fixtures/list_files/Winter 2019 Compliance List.csv"
+            "file": "api/fixtures/list_files/Winter 2019 Compliance List.csv",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -61,7 +65,8 @@
             "header": "country,name,address,sector,lat,lng",
             "created_at": "2019-09-30T07:27:00+00:00",
             "updated_at": "2019-10-02T17:27:43.137400+00:00",
-            "file": "api/fixtures/list_files/Winter 2018 Apparel List.csv"
+            "file": "api/fixtures/list_files/Winter 2018 Apparel List.csv",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -74,7 +79,8 @@
             "header": "country,name,address,sector,lat,lng",
             "created_at": "2019-09-24T15:00:58+00:00",
             "updated_at": "2019-10-02T17:27:43.831567+00:00",
-            "file": "api/fixtures/list_files/Fall 2017 Compliance List.csv"
+            "file": "api/fixtures/list_files/Fall 2017 Compliance List.csv",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -87,7 +93,8 @@
             "header": "country,name,address,sector,lat,lng",
             "created_at": "2019-09-27T22:40:08+00:00",
             "updated_at": "2019-10-02T17:27:43.021715+00:00",
-            "file": "api/fixtures/list_files/Summer 2019 Apparel List.csv"
+            "file": "api/fixtures/list_files/Summer 2019 Apparel List.csv",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -100,7 +107,8 @@
             "header": "country,name,address,sector,lat,lng",
             "created_at": "2019-09-30T18:44:17+00:00",
             "updated_at": "2019-10-02T17:27:43.071523+00:00",
-            "file": "api/fixtures/list_files/Fall 2018 Compliance List.csv"
+            "file": "api/fixtures/list_files/Fall 2018 Compliance List.csv",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -113,7 +121,8 @@
             "header": "country,name,address,sector,lat,lng",
             "created_at": "2019-09-25T10:50:11+00:00",
             "updated_at": "2019-10-02T17:27:43.062248+00:00",
-            "file": "api/fixtures/list_files/Spring 2017 Apparel List.csv"
+            "file": "api/fixtures/list_files/Spring 2017 Apparel List.csv",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -126,7 +135,8 @@
             "header": "country,name,address,sector,lat,lng",
             "created_at": "2019-09-28T05:45:13+00:00",
             "updated_at": "2019-10-02T17:27:43.412908+00:00",
-            "file": "api/fixtures/list_files/Summer 2018 Affiliate List.csv"
+            "file": "api/fixtures/list_files/Summer 2018 Affiliate List.csv",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -139,7 +149,8 @@
             "header": "country,name,address,sector,lat,lng",
             "created_at": "2019-09-25T01:41:26+00:00",
             "updated_at": "2019-10-02T17:27:43.235561+00:00",
-            "file": "api/fixtures/list_files/Spring 2019 Compliance List.csv"
+            "file": "api/fixtures/list_files/Spring 2019 Compliance List.csv",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -152,7 +163,8 @@
             "header": "country,name,address,sector,lat,lng",
             "created_at": "2019-09-24T16:02:55+00:00",
             "updated_at": "2019-10-02T17:27:43.041712+00:00",
-            "file": "api/fixtures/list_files/Winter 2017 Compliance List.csv"
+            "file": "api/fixtures/list_files/Winter 2017 Compliance List.csv",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -165,7 +177,8 @@
             "header": "country,name,address,sector,lat,lng",
             "created_at": "2019-09-24T13:25:32+00:00",
             "updated_at": "2019-10-02T17:27:43.815348+00:00",
-            "file": "api/fixtures/list_files/Summer 2017 Compliance List.csv"
+            "file": "api/fixtures/list_files/Summer 2017 Compliance List.csv",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -178,7 +191,8 @@
             "header": "country,name,address,sector,lat,lng",
             "created_at": "2019-09-26T01:09:05+00:00",
             "updated_at": "2019-10-02T17:27:43.252937+00:00",
-            "file": "api/fixtures/list_files/Winter 2019 Compliance List V2.csv"
+            "file": "api/fixtures/list_files/Winter 2019 Compliance List V2.csv",
+            "origin_source": "os_hub"
         }
     }
 ]

--- a/src/django/api/fixtures/sources.json
+++ b/src/django/api/fixtures/sources.json
@@ -9,7 +9,8 @@
             "is_active": true,
             "is_public": true,
             "created_at": "2019-09-27T16:59:22+00:00",
-            "updated_at": "2019-10-02T17:09:42.166354+00:00"
+            "updated_at": "2019-10-02T17:09:42.166354+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -22,7 +23,8 @@
             "is_active": true,
             "is_public": true,
             "created_at": "2019-10-02T04:11:48+00:00",
-            "updated_at": "2019-10-02T17:09:42.833622+00:00"
+            "updated_at": "2019-10-02T17:09:42.833622+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -35,7 +37,8 @@
             "is_active": true,
             "is_public": true,
             "created_at": "2019-10-01T07:01:04+00:00",
-            "updated_at": "2019-10-02T17:09:42.598308+00:00"
+            "updated_at": "2019-10-02T17:09:42.598308+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -48,7 +51,8 @@
             "is_active": true,
             "is_public": true,
             "created_at": "2019-09-24T19:46:31+00:00",
-            "updated_at": "2019-10-02T17:09:42.260815+00:00"
+            "updated_at": "2019-10-02T17:09:42.260815+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -61,7 +65,8 @@
             "is_active": true,
             "is_public": true,
             "created_at": "2019-09-24T07:59:48+00:00",
-            "updated_at": "2019-10-02T17:09:42.712375+00:00"
+            "updated_at": "2019-10-02T17:09:42.712375+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -74,7 +79,8 @@
             "is_active": true,
             "is_public": true,
             "created_at": "2019-09-24T09:33:23+00:00",
-            "updated_at": "2019-10-02T17:09:42.076597+00:00"
+            "updated_at": "2019-10-02T17:09:42.076597+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -87,7 +93,8 @@
             "is_active": true,
             "is_public": true,
             "created_at": "2019-09-27T03:00:44+00:00",
-            "updated_at": "2019-10-02T17:09:42.373038+00:00"
+            "updated_at": "2019-10-02T17:09:42.373038+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -100,7 +107,8 @@
             "is_active": true,
             "is_public": true,
             "created_at": "2019-09-26T10:32:49+00:00",
-            "updated_at": "2019-10-02T17:09:42.328477+00:00"
+            "updated_at": "2019-10-02T17:09:42.328477+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -113,7 +121,8 @@
             "is_active": true,
             "is_public": true,
             "created_at": "2019-10-01T16:32:39+00:00",
-            "updated_at": "2019-10-02T17:09:42.119121+00:00"
+            "updated_at": "2019-10-02T17:09:42.119121+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -126,7 +135,8 @@
             "is_active": true,
             "is_public": true,
             "created_at": "2019-10-01T19:57:15+00:00",
-            "updated_at": "2019-10-02T17:09:42.481622+00:00"
+            "updated_at": "2019-10-02T17:09:42.481622+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -139,7 +149,8 @@
             "is_active": true,
             "is_public": true,
             "created_at": "2019-09-24T07:46:56+00:00",
-            "updated_at": "2019-10-02T17:09:42.633297+00:00"
+            "updated_at": "2019-10-02T17:09:42.633297+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -152,7 +163,8 @@
             "is_active": true,
             "is_public": true,
             "created_at": "2019-09-27T10:59:11+00:00",
-            "updated_at": "2019-10-02T17:09:42.395896+00:00"
+            "updated_at": "2019-10-02T17:09:42.395896+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -165,7 +177,8 @@
             "is_active": true,
             "is_public": true,
             "created_at": "2019-09-30T05:18:50+00:00",
-            "updated_at": "2019-10-02T17:09:42.617551+00:00"
+            "updated_at": "2019-10-02T17:09:42.617551+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -178,7 +191,8 @@
             "is_active": true,
             "is_public": true,
             "created_at": "2019-09-26T02:56:07+00:00",
-            "updated_at": "2019-10-02T17:09:42.464989+00:00"
+            "updated_at": "2019-10-02T17:09:42.464989+00:00",
+            "origin_source": "os_hub"
         }
     }
 ]

--- a/src/django/api/fixtures/users.json
+++ b/src/django/api/fixtures/users.json
@@ -10,7 +10,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-10T18:27:44+00:00",
-            "updated_at": "2019-03-14T22:02:35.472753+00:00"
+            "updated_at": "2019-03-14T22:02:35.472753+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -24,7 +25,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-11T10:13:18+00:00",
-            "updated_at": "2019-03-14T22:02:35.546892+00:00"
+            "updated_at": "2019-03-14T22:02:35.546892+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -38,7 +40,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-07T17:15:13+00:00",
-            "updated_at": "2019-03-14T22:02:35.749864+00:00"
+            "updated_at": "2019-03-14T22:02:35.749864+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -52,7 +55,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-14T02:15:46+00:00",
-            "updated_at": "2019-03-14T22:02:35.528093+00:00"
+            "updated_at": "2019-03-14T22:02:35.528093+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -66,7 +70,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-13T20:19:04+00:00",
-            "updated_at": "2019-03-14T22:02:35.478109+00:00"
+            "updated_at": "2019-03-14T22:02:35.478109+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -80,7 +85,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-07T13:04:08+00:00",
-            "updated_at": "2019-03-14T22:02:35.221160+00:00"
+            "updated_at": "2019-03-14T22:02:35.221160+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -94,7 +100,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-09T16:31:19+00:00",
-            "updated_at": "2019-03-14T22:02:35.856162+00:00"
+            "updated_at": "2019-03-14T22:02:35.856162+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -108,7 +115,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-11T05:08:51+00:00",
-            "updated_at": "2019-03-14T22:02:35.830364+00:00"
+            "updated_at": "2019-03-14T22:02:35.830364+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -122,7 +130,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-09T01:17:55+00:00",
-            "updated_at": "2019-03-14T22:02:35.003747+00:00"
+            "updated_at": "2019-03-14T22:02:35.003747+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -136,7 +145,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-11T16:50:30+00:00",
-            "updated_at": "2019-03-14T22:02:35.276197+00:00"
+            "updated_at": "2019-03-14T22:02:35.276197+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -150,7 +160,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-07T07:29:19+00:00",
-            "updated_at": "2019-03-14T22:02:35.270604+00:00"
+            "updated_at": "2019-03-14T22:02:35.270604+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -164,7 +175,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-14T06:18:07+00:00",
-            "updated_at": "2019-03-14T22:02:35.162247+00:00"
+            "updated_at": "2019-03-14T22:02:35.162247+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -178,7 +190,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-11T23:24:21+00:00",
-            "updated_at": "2019-03-14T22:02:35.721755+00:00"
+            "updated_at": "2019-03-14T22:02:35.721755+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -192,7 +205,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-06T12:14:51+00:00",
-            "updated_at": "2019-03-14T22:02:35.124487+00:00"
+            "updated_at": "2019-03-14T22:02:35.124487+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -206,7 +220,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-08T18:39:14+00:00",
-            "updated_at": "2019-03-14T22:02:35.598074+00:00"
+            "updated_at": "2019-03-14T22:02:35.598074+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -220,7 +235,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-09T03:09:29+00:00",
-            "updated_at": "2019-03-14T22:02:35.180458+00:00"
+            "updated_at": "2019-03-14T22:02:35.180458+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -234,7 +250,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-10T05:37:43+00:00",
-            "updated_at": "2019-03-14T22:02:35.090123+00:00"
+            "updated_at": "2019-03-14T22:02:35.090123+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -248,7 +265,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-05T23:43:00+00:00",
-            "updated_at": "2019-03-14T22:02:35.120305+00:00"
+            "updated_at": "2019-03-14T22:02:35.120305+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -262,7 +280,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-11T08:53:48+00:00",
-            "updated_at": "2019-03-14T22:02:35.311090+00:00"
+            "updated_at": "2019-03-14T22:02:35.311090+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -276,7 +295,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-12T06:26:39+00:00",
-            "updated_at": "2019-03-14T22:02:35.574183+00:00"
+            "updated_at": "2019-03-14T22:02:35.574183+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -290,7 +310,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-10T09:02:34+00:00",
-            "updated_at": "2019-03-14T22:02:35.004832+00:00"
+            "updated_at": "2019-03-14T22:02:35.004832+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -304,7 +325,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-06T03:12:58+00:00",
-            "updated_at": "2019-03-14T22:02:35.091611+00:00"
+            "updated_at": "2019-03-14T22:02:35.091611+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -318,7 +340,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-13T00:23:03+00:00",
-            "updated_at": "2019-03-14T22:02:35.537184+00:00"
+            "updated_at": "2019-03-14T22:02:35.537184+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -332,7 +355,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-09T08:39:37+00:00",
-            "updated_at": "2019-03-14T22:02:35.920944+00:00"
+            "updated_at": "2019-03-14T22:02:35.920944+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -346,7 +370,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-07T00:39:34+00:00",
-            "updated_at": "2019-03-14T22:02:35.503901+00:00"
+            "updated_at": "2019-03-14T22:02:35.503901+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -360,7 +385,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-09T11:29:57+00:00",
-            "updated_at": "2019-03-14T22:02:35.616453+00:00"
+            "updated_at": "2019-03-14T22:02:35.616453+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -374,7 +400,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-14T01:19:01+00:00",
-            "updated_at": "2019-03-14T22:02:35.989863+00:00"
+            "updated_at": "2019-03-14T22:02:35.989863+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -388,7 +415,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-14T21:24:20+00:00",
-            "updated_at": "2019-03-14T22:02:35.337384+00:00"
+            "updated_at": "2019-03-14T22:02:35.337384+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -402,7 +430,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-07T20:49:48+00:00",
-            "updated_at": "2019-03-14T22:02:35.335560+00:00"
+            "updated_at": "2019-03-14T22:02:35.335560+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -416,7 +445,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-14T00:04:42+00:00",
-            "updated_at": "2019-03-14T22:02:35.960763+00:00"
+            "updated_at": "2019-03-14T22:02:35.960763+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -430,7 +460,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-06T11:34:06+00:00",
-            "updated_at": "2019-03-14T22:02:35.087218+00:00"
+            "updated_at": "2019-03-14T22:02:35.087218+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -444,7 +475,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-07T23:29:12+00:00",
-            "updated_at": "2019-03-14T22:02:35.104149+00:00"
+            "updated_at": "2019-03-14T22:02:35.104149+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -458,7 +490,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-08T10:07:03+00:00",
-            "updated_at": "2019-03-14T22:02:35.018152+00:00"
+            "updated_at": "2019-03-14T22:02:35.018152+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -472,7 +505,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-13T22:01:45+00:00",
-            "updated_at": "2019-03-14T22:02:35.727704+00:00"
+            "updated_at": "2019-03-14T22:02:35.727704+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -486,7 +520,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-07T00:53:46+00:00",
-            "updated_at": "2019-03-14T22:02:35.537747+00:00"
+            "updated_at": "2019-03-14T22:02:35.537747+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -500,7 +535,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-07T10:09:56+00:00",
-            "updated_at": "2019-03-14T22:02:35.961825+00:00"
+            "updated_at": "2019-03-14T22:02:35.961825+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -514,7 +550,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-06T22:33:21+00:00",
-            "updated_at": "2019-03-14T22:02:35.635745+00:00"
+            "updated_at": "2019-03-14T22:02:35.635745+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -528,7 +565,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-08T22:01:57+00:00",
-            "updated_at": "2019-03-14T22:02:35.482853+00:00"
+            "updated_at": "2019-03-14T22:02:35.482853+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -542,7 +580,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-08T06:48:08+00:00",
-            "updated_at": "2019-03-14T22:02:35.652955+00:00"
+            "updated_at": "2019-03-14T22:02:35.652955+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -556,7 +595,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-06T11:55:35+00:00",
-            "updated_at": "2019-03-14T22:02:35.357592+00:00"
+            "updated_at": "2019-03-14T22:02:35.357592+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -570,7 +610,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-07T01:30:07+00:00",
-            "updated_at": "2019-03-14T22:02:35.506757+00:00"
+            "updated_at": "2019-03-14T22:02:35.506757+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -584,7 +625,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-13T11:59:01+00:00",
-            "updated_at": "2019-03-14T22:02:35.284769+00:00"
+            "updated_at": "2019-03-14T22:02:35.284769+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -598,7 +640,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-11T03:00:38+00:00",
-            "updated_at": "2019-03-14T22:02:35.838187+00:00"
+            "updated_at": "2019-03-14T22:02:35.838187+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -612,7 +655,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-14T18:11:19+00:00",
-            "updated_at": "2019-03-14T22:02:35.677210+00:00"
+            "updated_at": "2019-03-14T22:02:35.677210+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -626,7 +670,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-06T20:42:27+00:00",
-            "updated_at": "2019-03-14T22:02:35.259434+00:00"
+            "updated_at": "2019-03-14T22:02:35.259434+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -640,7 +685,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-08T18:07:24+00:00",
-            "updated_at": "2019-03-14T22:02:35.939383+00:00"
+            "updated_at": "2019-03-14T22:02:35.939383+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -654,7 +700,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-11T16:03:48+00:00",
-            "updated_at": "2019-03-14T22:02:35.437188+00:00"
+            "updated_at": "2019-03-14T22:02:35.437188+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -668,7 +715,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-08T11:56:00+00:00",
-            "updated_at": "2019-03-14T22:02:35.877002+00:00"
+            "updated_at": "2019-03-14T22:02:35.877002+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -682,7 +730,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-13T16:53:02+00:00",
-            "updated_at": "2019-03-14T22:02:35.698401+00:00"
+            "updated_at": "2019-03-14T22:02:35.698401+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -696,7 +745,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-13T02:06:47+00:00",
-            "updated_at": "2019-03-14T22:02:35.745715+00:00"
+            "updated_at": "2019-03-14T22:02:35.745715+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -710,7 +760,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-09T11:18:43+00:00",
-            "updated_at": "2019-03-14T22:02:35.363598+00:00"
+            "updated_at": "2019-03-14T22:02:35.363598+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -724,7 +775,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-13T05:46:50+00:00",
-            "updated_at": "2019-03-14T22:02:35.034730+00:00"
+            "updated_at": "2019-03-14T22:02:35.034730+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -738,7 +790,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-06T02:58:13+00:00",
-            "updated_at": "2019-03-14T22:02:35.564006+00:00"
+            "updated_at": "2019-03-14T22:02:35.564006+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -752,7 +805,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-09T15:56:20+00:00",
-            "updated_at": "2019-03-14T22:02:35.084707+00:00"
+            "updated_at": "2019-03-14T22:02:35.084707+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -766,7 +820,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-07T07:00:58+00:00",
-            "updated_at": "2019-03-14T22:02:35.051149+00:00"
+            "updated_at": "2019-03-14T22:02:35.051149+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -780,7 +835,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-07T13:49:21+00:00",
-            "updated_at": "2019-03-14T22:02:35.509027+00:00"
+            "updated_at": "2019-03-14T22:02:35.509027+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -794,7 +850,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-10T04:17:29+00:00",
-            "updated_at": "2019-03-14T22:02:35.392519+00:00"
+            "updated_at": "2019-03-14T22:02:35.392519+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -808,7 +865,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-10T15:57:22+00:00",
-            "updated_at": "2019-03-14T22:02:35.550612+00:00"
+            "updated_at": "2019-03-14T22:02:35.550612+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -822,7 +880,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-06T11:10:58+00:00",
-            "updated_at": "2019-03-14T22:02:35.624481+00:00"
+            "updated_at": "2019-03-14T22:02:35.624481+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -836,7 +895,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-12T02:21:46+00:00",
-            "updated_at": "2019-03-14T22:02:35.642362+00:00"
+            "updated_at": "2019-03-14T22:02:35.642362+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -850,7 +910,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-12T12:47:26+00:00",
-            "updated_at": "2019-03-14T22:02:35.768101+00:00"
+            "updated_at": "2019-03-14T22:02:35.768101+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -864,7 +925,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-11T01:07:28+00:00",
-            "updated_at": "2019-03-14T22:02:35.682809+00:00"
+            "updated_at": "2019-03-14T22:02:35.682809+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -878,7 +940,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-07T06:32:35+00:00",
-            "updated_at": "2019-03-14T22:02:35.853868+00:00"
+            "updated_at": "2019-03-14T22:02:35.853868+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -892,7 +955,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-08T00:25:52+00:00",
-            "updated_at": "2019-03-14T22:02:35.352113+00:00"
+            "updated_at": "2019-03-14T22:02:35.352113+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -906,7 +970,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-14T18:58:08+00:00",
-            "updated_at": "2019-03-14T22:02:35.315980+00:00"
+            "updated_at": "2019-03-14T22:02:35.315980+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -920,7 +985,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-09T15:46:26+00:00",
-            "updated_at": "2019-03-14T22:02:35.073273+00:00"
+            "updated_at": "2019-03-14T22:02:35.073273+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -934,7 +1000,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-11T08:41:06+00:00",
-            "updated_at": "2019-03-14T22:02:35.885655+00:00"
+            "updated_at": "2019-03-14T22:02:35.885655+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -948,7 +1015,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-11T18:25:25+00:00",
-            "updated_at": "2019-03-14T22:02:35.712603+00:00"
+            "updated_at": "2019-03-14T22:02:35.712603+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -962,7 +1030,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-12T20:54:26+00:00",
-            "updated_at": "2019-03-14T22:02:35.883089+00:00"
+            "updated_at": "2019-03-14T22:02:35.883089+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -976,7 +1045,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-10T16:07:18+00:00",
-            "updated_at": "2019-03-14T22:02:35.204174+00:00"
+            "updated_at": "2019-03-14T22:02:35.204174+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -990,7 +1060,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-06T08:10:44+00:00",
-            "updated_at": "2019-03-14T22:02:35.366545+00:00"
+            "updated_at": "2019-03-14T22:02:35.366545+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1004,7 +1075,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-09T01:37:02+00:00",
-            "updated_at": "2019-03-14T22:02:35.422381+00:00"
+            "updated_at": "2019-03-14T22:02:35.422381+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1018,7 +1090,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-10T20:55:11+00:00",
-            "updated_at": "2019-03-14T22:02:35.644160+00:00"
+            "updated_at": "2019-03-14T22:02:35.644160+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1032,7 +1105,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-06T23:41:27+00:00",
-            "updated_at": "2019-03-14T22:02:35.775853+00:00"
+            "updated_at": "2019-03-14T22:02:35.775853+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1046,7 +1120,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-06T14:47:28+00:00",
-            "updated_at": "2019-03-14T22:02:35.192950+00:00"
+            "updated_at": "2019-03-14T22:02:35.192950+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1060,7 +1135,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-12T01:15:57+00:00",
-            "updated_at": "2019-03-14T22:02:35.931571+00:00"
+            "updated_at": "2019-03-14T22:02:35.931571+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1074,7 +1150,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-08T19:40:36+00:00",
-            "updated_at": "2019-03-14T22:02:35.736438+00:00"
+            "updated_at": "2019-03-14T22:02:35.736438+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1088,7 +1165,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-08T05:22:26+00:00",
-            "updated_at": "2019-03-14T22:02:35.581196+00:00"
+            "updated_at": "2019-03-14T22:02:35.581196+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1102,7 +1180,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-14T09:06:43+00:00",
-            "updated_at": "2019-03-14T22:02:35.581205+00:00"
+            "updated_at": "2019-03-14T22:02:35.581205+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1116,7 +1195,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-14T03:49:08+00:00",
-            "updated_at": "2019-03-14T22:02:35.504316+00:00"
+            "updated_at": "2019-03-14T22:02:35.504316+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1130,7 +1210,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-14T04:09:27+00:00",
-            "updated_at": "2019-03-14T22:02:35.652343+00:00"
+            "updated_at": "2019-03-14T22:02:35.652343+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1144,7 +1225,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-07T11:38:20+00:00",
-            "updated_at": "2019-03-14T22:02:35.281631+00:00"
+            "updated_at": "2019-03-14T22:02:35.281631+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1158,7 +1240,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-09T17:14:01+00:00",
-            "updated_at": "2019-03-14T22:02:35.851850+00:00"
+            "updated_at": "2019-03-14T22:02:35.851850+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1172,7 +1255,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-10T02:01:06+00:00",
-            "updated_at": "2019-03-14T22:02:35.118079+00:00"
+            "updated_at": "2019-03-14T22:02:35.118079+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1186,7 +1270,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-08T02:14:09+00:00",
-            "updated_at": "2019-03-14T22:02:35.985123+00:00"
+            "updated_at": "2019-03-14T22:02:35.985123+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1200,7 +1285,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-10T14:46:02+00:00",
-            "updated_at": "2019-03-14T22:02:35.404134+00:00"
+            "updated_at": "2019-03-14T22:02:35.404134+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1214,7 +1300,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-14T19:25:47+00:00",
-            "updated_at": "2019-03-14T22:02:35.795526+00:00"
+            "updated_at": "2019-03-14T22:02:35.795526+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1228,7 +1315,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-11T19:20:26+00:00",
-            "updated_at": "2019-03-14T22:02:35.820884+00:00"
+            "updated_at": "2019-03-14T22:02:35.820884+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1242,7 +1330,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-11T19:55:25+00:00",
-            "updated_at": "2019-03-14T22:02:35.718536+00:00"
+            "updated_at": "2019-03-14T22:02:35.718536+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1256,7 +1345,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-09T21:16:43+00:00",
-            "updated_at": "2019-03-14T22:02:35.609652+00:00"
+            "updated_at": "2019-03-14T22:02:35.609652+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1270,7 +1360,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-10T13:10:44+00:00",
-            "updated_at": "2019-03-14T22:02:35.770443+00:00"
+            "updated_at": "2019-03-14T22:02:35.770443+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1284,7 +1375,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-07T14:35:11+00:00",
-            "updated_at": "2019-03-14T22:02:35.484928+00:00"
+            "updated_at": "2019-03-14T22:02:35.484928+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1298,7 +1390,8 @@
             "is_staff": false,
             "is_active": true,
             "created_at": "2019-03-08T15:55:38+00:00",
-            "updated_at": "2019-03-14T22:02:35.455055+00:00"
+            "updated_at": "2019-03-14T22:02:35.455055+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1312,7 +1405,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-11T19:34:06+00:00",
-            "updated_at": "2019-03-14T22:02:35.184525+00:00"
+            "updated_at": "2019-03-14T22:02:35.184525+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1326,7 +1420,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-09T10:29:12+00:00",
-            "updated_at": "2019-03-14T22:02:35.145157+00:00"
+            "updated_at": "2019-03-14T22:02:35.145157+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1340,7 +1435,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-11T13:16:18+00:00",
-            "updated_at": "2019-03-14T22:02:35.999410+00:00"
+            "updated_at": "2019-03-14T22:02:35.999410+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1354,7 +1450,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-09T10:33:57+00:00",
-            "updated_at": "2019-03-14T22:02:35.982834+00:00"
+            "updated_at": "2019-03-14T22:02:35.982834+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1368,7 +1465,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-07T01:51:33+00:00",
-            "updated_at": "2019-03-14T22:02:35.008011+00:00"
+            "updated_at": "2019-03-14T22:02:35.008011+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1382,7 +1480,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-12T16:22:57+00:00",
-            "updated_at": "2019-03-14T22:02:35.179389+00:00"
+            "updated_at": "2019-03-14T22:02:35.179389+00:00",
+            "origin_source": "os_hub"
         }
     },
     {
@@ -1396,7 +1495,8 @@
             "is_staff": true,
             "is_active": true,
             "created_at": "2019-03-14T13:48:26+00:00",
-            "updated_at": "2019-03-14T22:02:35.645478+00:00"
+            "updated_at": "2019-03-14T22:02:35.645478+00:00",
+            "origin_source": "os_hub"
         }
     }
 ]


### PR DESCRIPTION
[OSDEV-2019](https://opensupplyhub.atlassian.net/browse/OSDEV-2019) **OS Hub DB. Add source column to tables for tracking origin of records**

- Added origin_source field to fixtures data.
- Fixed issue with INSTANCE_SOURCE for Dedupe Hub if no environment variable is provided
- Updated terraform variables.

[OSDEV-2019]: https://opensupplyhub.atlassian.net/browse/OSDEV-2019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ