### PR TITLE
[OSDEV-2164] Added search functionality for user email and contributor name in the Facility Download Limits admin page.

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -14,6 +14,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-2089](https://opensupplyhub.atlassian.net/browse/OSDEV-2089) - Added `geocoded_location_type` and `geocoded_address` fields to GET `/api/v1/production-locations/` and GET `/api/v1/production-locations/{os_id}/` endpoints.
 * [OSDEV-2068](https://opensupplyhub.atlassian.net/browse/OSDEV-2068) - Enabled users to download their own data without impacting free & purchased data-download allowances. Introduced `is_same_contributor` field in the GET `/api/facilities-downloads` response.
 
+### What's new
+* [OSDEV-2164](https://opensupplyhub.atlassian.net/browse/OSDEV-2164) - Added search functionality for user email and contributor name in the Facility Download Limits interface of the Django admin panel.
+
 ### Release instructions
 * Ensure that the following commands are included in the `post_deployment` command:
     * `migrate`

--- a/src/django/api/admin.py
+++ b/src/django/api/admin.py
@@ -180,7 +180,7 @@ class FacilityDownloadLimitAdmin(admin.ModelAdmin):
                     'updated_at',
                     'purchase_date',
                     )
-    search_fields = ('user__username',)
+    search_fields = ('user__email', 'user__contributor__name')
     autocomplete_fields = ('user',)
 
     def get_ordering(self, request):


### PR DESCRIPTION
This PR introduces search functionality on the Facility Download Limits page of the Django admin panel. Admins can now filter records by user email and contributor name, making it easier to locate and manage specific entries.