### PR TITLE
Enhanced the ./src/anon-tools/do_restore.sh script to use more precise filtering when looking up the bastion host

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -3,6 +3,39 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). The format is based on the `RELEASE-NOTES-TEMPLATE.md` file.
 
+## Release 2.11.0
+
+## Introduction
+* Product name: Open Supply Hub
+* Release date: August 23, 2025
+
+### Database changes
+* *Describe high-level database changes.*
+
+#### Migrations
+* *Describe migrations here.*
+
+#### Schema changes
+* *Describe schema changes here.*
+
+### Code/API changes
+* *Describe code/API changes here.*
+
+### Architecture/Environment changes
+* *Describe architecture/environment changes here.*
+
+### Bugfix
+* Enhanced the `./src/anon-tools/do_restore.sh` script to use more precise filtering when looking up the bastion host, improving reliability and reducing potential for incorrect host selection. The *bastion* filter now ensures that only an instance tagged with both the correct environment and the specific "Bastion" name is selected.
+
+### What's new
+* *Describe what's new here. The changes that can impact user experience should be listed in this section.*
+
+### Release instructions
+* Ensure that the following commands are included in the `post_deployment` command:
+    * `migrate`
+    * `reindex_database`
+
+
 ## Release 2.10.0
 
 ## Introduction

--- a/src/anon-tools/do_restore.sh
+++ b/src/anon-tools/do_restore.sh
@@ -3,7 +3,7 @@
 
 aws s3 cp s3://oshub-dumps-anonymized/osh_prod_large_anon.dump /dumps/osh_prod_large.dump
 
-bastion="$(aws ec2 describe-instances --filters "Name=tag:Environment,Values=$ENVIRONMENT" --query 'Reservations[0].Instances[0].PublicDnsName' --output text)"
+bastion="$(aws ec2 describe-instances --filters "Name=tag:Environment,Values=$ENVIRONMENT" "Name=tag:Name,Values=Bastion" --query 'Reservations[0].Instances[0].PublicDnsName' --output text)"
 
 echo "Bastion: $bastion"
 


### PR DESCRIPTION
Enhanced the `./src/anon-tools/do_restore.sh` script to use more precise filtering when looking up the bastion host, improving reliability and reducing potential for incorrect host selection. The *bastion* filter now ensures that only an instance tagged with both the correct environment and the specific "Bastion" name is selected.

_Note: The changes have been successfully tested in the RBA environment, where multiple EC2 instances are running._