### PR TITLE
Migrate to the BitnamiLegacy Kafka image

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
     * **Comprehensive Logging**: Detailed logging with configurable verbosity levels for monitoring and debugging.
 * [OSDEV-2073](https://opensupplyhub.atlassian.net/browse/OSDEV-2073) - Set up `AWS Batch` infrastructure for database synchronization, including compute environment, job queue, job definition, and `EFS` integration for persistent storage. Added required variables and RBA environment configuration to support secure database connectivity and reliable sync execution.
 * [OSDEV-2078](https://opensupplyhub.atlassian.net/browse/OSDEV-2078) - Setup AWS EventBridge to trigger database sync every day at 7:00 AM UTC.
+* Migrate to the `bitnamilegacy/kafka` image instead of `bitnami/kafka`, as Bitnami is deprecating support for non-hardened, Debian-based images in its free tier and will gradually remove these tags from the public catalog.
 
 ### Bugfix
 * Enhanced the `./src/anon-tools/do_restore.sh` script to use more precise filtering when looking up the bastion host, improving reliability and reducing potential for incorrect host selection. The *bastion* filter now ensures that only an instance tagged with both the correct environment and the specific "Bastion" name is selected.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,7 +113,7 @@ services:
       - proxynet
 
   kafka:
-    image: "bitnami/kafka:3.9.0"
+    image: "bitnamilegacy/kafka:3.9.0"
     ports:
       - "9092:9092"
     environment:


### PR DESCRIPTION
Migrate to the `bitnamilegacy/kafka` image instead of `bitnami/kafka`, as Bitnami is deprecating support for non-hardened, Debian-based images in its free tier and will gradually remove these tags from the public catalog.