### PR TITLE
[OSDEV-2032] Fixed the incorrect indexing of the location type in the production locations OpenSearch index

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -26,12 +26,16 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Bugfix
 * Removed the unnecessary duplicate assignment of the `origin_source` field for `Contributor`, `ExtendedField`, `Facility`, `FacilityActivityReport`, `FacilityAlias`, `FacilityClaim`, `FacilityList`, `FacilityListItem`, `FacilityMatch`, `Source`, `FacilityLocation`, and `User` via the custom `default_origin_source` Django management command — and removed the command itself. The `origin_source` field will be set by Django fixtures when deploying the local environment via the `start_local_dev` script and during test runs, which include executing the `start_code_quality_dev` bash script. For models like `FacilityListItem`, `ExtendedField`, and others, it will also be set during list processing triggered by the `reset_database` custom Django management command in the `start_local_dev` and `start_code_quality_dev` bash scripts.
+* [OSDEV-2032](https://opensupplyhub.atlassian.net/browse/OSDEV-2032) - Fixed the incorrect indexing of the location type in the production locations OpenSearch index. Previously, it was incorrectly taking the processing type value as the location type — using the fourth item in the `matched_values` array instead of the third, which contains the location type. Also, updated the Logstash filters for both processing type and location type to return only unique values and write them to the production locations OpenSearch index.
 
 ### What's new
 * [OSDEV-2023](https://opensupplyhub.atlassian.net/browse/OSDEV-2023) - The `Recruitment Agency` has been added to facility type and processing type. So a user can filter production locations on the `/facilities` page, can add this type on the `/contribute/single-location/info/` and `/claimed/:id/` pages.
 
 ### Release instructions
-* *Provide release instructions here.*
+* Ensure that the following commands are included in the `post_deployment` command:
+    * `migrate`
+    * `reindex_database`
+* Run `[Release] Deploy` pipeline for the target environment with the flag `Clear the custom OpenSearch indexes and templates` set to true - to update the index mapping for the `production-locations` index after changing the Logstash filters for the `location_type` and `processing_type` fields.
 
 
 ## Release 2.7.0

--- a/src/logstash/scripts/production_locations/location_type.rb
+++ b/src/logstash/scripts/production_locations/location_type.rb
@@ -8,10 +8,68 @@ def filter(event)
   end
 
   # Extract processing types and remove null values.
-  values = location_type_value['matched_values'].map { |value| value[3] if value[3] != nil }.compact
+  values = location_type_value['matched_values'].map { |value| value[2] if value[2] != nil }.compact.uniq
 
   # Set the location_type field only if there are non-null values.
   event.set('location_type', values) if values.any?
 
   return [event]
+end
+
+test 'location_type filter with valid matched_values' do
+  in_event {
+    {
+      'location_type_value' => {
+        'matched_values' => [
+          ['a', 'b', 'value1'],
+          ['c', 'd', 'value2'],
+          ['e', 'f', 'value2'],
+          ['g', 'h', nil]
+        ]
+      }
+    }
+  }
+
+  expect('sets location_type with unique non-nil values') do |events|
+    values = events[0].get('location_type')
+    values.sort == ['value1', 'value2']
+  end
+end
+
+test 'location_type filter with only nil matched values' do
+  in_event {
+    {
+      'location_type_value' => {
+        'matched_values' => [
+          ['a', 'b', nil],
+          ['c', 'd', nil]
+        ]
+      }
+    }
+  }
+  expect('does not set location_type') do |events|
+    !events[0].to_hash.key?('location_type')
+  end
+end
+
+test 'location_type filter with missing matched_values key' do
+  in_event {
+    {
+      'location_type_value' => {}
+    }
+  }
+
+  expect('does not set location_type') do |events|
+    !events[0].to_hash.key?('location_type')
+  end
+end
+
+test 'location_type filter with missing location_type_value key' do
+  in_event {
+    {}
+  }
+
+  expect('does not set location_type') do |events|
+    !events[0].to_hash.key?('location_type')
+  end
 end

--- a/src/logstash/scripts/production_locations/processing_type.rb
+++ b/src/logstash/scripts/production_locations/processing_type.rb
@@ -41,8 +41,8 @@ test 'processing_type filter with only nil matched values' do
     {
       'processing_type_value' => {
         'matched_values' => [
-          ['a', 'b', nil],
-          ['c', 'd', nil]
+          ['a', 'b', 'c', nil],
+          ['d', 'e', 'f', nil]
         ]
       }
     }

--- a/src/logstash/scripts/production_locations/processing_type.rb
+++ b/src/logstash/scripts/production_locations/processing_type.rb
@@ -8,10 +8,68 @@ def filter(event)
   end
 
   # Extract processing types and remove null values.
-  values = processing_type_value['matched_values'].map { |value| value[3] if value[3] != nil }.compact
+  values = processing_type_value['matched_values'].map { |value| value[3] if value[3] != nil }.compact.uniq
 
   # Set the processing_type field only if there are non-null values.
   event.set('processing_type', values) if values.any?
 
   return [event]
+end 
+
+test 'processing_type filter with valid matched_values' do
+  in_event {
+    {
+      'processing_type_value' => {
+        'matched_values' => [
+          ['a', 'b', 'c', 'value1'],
+          ['d', 'e', 'f', 'value2'],
+          ['g', 'h', 'i', 'value1'],
+          ['j', 'k', 'l', nil]
+        ]
+      }
+    }
+  }
+
+  expect('sets processing_type with unique non-nil values') do |events|
+    values = events[0].get('processing_type')
+    values.sort == ['value1', 'value2']
+  end
+end
+
+test 'processing_type filter with only nil matched values' do
+  in_event {
+    {
+      'processing_type_value' => {
+        'matched_values' => [
+          ['a', 'b', nil],
+          ['c', 'd', nil]
+        ]
+      }
+    }
+  }
+  expect('does not set processing_type') do |events|
+    !events[0].to_hash.key?('processing_type')
+  end
+end
+
+test 'processing_type filter with missing matched_values key' do
+  in_event {
+    {
+      'processing_type_value' => {}
+    }
+  }
+
+  expect('does not set processing_type') do |events|
+    !events[0].to_hash.key?('processing_type')
+  end
+end
+
+test 'processing_type filter with missing processing_type_value key' do
+  in_event {
+    {}
+  }
+
+  expect('does not set processing_type') do |events|
+    !events[0].to_hash.key?('processing_type')
+  end
 end


### PR DESCRIPTION
[[OSDEV-2032](https://opensupplyhub.atlassian.net/browse/OSDEV-2038)]
Fixed the incorrect indexing of the location type in the production locations OpenSearch index. Previously, it was incorrectly taking the processing type value as the location type — using the fourth item in the `matched_values` array instead of the third, which contains the location type. Also, updated the Logstash filters for both processing type and location type to return only unique values and write them to the production locations OpenSearch index.

[OSDEV-2032]: https://opensupplyhub.atlassian.net/browse/OSDEV-2032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ