### PR TITLE
[OSDEV-1881] Automated Email Alerts for Download Limits

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -33,7 +33,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * *Describe bugfix here.*
 
 ### What's new
-* *Describe what's new here. The changes that can impact user experience should be listed in this section.*
+* [OSDEV-1881](https://opensupplyhub.atlassian.net/browse/OSDEV-1881) - Implemented automated email notifications for registered users in three scenarios: when nearing the 5,000-record annual download limit, upon reaching that limit, and after exhausting all purchased downloads.
 
 ### Release instructions
 * Ensure that the following commands are included in the `post_deployment` command:

--- a/src/django/api/facilities_download_view_set.py
+++ b/src/django/api/facilities_download_view_set.py
@@ -69,13 +69,20 @@ class FacilitiesDownloadViewSet(mixins.ListModelMixin,
 
         paginator = self.paginator
         if paginator.page.number == paginator.page.paginator.num_pages:
+            prev_free_amount = facility_download_limit \
+                .free_download_records
+            prev_paid_amount = facility_download_limit \
+                .paid_download_records
+
             FacilitiesDownloadService.register_download_if_needed(
                 facility_download_limit,
                 total_records
             )
             FacilitiesDownloadService.send_email_if_needed(
                 request,
-                facility_download_limit
+                facility_download_limit,
+                prev_free_amount,
+                prev_paid_amount
             )
 
         return response

--- a/src/django/api/facilities_download_view_set.py
+++ b/src/django/api/facilities_download_view_set.py
@@ -73,5 +73,9 @@ class FacilitiesDownloadViewSet(mixins.ListModelMixin,
                 facility_download_limit,
                 total_records
             )
+            FacilitiesDownloadService.send_email_if_needed(
+                request,
+                facility_download_limit
+            )
 
         return response

--- a/src/django/api/mail.py
+++ b/src/django/api/mail.py
@@ -597,7 +597,7 @@ def send_slc_contribution_rejected_email(request, moderation_event):
     )
 
 
-def send_ddl_near_annual_limit_email(amount, link, email):
+def send_ddl_near_annual_limit_email(amount, url, email):
     subj_template = get_template(
         'mail/ddl_near_annual_limit_subject.txt'
     )
@@ -610,7 +610,7 @@ def send_ddl_near_annual_limit_email(amount, link, email):
 
     dictionary = {
         'available_amount': amount,
-        'purchase_link': link,
+        'purchase_url': url,
     }
 
     send_mail(
@@ -622,7 +622,7 @@ def send_ddl_near_annual_limit_email(amount, link, email):
     )
 
 
-def send_ddl_reach_annual_limit_email(link, email):
+def send_ddl_reach_annual_limit_email(url, email):
     subj_template = get_template(
         'mail/ddl_reach_annual_limit_subject.txt'
     )
@@ -634,7 +634,7 @@ def send_ddl_reach_annual_limit_email(link, email):
     )
 
     dictionary = {
-        'purchase_link': link,
+        'purchase_url': url,
     }
 
     send_mail(
@@ -646,7 +646,7 @@ def send_ddl_reach_annual_limit_email(link, email):
     )
 
 
-def send_ddl_reach_paid_limit_email(link, email):
+def send_ddl_reach_paid_limit_email(url, email):
     subj_template = get_template(
         'mail/ddl_reach_paid_limit_subject.txt'
     )
@@ -658,7 +658,7 @@ def send_ddl_reach_paid_limit_email(link, email):
     )
 
     dictionary = {
-        'purchase_link': link,
+        'purchase_url': url,
     }
 
     send_mail(

--- a/src/django/api/mail.py
+++ b/src/django/api/mail.py
@@ -595,3 +595,76 @@ def send_slc_contribution_rejected_email(request, moderation_event):
         [moderation_event.contributor.admin.email],
         html_message=html_template.render(rejected_dictionary)
     )
+
+
+def send_ddl_near_annual_limit_email(amount, link, email):
+    subj_template = get_template(
+        'mail/ddl_near_annual_limit_subject.txt'
+    )
+    text_template = get_template(
+        'mail/ddl_near_annual_limit_body.txt'
+    )
+    html_template = get_template(
+        'mail/ddl_near_annual_limit_body.html'
+    )
+
+    dictionary = {
+        'available_amount': amount,
+        'purchase_link': link,
+    }
+
+    send_mail(
+        subj_template.render().rstrip(),
+        text_template.render(dictionary),
+        settings.DATA_FROM_EMAIL,
+        [email],
+        html_message=html_template.render(dictionary)
+    )
+
+
+def send_ddl_reach_annual_limit_email(link, email):
+    subj_template = get_template(
+        'mail/ddl_reach_annual_limit_subject.txt'
+    )
+    text_template = get_template(
+        'mail/ddl_reach_annual_limit_body.txt'
+    )
+    html_template = get_template(
+        'mail/ddl_reach_annual_limit_body.html'
+    )
+
+    dictionary = {
+        'purchase_link': link,
+    }
+
+    send_mail(
+        subj_template.render().rstrip(),
+        text_template.render(dictionary),
+        settings.DATA_FROM_EMAIL,
+        [email],
+        html_message=html_template.render(dictionary)
+    )
+
+
+def send_ddl_reach_paid_limit_email(link, email):
+    subj_template = get_template(
+        'mail/ddl_reach_paid_limit_subject.txt'
+    )
+    text_template = get_template(
+        'mail/ddl_reach_paid_limit_body.txt'
+    )
+    html_template = get_template(
+        'mail/ddl_reach_paid_limit_body.html'
+    )
+
+    dictionary = {
+        'purchase_link': link,
+    }
+
+    send_mail(
+        subj_template.render().rstrip(),
+        text_template.render(dictionary),
+        settings.DATA_FROM_EMAIL,
+        [email],
+        html_message=html_template.render(dictionary)
+    )

--- a/src/django/api/services/facilities_download_service.py
+++ b/src/django/api/services/facilities_download_service.py
@@ -115,7 +115,7 @@ class FacilitiesDownloadService:
             limit.refresh_from_db()
 
             site_url = request.build_absolute_uri('/')
-            redirect_path = site_url + '/facilities'
+            redirect_path = site_url + 'facilities'
             url = FacilitiesDownloadService.get_checkout_url(
                 limit.user.id,
                 redirect_path

--- a/src/django/api/services/facilities_download_service.py
+++ b/src/django/api/services/facilities_download_service.py
@@ -110,7 +110,12 @@ class FacilitiesDownloadService:
             limit.register_download(record_count)
 
     @staticmethod
-    def send_email_if_needed(request, limit: FacilityDownloadLimit):
+    def send_email_if_needed(
+        request,
+        limit: FacilityDownloadLimit,
+        prev_free,
+        prev_paid
+    ):
         if limit:
             limit.refresh_from_db()
 
@@ -121,9 +126,7 @@ class FacilitiesDownloadService:
                 redirect_path
             )
 
-
-            if (limit.free_download_records <= 1000
-                and limit.free_download_records != 0
+            if (0 < limit.free_download_records <= 1000
                 and limit.paid_download_records == 0
             ):
                 send_ddl_near_annual_limit_email(
@@ -131,17 +134,16 @@ class FacilitiesDownloadService:
                     url,
                     limit.user.email
                 )
-            if (limit.free_download_records == 0
-                and limit.purchase_date is None
-                and limit.paid_download_records == 0
+            elif (limit.free_download_records == 0
+                and prev_free > 0
+                and prev_paid == 0
             ):
                 send_ddl_reach_annual_limit_email(
                     url,
                     limit.user.email
                 )
-            if (limit.paid_download_records == 0
-                and limit.purchase_date is not None
-                and limit.free_download_records == 0
+            elif (limit.paid_download_records == 0
+                and prev_paid > 0
             ):
                 send_ddl_reach_paid_limit_email(
                     url,

--- a/src/django/api/templates/mail/ddl_near_annual_limit_body.html
+++ b/src/django/api/templates/mail/ddl_near_annual_limit_body.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>
+            Open Supply Hub Data Downloads Limitation
+        </title>
+    </head>
+    <body>
+        <p>
+            Hello,
+        </p>
+        <p>
+            We’re writing to notify you that you have used over 4,000 of your 5,000 annual production location downloads.
+            This account has {{ available_amount }} production locations available to download.
+        </p>
+        <p>
+            Purchase additional downloads for immediate access when you reach your limit.
+        </p>
+        <p>
+            <a href="{{ purchase_link }}">Purchase More Downloads</a>
+        </p>
+        <p>
+            Best Regards,
+        </p>
+        {% include "mail/signature_block.html" %}
+    </body>
+</html>

--- a/src/django/api/templates/mail/ddl_near_annual_limit_body.html
+++ b/src/django/api/templates/mail/ddl_near_annual_limit_body.html
@@ -17,7 +17,7 @@
             Purchase additional downloads for immediate access when you reach your limit.
         </p>
         <p>
-            <a href="{{ purchase_link }}">Purchase More Downloads</a>
+            <a href="{{ purchase_url }}">Purchase More Downloads</a>
         </p>
         <p>
             Best Regards,

--- a/src/django/api/templates/mail/ddl_near_annual_limit_body.txt
+++ b/src/django/api/templates/mail/ddl_near_annual_limit_body.txt
@@ -1,0 +1,14 @@
+{% block content %}
+Hello,
+
+We’re writing to notify you that you have used over 4,000 of your 5,000 annual production location downloads.
+This account has {{ available_amount }} production locations available to download.
+
+Purchase additional downloads for immediate access when you reach your limit.
+
+{{ purchase_link }}
+
+Best Regards,
+
+{% include "mail/signature_block.txt" %}
+{% endblock content %}

--- a/src/django/api/templates/mail/ddl_near_annual_limit_body.txt
+++ b/src/django/api/templates/mail/ddl_near_annual_limit_body.txt
@@ -6,7 +6,7 @@ This account has {{ available_amount }} production locations available to downlo
 
 Purchase additional downloads for immediate access when you reach your limit.
 
-{{ purchase_link }}
+{{ purchase_url }}
 
 Best Regards,
 

--- a/src/django/api/templates/mail/ddl_near_annual_limit_subject.txt
+++ b/src/django/api/templates/mail/ddl_near_annual_limit_subject.txt
@@ -1,0 +1,1 @@
+Open Supply Hub Data Downloads Limitation

--- a/src/django/api/templates/mail/ddl_reach_annual_limit_body.html
+++ b/src/django/api/templates/mail/ddl_reach_annual_limit_body.html
@@ -16,7 +16,7 @@
             Purchase additional downloads to continue accessing Open Supply Hub data.
         </p>
         <p>
-            <a href="{{ purchase_link }}">Purchase More Downloads</a>
+            <a href="{{ purchase_url }}">Purchase More Downloads</a>
         </p>
         <p>
             Best Regards,

--- a/src/django/api/templates/mail/ddl_reach_annual_limit_body.html
+++ b/src/django/api/templates/mail/ddl_reach_annual_limit_body.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>
+            Open Supply Hub Data Downloads Limitation
+        </title>
+    </head>
+    <body>
+        <p>
+            Hello,
+        </p>
+        <p>
+            You have reached your annual download limit of 5,000 production locations.
+        </p>
+        <p>
+            Purchase additional downloads to continue accessing Open Supply Hub data.
+        </p>
+        <p>
+            <a href="{{ purchase_link }}">Purchase More Downloads</a>
+        </p>
+        <p>
+            Best Regards,
+        </p>
+        {% include "mail/signature_block.html" %}
+    </body>
+</html>

--- a/src/django/api/templates/mail/ddl_reach_annual_limit_body.txt
+++ b/src/django/api/templates/mail/ddl_reach_annual_limit_body.txt
@@ -5,7 +5,7 @@ You have reached your annual download limit of 5,000 production locations.
 
 Purchase additional downloads to continue accessing Open Supply Hub data.
 
-{{ purchase_link }}
+{{ purchase_url }}
 
 Best Regards,
 

--- a/src/django/api/templates/mail/ddl_reach_annual_limit_body.txt
+++ b/src/django/api/templates/mail/ddl_reach_annual_limit_body.txt
@@ -1,0 +1,13 @@
+{% block content %}
+Hello,
+
+You have reached your annual download limit of 5,000 production locations.
+
+Purchase additional downloads to continue accessing Open Supply Hub data.
+
+{{ purchase_link }}
+
+Best Regards,
+
+{% include "mail/signature_block.txt" %}
+{% endblock content %}

--- a/src/django/api/templates/mail/ddl_reach_annual_limit_subject.txt
+++ b/src/django/api/templates/mail/ddl_reach_annual_limit_subject.txt
@@ -1,0 +1,1 @@
+Open Supply Hub Data Downloads Limitation

--- a/src/django/api/templates/mail/ddl_reach_paid_limit_body.html
+++ b/src/django/api/templates/mail/ddl_reach_paid_limit_body.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>
+            Open Supply Hub Data Downloads Limitation
+        </title>
+    </head>
+    <body>
+        <p>
+            Hello,
+        </p>
+        <p>
+            You have used all of your purchased production location downloads.
+        </p>
+        <p>
+            Purchase more downloads to continue accessing Open Supply Hub data.
+        </p>
+        <p>
+            <a href="{{ purchase_link }}">Purchase More Downloads</a>
+        </p>
+        <p>
+            Best Regards,
+        </p>
+        {% include "mail/signature_block.html" %}
+    </body>
+</html>

--- a/src/django/api/templates/mail/ddl_reach_paid_limit_body.html
+++ b/src/django/api/templates/mail/ddl_reach_paid_limit_body.html
@@ -16,7 +16,7 @@
             Purchase more downloads to continue accessing Open Supply Hub data.
         </p>
         <p>
-            <a href="{{ purchase_link }}">Purchase More Downloads</a>
+            <a href="{{ purchase_url }}">Purchase More Downloads</a>
         </p>
         <p>
             Best Regards,

--- a/src/django/api/templates/mail/ddl_reach_paid_limit_body.txt
+++ b/src/django/api/templates/mail/ddl_reach_paid_limit_body.txt
@@ -5,7 +5,7 @@ You have used all of your purchased production location downloads.
 
 Purchase more downloads to continue accessing Open Supply Hub data.
 
-{{ purchase_link }}
+{{ purchase_url }}
 
 Best Regards,
 

--- a/src/django/api/templates/mail/ddl_reach_paid_limit_body.txt
+++ b/src/django/api/templates/mail/ddl_reach_paid_limit_body.txt
@@ -1,0 +1,13 @@
+{% block content %}
+Hello,
+
+You have used all of your purchased production location downloads.
+
+Purchase more downloads to continue accessing Open Supply Hub data.
+
+{{ purchase_link }}
+
+Best Regards,
+
+{% include "mail/signature_block.txt" %}
+{% endblock content %}

--- a/src/django/api/templates/mail/ddl_reach_paid_limit_subject.txt
+++ b/src/django/api/templates/mail/ddl_reach_paid_limit_subject.txt
@@ -1,0 +1,1 @@
+Open Supply Hub Data Downloads Limitation


### PR DESCRIPTION
**[OSDEV-1881](https://opensupplyhub.atlassian.net/browse/OSDEV-1881) Automated Email Alerts for Download Limits**

- Implemented automated email notifications for registered users in three scenarios: when nearing the 5,000-record annual download limit, upon reaching that limit, and after exhausting all purchased downloads.