### PR TITLE
[Bugfix][OSDEV-2137][OSDEV-2068] Fixed performance issue with /facilities and /facilities-downloads endpoints

### DIFF
--- a/src/django/api/serializers/facility/utils.py
+++ b/src/django/api/serializers/facility/utils.py
@@ -348,14 +348,30 @@ def add_http_prefix_to_url(value: str) -> str:
     return value
 
 
-def is_same_contributor_for_queryset(queryset: Iterable, request) -> bool:
+def is_same_contributor_for_queryset(queryset, request) -> bool:
+    contributor = getattr(request.user, 'contributor', None)
+    if not contributor:
+        return False
+    current_user_contributor_id = contributor.id
+
+    facilities_without_contributor_count = queryset.exclude(
+        contributors_id__contains=[current_user_contributor_id]
+    ).exists()
+    
+    if facilities_without_contributor_count:
+        return False
+    
+    return queryset.exists()
+
+
+def is_same_contributor_for_list(list, request) -> bool:
     contributor = getattr(request.user, 'contributor', None)
     if not contributor:
         return False
     current_user_contributor_id = contributor.id
 
     found_any_facility = False
-    for facility in queryset:
+    for facility in list:
         found_any_facility = True
         facility_contributor_ids = [
             contributor.get('id') for contributor in facility.contributors

--- a/src/django/api/services/facilities_download_service.py
+++ b/src/django/api/services/facilities_download_service.py
@@ -73,8 +73,8 @@ class FacilitiesDownloadService:
         )
 
     @staticmethod
-    def enforce_limits(qs, limit, is_first_page):
-        if not limit or not is_first_page:
+    def enforce_limits(count, limit):
+        if not limit:
             return
 
         allowed = limit.free_download_records + limit.paid_download_records
@@ -85,10 +85,7 @@ class FacilitiesDownloadService:
                 "for facility record downloads..."
             )
 
-        probe = list(
-            qs.order_by("id").values_list("id", flat=True)[:allowed + 1]
-        )
-        if len(probe) > allowed:
+        if count > allowed:
             raise ValidationError(
                 "Downloads are supported only for searches resulting in "
                 f"{allowed} facilities or less."

--- a/src/django/api/views/facility/facilities_view_set.py
+++ b/src/django/api/views/facility/facilities_view_set.py
@@ -90,7 +90,10 @@ from api.serializers import (
 from api.serializers.facility.facility_list_page_parameter_serializer \
     import FacilityListPageParameterSerializer
 from api.throttles import DataUploadThrottle
-from api.serializers.facility.utils import is_same_contributor_for_queryset
+from api.serializers.facility.utils import (
+    is_same_contributor_for_queryset,
+    is_same_contributor_for_list
+)
 
 from api.views.disabled_pagination_inspector import DisabledPaginationInspector
 
@@ -274,7 +277,7 @@ class FacilitiesViewSet(ListModelMixin,
                                                  context=context,
                                                  exclude_fields=exclude_fields)
 
-            is_same_contributor = is_same_contributor_for_queryset(
+            is_same_contributor = is_same_contributor_for_list(
                 page_queryset,
                 request
             )


### PR DESCRIPTION
[Bugfix] [OSDEV-2137](https://opensupplyhub.atlassian.net/browse/OSDEV-2137) & [OSDEV-2068](https://opensupplyhub.atlassian.net/browse/OSDEV-2068) **Fixed performance issue with /facilities and /facilities-downloads endpoints**

- Fixed issue with performance when get `is_same_contributor` from list or query set for `/facilities` and `/facilities-downloads` endpoints