### PR TITLE
[Backmerge][OSDEV-2123] Updated VPN EC2 instance configuration to use a specific AMI

### DIFF
--- a/deployment/environments/terraform-development.tfvars
+++ b/deployment/environments/terraform-development.tfvars
@@ -70,3 +70,5 @@ app_logstash_fargate_cpu = 256
 app_logstash_fargate_memory = 2048
 
 instance_source= "os_hub"
+
+vpn_ec2_ami = "ami-0940c95b23a1f7cac"

--- a/deployment/environments/terraform-preprod.tfvars
+++ b/deployment/environments/terraform-preprod.tfvars
@@ -71,3 +71,4 @@ app_logstash_fargate_memory = 2048
 
 instance_source= "os_hub"
 
+vpn_ec2_ami = "ami-0940c95b23a1f7cac"

--- a/deployment/environments/terraform-production.tfvars
+++ b/deployment/environments/terraform-production.tfvars
@@ -69,3 +69,4 @@ app_logstash_fargate_memory = 2048
 
 instance_source= "os_hub"
 
+vpn_ec2_ami = "ami-0940c95b23a1f7cac"

--- a/deployment/environments/terraform-rba.tfvars
+++ b/deployment/environments/terraform-rba.tfvars
@@ -71,3 +71,4 @@ export_csv_enabled = false
 
 instance_source= "rba"
 
+vpn_ec2_ami = "ami-0940c95b23a1f7cac"

--- a/deployment/environments/terraform-staging.tfvars
+++ b/deployment/environments/terraform-staging.tfvars
@@ -67,3 +67,4 @@ app_logstash_fargate_memory = 2048
 
 instance_source= "os_hub"
 
+vpn_ec2_ami = "ami-0940c95b23a1f7cac"

--- a/deployment/environments/terraform-test.tfvars
+++ b/deployment/environments/terraform-test.tfvars
@@ -75,3 +75,4 @@ app_logstash_fargate_memory = 2048
 
 instance_source= "os_hub"
 
+vpn_ec2_ami = "ami-0940c95b23a1f7cac"

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -802,7 +802,7 @@ variable "waf_enabled" {
 }
 
 
-### DIRECT DATA LOAD VARIABLES - START ###
+# Direct data load variables
 
 variable "direct_data_load_sheet_id" {
   type        = string
@@ -834,7 +834,7 @@ variable "direct_data_load_tab_id" {
   description = "Tab ID of the Google Sheet for direct data load"
 }
 
-### DIRECT DATA LOAD VARIABLES - END ###
+# Stripe variables
 
 variable "stripe_secret_key" {
   type        = string
@@ -852,6 +852,8 @@ variable "stripe_price_id" {
   type        = string
   description = "Stripe price ID for subscription plans"
 }
+
+# Dark visitors variables
 
 variable "dark_visitors_project_key" {
   type        = string
@@ -874,4 +876,11 @@ variable "dromo_schema_id" {
   type        = string
   description = "Dromo schema ID for data management"
   sensitive   = true
+}
+
+# VPN EC2 variables
+
+variable "vpn_ec2_ami" {
+  type        = string
+  description = "VPN EC2 AMI"
 }

--- a/deployment/terraform/vpn-ec2.tf
+++ b/deployment/terraform/vpn-ec2.tf
@@ -1,16 +1,3 @@
-data "aws_ami" "aws_ami_vpn_ec2" {
-  most_recent = true
-  owners      = ["amazon"]
-  filter {
-    name   = "architecture"
-    values = ["arm64"]
-  }
-  filter {
-    name   = "name"
-    values = ["al2023-ami-2023*"]
-  }
-}
-
 data "aws_iam_policy_document" "vpn_instance_assume_role" {
   statement {
     effect = "Allow"
@@ -49,7 +36,7 @@ data "template_file" "wireguard_compose" {
 
 resource "aws_instance" "vpn_ec2" {
   count         = var.environment == "Rba" ? 1 : 0
-  ami           = data.aws_ami.aws_ami_vpn_ec2.id
+  ami           = var.vpn_ec2_ami
   instance_type = "t4g.nano"
   subnet_id     = module.vpc.public_subnet_ids[count.index]
 

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -50,6 +50,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
     * Refactored the filter sidebar header into a separate `FilterSidebarHeader` component to improve code organization and maintainability.
 * [OSDEV-2036](https://opensupplyhub.atlassian.net/browse/OSDEV-2036) - Connected DarkVisitors trackers to the Open Supply Hub site. Both "client analytics" (for JavaScript-capable sessions, including browser-based AI agents) and "server analytics" (for bots that don’t execute JavaScript) were enabled.
 
+### Architecture/Environment changes
+* [OSDEV-2123](https://opensupplyhub.atlassian.net/browse/OSDEV-2123) - Updated VPN EC2 instance configuration to use a specific Amazon Linux 2023 AMI (`ami-0940c95b23a1f7cac`) instead of dynamically selecting the most recent AMI. This change ensures consistent AMI usage across deployments and prevents unnecessary reboots of the VPN server that could result in loss of VPN access through WireGuard. 
+
 ### What's new
 * [OSDEV-1881](https://opensupplyhub.atlassian.net/browse/OSDEV-1881) - Implemented automated email notifications for registered users in three scenarios: when nearing the 5,000-record annual download limit, upon reaching that limit, and after exhausting all purchased downloads.
 


### PR DESCRIPTION
[[OSDEV-2123](https://opensupplyhub.atlassian.net/browse/OSDEV-2123)]
Updated VPN EC2 instance configuration to use a specific Amazon Linux 2023 AMI (ami-0940c95b23a1f7cac) instead of dynamically selecting the most recent AMI. This change ensures consistent AMI usage across deployments and prevents unnecessary reboots of the VPN server that could result in loss of VPN access through WireGuard.

[OSDEV-2123]: https://opensupplyhub.atlassian.net/browse/OSDEV-2123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ