### PR TITLE
[OSDEV-2055] Data Download Limits: Embedded Map download limits check

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -47,6 +47,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-1865](https://opensupplyhub.atlassian.net/browse/OSDEV-1865) - 5000 facility records for download annually have been added for a registered free user.
 * [OSDEV-1879](https://opensupplyhub.atlassian.net/browse/OSDEV-1879) - Added Stripe-powered upgrade workflow allowing registered users to purchase additional 5,000 record download packages.
 * [OSDEV-2023](https://opensupplyhub.atlassian.net/browse/OSDEV-2023) - The `Recruitment Agency` has been added to facility type and processing type. So a user can filter production locations on the `/facilities` page, can add this type on the `/contribute/single-location/info/` and `/claimed/:id/` pages.
+* [OSDEV-2055](https://opensupplyhub.atlassian.net/browse/OSDEV-2055) - Increased per-download limit to 10,000 records for the `private_instance` active flag. Embeded Map now bypasses download limit checks and reflect to the new 10,000 record limit.
 
 ### Release instructions
 * Ensure that the following commands are included in the `post_deployment` command:

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -213,7 +213,7 @@ class APIErrorMessages:
 
 
 class FacilitiesDownloadSettings:
-    FACILITIES_DOWNLOAD_LIMIT = 5000
+    FREE_FACILITIES_DOWNLOAD_LIMIT = 5000
 
 
 class FacilitiesListSettings:

--- a/src/django/api/facilities_download_view_set.py
+++ b/src/django/api/facilities_download_view_set.py
@@ -18,8 +18,11 @@ class FacilitiesDownloadViewSet(mixins.ListModelMixin,
     queryset = FacilityIndex.objects.all()
     pagination_class = PageAndSizePagination
 
+    def is_embed_mode(self):
+        return self.request.query_params.get('embed') == '1'
+
     def get_serializer(self, page_queryset):
-        if self.request.query_params.get('embed') == '1':
+        if self.is_embed_mode():
             contributor_id = get_embed_contributor_id_from_query_params(
                 self.request.query_params
             )
@@ -42,7 +45,10 @@ class FacilitiesDownloadViewSet(mixins.ListModelMixin,
         total_records = queryset.count()
         facility_download_limit = None
 
-        if not switch_is_active('private_instance'):
+        if (
+            not switch_is_active('private_instance')
+            and not self.is_embed_mode()
+        ):
             facility_download_limit = FacilitiesDownloadService \
                 .get_download_limit(request)
         FacilitiesDownloadService.enforce_limits(

--- a/src/django/api/models/facility_download_limit.py
+++ b/src/django/api/models/facility_download_limit.py
@@ -32,7 +32,7 @@ class FacilityDownloadLimit(models.Model):
         help_text='The user to whom the download limit applies.'
     )
     free_download_records = models.PositiveIntegerField(
-        default=FacilitiesDownloadSettings.FACILITIES_DOWNLOAD_LIMIT,
+        default=FacilitiesDownloadSettings.FREE_FACILITIES_DOWNLOAD_LIMIT,
         help_text=('The number of facilities the user '
                    'can download per calendar year for free.')
     )

--- a/src/django/api/models/facility_download_limit_manager.py
+++ b/src/django/api/models/facility_download_limit_manager.py
@@ -14,7 +14,7 @@ class FacilityDownloadLimitManager(models.Manager):
         expired_free_limits = self.filter(
             updated_at__lt=one_year_ago_with_leap
         )
-        limit = FacilitiesDownloadSettings.FACILITIES_DOWNLOAD_LIMIT
+        limit = FacilitiesDownloadSettings.FREE_FACILITIES_DOWNLOAD_LIMIT
         expired_free_limits.update(
             free_download_records=limit,
             updated_at=now,

--- a/src/django/api/serializers/user/user_serializer.py
+++ b/src/django/api/serializers/user/user_serializer.py
@@ -146,4 +146,4 @@ class UserSerializer(ModelSerializer):
             limit = FacilityDownloadLimit.objects.get(user=user)
             return limit.free_download_records + limit.paid_download_records
         except FacilityDownloadLimit.DoesNotExist:
-            return FacilitiesDownloadSettings.FACILITIES_DOWNLOAD_LIMIT
+            return FacilitiesDownloadSettings.FREE_FACILITIES_DOWNLOAD_LIMIT

--- a/src/django/api/tests/test_facilities_download_viewset.py
+++ b/src/django/api/tests/test_facilities_download_viewset.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 from django.utils.timezone import make_aware, datetime
 
 # Override constants different from production value for easier testing.
-FACILITIES_DOWNLOAD_LIMIT = 3
+FREE_FACILITIES_DOWNLOAD_LIMIT = 3
 
 
 class FacilitiesDownloadViewSetTest(APITestCase):
@@ -450,15 +450,15 @@ class FacilitiesDownloadViewSetTest(APITestCase):
         )
 
     @patch(
-        'api.constants.FacilitiesDownloadSettings.FACILITIES_DOWNLOAD_LIMIT',
-        FACILITIES_DOWNLOAD_LIMIT
+        'api.constants.FacilitiesDownloadSettings.FREE_FACILITIES_DOWNLOAD_LIMIT',
+        FREE_FACILITIES_DOWNLOAD_LIMIT
     )
     def test_user_cannot_download_over_records_limit(self):
         user = self.create_user()
         self.login_user(user)
         FacilityDownloadLimit.objects.create(
             user=user,
-            free_download_records=FACILITIES_DOWNLOAD_LIMIT,
+            free_download_records=FREE_FACILITIES_DOWNLOAD_LIMIT,
             paid_download_records=1
         )
         response = self.get_facility_downloads()
@@ -498,8 +498,8 @@ class FacilitiesDownloadViewSetTest(APITestCase):
         self.assertEqual(limit.updated_at.date(), release_date.date())
 
     @patch(
-        'api.constants.FacilitiesDownloadSettings.FACILITIES_DOWNLOAD_LIMIT',
-        FACILITIES_DOWNLOAD_LIMIT
+        'api.constants.FacilitiesDownloadSettings.FREE_FACILITIES_DOWNLOAD_LIMIT',
+        FREE_FACILITIES_DOWNLOAD_LIMIT
     )
     def test_api_user_can_download_over_limit(self):
         user = self.create_user(is_api_user=True)
@@ -509,7 +509,7 @@ class FacilitiesDownloadViewSetTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertGreater(
             len(response.data.get("results", {}).get("rows", [])),
-            FACILITIES_DOWNLOAD_LIMIT
+            FREE_FACILITIES_DOWNLOAD_LIMIT
         )
 
     def test_api_user_not_limited_by_download_count(self):

--- a/src/django/api/tests/test_facility_download_limit_manager.py
+++ b/src/django/api/tests/test_facility_download_limit_manager.py
@@ -92,7 +92,7 @@ class FacilityDownloadLimitManagerTest(TestCase):
         # Assert expired free limits updated.
         self.assertEqual(
             expired_free.free_download_records,
-            FacilitiesDownloadSettings.FACILITIES_DOWNLOAD_LIMIT,
+            FacilitiesDownloadSettings.FREE_FACILITIES_DOWNLOAD_LIMIT,
         )
         self.assertTrue(expired_free.updated_at > one_year_ago)
         # Assert fresh free limits unchanged.

--- a/src/django/api/tests/test_user_serializer.py
+++ b/src/django/api/tests/test_user_serializer.py
@@ -23,7 +23,7 @@ class UserSerializerTest(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json()["allowed_records_number"],
-            FacilitiesDownloadSettings.FACILITIES_DOWNLOAD_LIMIT
+            FacilitiesDownloadSettings.FREE_FACILITIES_DOWNLOAD_LIMIT
         )
 
     def test_get_free_records_number(self):
@@ -39,5 +39,5 @@ class UserSerializerTest(APITestCase):
 
         self.assertEqual(
             number_from_db,
-            FacilitiesDownloadSettings.FACILITIES_DOWNLOAD_LIMIT
+            FacilitiesDownloadSettings.FREE_FACILITIES_DOWNLOAD_LIMIT
         )

--- a/src/react/src/components/DownloadFacilitiesButton.jsx
+++ b/src/react/src/components/DownloadFacilitiesButton.jsx
@@ -142,7 +142,7 @@ const DownloadFacilitiesButton = ({
                             }
                         />
                         <span className={classes.buttonText}>
-                            {upgrade ? 'Upgrade to Download' : 'Download'}
+                            {upgrade ? 'Purchase More Downloads' : 'Download'}
                         </span>
                         {upgrade ? (
                             ''

--- a/src/react/src/components/DownloadFacilitiesButton.jsx
+++ b/src/react/src/components/DownloadFacilitiesButton.jsx
@@ -116,7 +116,9 @@ const DownloadFacilitiesButton = ({
             Downloads are supported for searches resulting in{' '}
             {isEmbedded ? FACILITIES_DOWNLOAD_LIMIT : userAllowedRecords}{' '}
             production locations or less.
-            {user.isAnon && ' Log in to download this dataset.'}
+            {user.isAnon && !isEmbedded
+                ? ' Log in to download this dataset.'
+                : ''}
         </p>
     );
 

--- a/src/react/src/components/DownloadFacilitiesButton.jsx
+++ b/src/react/src/components/DownloadFacilitiesButton.jsx
@@ -16,7 +16,10 @@ import DownloadIcon from './DownloadIcon';
 import ArrowDropDownIcon from './ArrowDropDownIcon';
 import { hideLogDownloadError } from '../actions/logDownload';
 import DownloadMenu from '../components/DownloadMenu';
-import { FACILITIES_DOWNLOAD_LIMIT } from '../util/constants';
+import {
+    FREE_FACILITIES_DOWNLOAD_LIMIT,
+    FACILITIES_DOWNLOAD_LIMIT,
+} from '../util/constants';
 
 const downloadFacilitiesStyles = theme =>
     Object.freeze({
@@ -111,7 +114,8 @@ const DownloadFacilitiesButton = ({
     const tooltipTitle = (
         <p className={classes.downloadTooltip}>
             Downloads are supported for searches resulting in{' '}
-            {userAllowedRecords} production locations or less.
+            {isEmbedded ? FACILITIES_DOWNLOAD_LIMIT : userAllowedRecords}{' '}
+            production locations or less.
             {user.isAnon && ' Log in to download this dataset.'}
         </p>
     );
@@ -164,7 +168,7 @@ const DownloadFacilitiesButton = ({
 DownloadFacilitiesButton.defaultProps = {
     disabled: false,
     upgrade: false,
-    userAllowedRecords: FACILITIES_DOWNLOAD_LIMIT,
+    userAllowedRecords: FREE_FACILITIES_DOWNLOAD_LIMIT,
     logDownloadError: null,
     checkoutUrl: null,
     checkoutUrlError: null,

--- a/src/react/src/components/FilterSidebarFacilitiesTab.jsx
+++ b/src/react/src/components/FilterSidebarFacilitiesTab.jsx
@@ -369,6 +369,7 @@ function FilterSidebarFacilitiesTab({
                             disabled={
                                 facilitiesCount > FACILITIES_DOWNLOAD_LIMIT
                             }
+                            userAllowedRecords={FACILITIES_DOWNLOAD_LIMIT}
                             setLoginRequiredDialogIsOpen={
                                 setLoginRequiredDialogIsOpen
                             }

--- a/src/react/src/components/FilterSidebarFacilitiesTab.jsx
+++ b/src/react/src/components/FilterSidebarFacilitiesTab.jsx
@@ -354,9 +354,14 @@ function FilterSidebarFacilitiesTab({
                         flag={PRIVATE_INSTANCE}
                         alternative={
                             <DownloadFacilitiesButton
+                                disabled={
+                                    embed &&
+                                    facilitiesCount > FACILITIES_DOWNLOAD_LIMIT
+                                }
                                 upgrade={
+                                    !embed &&
                                     facilitiesCount >
-                                    user.allowed_records_number
+                                        user.allowed_records_number
                                 }
                                 userAllowedRecords={user.allowed_records_number}
                                 setLoginRequiredDialogIsOpen={

--- a/src/react/src/components/NonVectorTileFilterSidebarFacilitiesTab.jsx
+++ b/src/react/src/components/NonVectorTileFilterSidebarFacilitiesTab.jsx
@@ -105,6 +105,7 @@ function NonVectorTileFilterSidebarFacilitiesTab({
     data,
     error,
     windowHeight,
+    embed,
     returnToSearchTab,
     filterText,
     updateFilterText,
@@ -228,9 +229,14 @@ function NonVectorTileFilterSidebarFacilitiesTab({
                         flag={PRIVATE_INSTANCE}
                         alternative={
                             <DownloadFacilitiesButton
+                                disabled={
+                                    embed &&
+                                    facilitiesCount > FACILITIES_DOWNLOAD_LIMIT
+                                }
                                 upgrade={
+                                    !embed &&
                                     facilitiesCount >
-                                    user.allowed_records_number
+                                        user.allowed_records_number
                                 }
                                 userAllowedRecords={user.allowed_records_number}
                                 setLoginRequiredDialogIsOpen={
@@ -379,6 +385,7 @@ NonVectorTileFilterSidebarFacilitiesTab.propTypes = {
     returnToSearchTab: func.isRequired,
     filterText: string.isRequired,
     updateFilterText: func.isRequired,
+    embed: bool.isRequired,
     user: userPropType,
 };
 
@@ -393,6 +400,7 @@ function mapStateToProps({
     auth: {
         user: { user },
     },
+    embeddedMap: { embed },
 }) {
     return {
         user,
@@ -401,6 +409,7 @@ function mapStateToProps({
         fetching,
         filterText,
         windowHeight,
+        embed: !!embed,
     };
 }
 

--- a/src/react/src/components/NonVectorTileFilterSidebarFacilitiesTab.jsx
+++ b/src/react/src/components/NonVectorTileFilterSidebarFacilitiesTab.jsx
@@ -243,6 +243,7 @@ function NonVectorTileFilterSidebarFacilitiesTab({
                             disabled={
                                 facilitiesCount > FACILITIES_DOWNLOAD_LIMIT
                             }
+                            userAllowedRecords={FACILITIES_DOWNLOAD_LIMIT}
                             setLoginRequiredDialogIsOpen={
                                 setLoginRequiredDialogIsOpen
                             }

--- a/src/react/src/util/constants.jsx
+++ b/src/react/src/util/constants.jsx
@@ -6,7 +6,8 @@ import COLOURS from './COLOURS';
 export const DEFAULT_SORT_OPTION_INDEX = 2;
 export const OTHER = 'Other';
 export const FACILITIES_REQUEST_PAGE_SIZE = 50;
-export const FACILITIES_DOWNLOAD_LIMIT = 5000;
+export const FACILITIES_DOWNLOAD_LIMIT = 10000;
+export const FREE_FACILITIES_DOWNLOAD_LIMIT = 5000;
 export const FACILITIES_DOWNLOAD_REQUEST_PAGE_SIZE = 100;
 
 export const WEB_HEADER_HEIGHT = '160px';

--- a/src/react/src/util/constants.jsx
+++ b/src/react/src/util/constants.jsx
@@ -1302,7 +1302,7 @@ export const USER_DEFAULT_STATE = Object.freeze({
     is_superuser: false,
     is_staff: false,
     is_moderation_mode: false,
-    allowed_records_number: FACILITIES_DOWNLOAD_LIMIT,
+    allowed_records_number: FREE_FACILITIES_DOWNLOAD_LIMIT,
 });
 
 export const facilityClaimStepsNames = Object.freeze({


### PR DESCRIPTION
**[OSDEV-2055](https://opensupplyhub.atlassian.net/browse/OSDEV-2055) Data Download Limits: Embedded Map download limits check**

- Updated implementation for private_instance flag to allow 10k records instead of 5k records per download.
- Added logic to skip download limit check for Embeded Map requests.
- Updated the UI part of Embeded Map to properly allow and show 10k records limitation per download.
- Update button text from _Upgrade to Download_ to _Purchase More Downloads_.