### PR TITLE
[OSDEV-2137] Fix incorrect next page for multiple query param in Facilities Download endpoint 

### DIFF
--- a/src/django/api/services/facilities_download_service.py
+++ b/src/django/api/services/facilities_download_service.py
@@ -244,14 +244,14 @@ class FacilitiesDownloadService:
         page_size: int,
         is_last_page: bool
     ):
-        base_qs_params = request.query_params.copy()
 
         def make_link(target_page):
-            query = base_qs_params.copy()
-            query['page'] = target_page
-            query['pageSize'] = page_size
+            query_dict = dict(request.query_params.lists())
+            query_dict['page'] = [str(target_page)]
+            query_dict['pageSize'] = [str(page_size)]
+
             return request.build_absolute_uri(
-                '?' + urlencode(query, doseq=True)
+                '?' + urlencode(query_dict, doseq=True)
             )
 
         next_link = None if is_last_page else make_link(page + 1)

--- a/src/django/api/tests/test_facilities_download_viewset.py
+++ b/src/django/api/tests/test_facilities_download_viewset.py
@@ -454,7 +454,12 @@ class FacilitiesDownloadViewSetTest(APITestCase):
         user = self.create_user()
         self.login_user(user)
 
-        response = self.get_facility_downloads({"countries": ["IN", "US"], "pageSize": 2})
+        response = self.get_facility_downloads(
+            {
+                "countries": ["IN", "US"],
+                "pageSize": 2
+            }
+        )
 
         expected_root = "http://testserver/api/facilities-downloads/"
         expected_query = "?countries=IN&countries=US&pageSize=2&page=2"

--- a/src/django/api/tests/test_facilities_download_viewset.py
+++ b/src/django/api/tests/test_facilities_download_viewset.py
@@ -450,6 +450,21 @@ class FacilitiesDownloadViewSetTest(APITestCase):
             expected_data
         )
 
+    def test_query_multi_param_next_page(self):
+        user = self.create_user()
+        self.login_user(user)
+
+        response = self.get_facility_downloads({"countries": ["IN", "US"], "pageSize": 2})
+
+        expected_root = "http://testserver/api/facilities-downloads/"
+        expected_query = "?countries=IN&countries=US&pageSize=2&page=2"
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data.get("next", ""),
+            expected_root + expected_query
+        )
+
     @patch(
         'api.constants.FacilitiesDownloadSettings.'
         'FREE_FACILITIES_DOWNLOAD_LIMIT',


### PR DESCRIPTION
**[OSDEV-2137](https://opensupplyhub.atlassian.net/browse/OSDEV-2137) Fix incorrect next page for multiple query param in Facilities Download endpoint**

- Fix for multiple values for filter params like countries when build next or previous page
- Added unit tests

[OSDEV-2137]: https://opensupplyhub.atlassian.net/browse/OSDEV-2137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ