### PR TITLE
[Release Bug] [OSDEV-1868] Updated tooltip texts.

### DIFF
--- a/src/react/src/__tests__/components/DownloadFacilitiesButton.test.js
+++ b/src/react/src/__tests__/components/DownloadFacilitiesButton.test.js
@@ -30,6 +30,7 @@ describe('DownloadFacilitiesButton component', () => {
     setLoginRequiredDialogIsOpen: false,
     handleDownload,
     userAllowedRecords: 5000,
+    facilitiesCount: 10,
   };
 
   const createMockStore = (customState = {}) => {
@@ -173,7 +174,7 @@ describe('DownloadFacilitiesButton component', () => {
       },
       embeddedMap: { embed: false },
     };
-    const expectedTooltipText = "You've reached your annual download limit. Purchase additional downloads for immediate access.";
+    const expectedTooltipText = "You've reached your annual download limit of 5000 production locations. Purchase additional downloads to download more data.";
 
     const { getByRole } = renderComponent(props, customState);
 
@@ -191,6 +192,7 @@ describe('DownloadFacilitiesButton component', () => {
       userAllowedRecords: 1000,
       upgrade: true,
       isEmbedded: false,
+      facilitiesCount: 2000,
     };
     const customState = {
       auth: {
@@ -203,7 +205,7 @@ describe('DownloadFacilitiesButton component', () => {
       },
       embeddedMap: { embed: false },
     };
-    const expectedTooltipText = "Registered users can download up to 5000 production locations annually for free. This account has 1000 production locations available to download. Purchase additional downloads for immediate access.";
+    const expectedTooltipText = "You are trying to download 2000 production locations but this account only has 1000 production locations available to download. Purchase additional downloads to continue.";
     const { getByRole } = renderComponent(props, customState);
 
     const button = getByRole('button', { name: 'Purchase More Downloads' });

--- a/src/react/src/components/DownloadFacilitiesButton.jsx
+++ b/src/react/src/components/DownloadFacilitiesButton.jsx
@@ -70,6 +70,7 @@ const DownloadFacilitiesButton = ({
     setLoginRequiredDialogIsOpen,
     classes,
     theme,
+    facilitiesCount,
 }) => {
     const [anchorEl, setAnchorEl] = React.useState(null);
     const isPrivateInstance = includes(activeFeatureFlags, PRIVATE_INSTANCE);
@@ -128,6 +129,7 @@ const DownloadFacilitiesButton = ({
                 isPrivateInstance,
                 upgrade,
                 classes,
+                facilitiesCount,
             }),
         [
             user,
@@ -136,6 +138,7 @@ const DownloadFacilitiesButton = ({
             isPrivateInstance,
             upgrade,
             classes,
+            facilitiesCount,
         ],
     );
 
@@ -207,6 +210,7 @@ DownloadFacilitiesButton.propTypes = {
     checkoutUrlError: string,
     classes: object.isRequired,
     activeFeatureFlags: arrayOf(string).isRequired,
+    facilitiesCount: number.isRequired,
 };
 
 function mapStateToProps({

--- a/src/react/src/components/FilterSidebarFacilitiesTab.jsx
+++ b/src/react/src/components/FilterSidebarFacilitiesTab.jsx
@@ -367,6 +367,7 @@ function FilterSidebarFacilitiesTab({
                                 setLoginRequiredDialogIsOpen={
                                     setLoginRequiredDialogIsOpen
                                 }
+                                facilitiesCount={facilitiesCount}
                             />
                         }
                     >

--- a/src/react/src/components/NonVectorTileFilterSidebarFacilitiesTab.jsx
+++ b/src/react/src/components/NonVectorTileFilterSidebarFacilitiesTab.jsx
@@ -242,6 +242,7 @@ function NonVectorTileFilterSidebarFacilitiesTab({
                                 setLoginRequiredDialogIsOpen={
                                     setLoginRequiredDialogIsOpen
                                 }
+                                facilitiesCount={facilitiesCount}
                             />
                         }
                     >

--- a/src/react/src/util/getTooltipForFacilitiesDownload.jsx
+++ b/src/react/src/util/getTooltipForFacilitiesDownload.jsx
@@ -12,16 +12,17 @@ const getTooltipForFacilitiesDownload = ({
     isPrivateInstance,
     upgrade,
     classes,
+    facilitiesCount,
 }) => {
     const tooltipTexts = {
         availableDownloads: `Registered users can download up to ${FREE_FACILITIES_DOWNLOAD_LIMIT} production
-            locations annually for free. This account has ${userAllowedRecords} production locations
-            available to download. Additional downloads are available for purchase.`,
-        outOfDownloads:
-            "You've reached your annual download limit. Purchase additional downloads for immediate access.",
-        limitExceededByResults: `Registered users can download up to ${FREE_FACILITIES_DOWNLOAD_LIMIT}
-            production locations annually for free. This account has ${userAllowedRecords} production
-            locations available to download. Purchase additional downloads for immediate access.`,
+        locations annually for free. This account has ${userAllowedRecords} production locations available to
+        download. Additional downloads are available for purchase.`,
+        outOfDownloads: `You've reached your annual download limit of ${FREE_FACILITIES_DOWNLOAD_LIMIT} production
+        locations. Purchase additional downloads to download more data.`,
+        limitExceededByResults: `You are trying to download ${facilitiesCount} production locations but this account only has
+        ${userAllowedRecords} production locations available to download. Purchase additional downloads to
+        continue.`,
         anonymousUser: 'Log in or sign up to download this dataset.',
         embeddedOrPrivateInstance: `Downloads are supported for searches resulting in ${FACILITIES_DOWNLOAD_LIMIT} production locations or less.`,
     };


### PR DESCRIPTION
[OSDEV-1868](https://opensupplyhub.atlassian.net/browse/OSDEV-1868) Updated tooltip texts.
Updated text for `out of downloads` and `limit exceeded by results` cases. Passed `facilitiesCount` to the DownloadFacilitiesButton component, added to propTypes, fixed tests.