### PR TITLE
[Release Bug] [OSDEV-2107] Search button redirects user to Stripe Checkout page instead of search result

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -40,6 +40,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
     * Fixed the incorrect indexing of the location type in the production locations OpenSearch index. Previously, it was incorrectly taking the processing type value as the location type — using the fourth item in the `matched_values` array instead of the third, which contains the location type. Also, updated the Logstash filters for both processing type and location type to return only unique values and write them to the production locations OpenSearch index.
     * Adjusted the post-submit popup. Instead of displaying the cleaned and transformed data from ContriCleaner, we now show only the raw input submitted by the user.
 * [OSDEV-1913](https://opensupplyhub.atlassian.net/browse/OSDEV-1913) - The `max_length` for the `path` field in the `DownloadLog` model has been increased from 2083 to 4096 to fix the too long value error.
+* [OSDEV-2107](https://opensupplyhub.atlassian.net/browse/OSDEV-2107) - Fixed an issue where navigating back from the Stripe Checkout page using the browser’s back button caused the search button to repeatedly redirect to Stripe Checkout.
 
 ### What's new
 * [OSDEV-2023](https://opensupplyhub.atlassian.net/browse/OSDEV-2023) - The `Recruitment Agency` has been added to facility type and processing type. So a user can filter production locations on the `/facilities` page, can add this type on the `/contribute/single-location/info/` and `/claimed/:id/` pages.

--- a/src/react/src/actions/downloadLimit.js
+++ b/src/react/src/actions/downloadLimit.js
@@ -14,6 +14,9 @@ export const failFetchDownloadLimitCheckoutUrl = createAction(
 export const hideDownloadLimitCheckoutUrlError = createAction(
     'HIDE_DOWNLOAD_LIMIT_CHECKOUT_URL_ERROR',
 );
+export const clearDownloadLimitCheckoutUrl = createAction(
+    'CLEAR_DOWNLOAD_LIMIT_CHECKOUT_URL',
+);
 export const completeFetchDownloadLimitCheckoutUrl = createAction(
     'COMPLETE_FETCH_DOWNLOAD_LIMIT_CHECKOUT_URL',
 );

--- a/src/react/src/components/DownloadFacilitiesButton.jsx
+++ b/src/react/src/components/DownloadFacilitiesButton.jsx
@@ -11,6 +11,7 @@ import { toast } from 'react-toastify';
 import downloadFacilities from '../actions/downloadFacilities';
 import {
     hideDownloadLimitCheckoutUrlError,
+    clearDownloadLimitCheckoutUrl,
     downloadLimitCheckoutUrl,
 } from '../actions/downloadLimit';
 import DownloadIcon from './DownloadIcon';
@@ -89,6 +90,7 @@ const DownloadFacilitiesButton = ({
     useEffect(() => {
         if (checkoutUrl) {
             window.location.href = checkoutUrl;
+            dispatch(clearDownloadLimitCheckoutUrl());
         }
         if (checkoutUrlError) {
             toast(checkoutUrlError);

--- a/src/react/src/reducers/DownloadLimitReducer.js
+++ b/src/react/src/reducers/DownloadLimitReducer.js
@@ -5,6 +5,7 @@ import {
     startFetchDownloadLimitCheckoutUrl,
     failFetchDownloadLimitCheckoutUrl,
     hideDownloadLimitCheckoutUrlError,
+    clearDownloadLimitCheckoutUrl,
     completeFetchDownloadLimitCheckoutUrl,
 } from '../actions/downloadLimit';
 
@@ -37,6 +38,12 @@ export default createReducer(
             update(state, {
                 checkout: {
                     error: { $set: initialState.checkout.error },
+                },
+            }),
+        [clearDownloadLimitCheckoutUrl]: state =>
+            update(state, {
+                checkout: {
+                    checkoutUrl: { $set: initialState.checkout.checkoutUrl },
                 },
             }),
         [completeFetchDownloadLimitCheckoutUrl]: (state, payload) =>


### PR DESCRIPTION
**[Release Bug] [OSDEV-2107](https://opensupplyhub.atlassian.net/browse/OSDEV-2107) Search button redirects user to Stripe Checkout page instead of search result**

- Fixed an issue where navigating back from the Stripe Checkout page using the browser’s back button caused the search button to repeatedly redirect to Stripe Checkout.

[OSDEV-2107]: https://opensupplyhub.atlassian.net/browse/OSDEV-2107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ