### PR TITLE
[OSDEV-2083] Update python and OpenSearch client versions

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -22,7 +22,13 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * *Describe code/API changes here.*
 
 ### Architecture/Environment changes
-* *Describe architecture/environment changes here.*
+* [OSDEV-2083](https://opensupplyhub.atlassian.net/browse/OSDEV-2083) - The following updates were made:
+    * Updated Python version from `3.7` to `3.8` to support higher OpenSearch client version with necessary features.
+    * Added system dependencies: `libmemcached-dev`, `zlib1g-dev` to support building C-based packages like `pylibmc`.
+    * Package `aiokafka` updated from `0.8.0` → `0.8.1` resolve warning that appear with Python `3.8`.
+    * Package `pytz` upgraded from `2018.7` → `2023.3` to include up-to-date and stable timezone data.
+    * Package `requests` upgraded from `2.31.0` → `2.32.4` for improved security and compatibility.
+    * Package `opensearch-py` upgraded from `2.5.0` → `2.8.0` to enabling hybrid search.
 
 ### Bugfix
 * *Describe bugfix here.*

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -25,7 +25,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-2083](https://opensupplyhub.atlassian.net/browse/OSDEV-2083) - The following updates were made:
     * Updated Python version from `3.7` to `3.8` to support higher OpenSearch client version with necessary features.
     * Added system dependencies: `libmemcached-dev`, `zlib1g-dev` to support building C-based packages like `pylibmc`.
-    * Package `aiokafka` updated from `0.8.0` → `0.8.1` resolve warning that appear with Python `3.8`.
     * Package `pytz` upgraded from `2018.7` → `2023.3` to include up-to-date and stable timezone data.
     * Package `requests` upgraded from `2.31.0` → `2.32.4` for improved security and compatibility.
     * Package `opensearch-py` upgraded from `2.5.0` → `2.8.0` to enabling hybrid search.

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -27,7 +27,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
     * Added system dependencies: `libmemcached-dev`, `zlib1g-dev` to support building C-based packages like `pylibmc`.
     * Package `pytz` upgraded from `2018.7` → `2023.3` to include up-to-date and stable timezone data.
     * Package `requests` upgraded from `2.31.0` → `2.32.4` for improved security and compatibility.
-    * Package `opensearch-py` upgraded from `2.5.0` → `2.8.0` to enabling hybrid search.
+    * Package `opensearch-py` upgraded from `2.5.0` → `2.8.0` to enable hybrid search.
 
 ### Bugfix
 * *Describe bugfix here.*

--- a/src/django/Dockerfile
+++ b/src/django/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.7-slim-bookworm
+FROM --platform=linux/amd64 python:3.8-slim-bookworm
 
 RUN mkdir -p /usr/local/src/static/static
 WORKDIR /usr/local/src
@@ -18,6 +18,8 @@ RUN set -ex \
     gettext \
     postgresql-client-15 \
     git \
+    libmemcached-dev \
+    zlib1g-dev \
     curl \
     " \
     && apt-get update && apt-get install -y $buildDeps $deps --no-install-recommends \

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -1,4 +1,4 @@
-aiokafka==0.8.0
+aiokafka==0.8.1
 base32-crockford==0.3.0
 boto3==1.24.23
 coreapi==2.3.3
@@ -27,15 +27,15 @@ openpyxl==3.0.9
 pycodestyle==2.8.0
 pyflakes==2.4.0
 pylibmc==1.6.0
-pytz==2018.7
+pytz==2023.3
 pymemcache==3.5.2
-requests==2.31.0
+requests==2.32.4
 rollbar==0.16.3
 thefuzz==0.19.0
 Unidecode==1.0.23
 django-slowtests
 django-allauth==0.54.0
-opensearch-py==2.5.0
+opensearch-py==2.8.0
 gunicorn==20.1.0
 django==3.2.17
 psycopg2==2.9.4

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -1,4 +1,4 @@
-aiokafka==0.8.1
+aiokafka==0.8.0
 base32-crockford==0.3.0
 boto3==1.24.23
 coreapi==2.3.3


### PR DESCRIPTION
**[OSDEV-2083](https://opensupplyhub.atlassian.net/browse/OSDEV-2083) Update python and OpenSearch client versions**
- Updated Python version from `3.7` to `3.8` to support higher OpenSearch client version with necessary features.
- Added system dependencies: `libmemcached-dev`, `zlib1g-dev` to support building C-based packages like `pylibmc`.
- Package `pytz` upgraded from `2018.7` → `2023.3` to include up-to-date and stable timezone data.
- Package `requests` upgraded from `2.31.0` → `2.32.4` for improved security and compatibility.
- Package `opensearch-py` upgraded from `2.5.0` → `2.8.0` to enable hybrid search.




[OSDEV-2083]: https://opensupplyhub.atlassian.net/browse/OSDEV-2083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ