### PR TITLE
[Quickfix-v.2.12][OSDEV-2077] Disabled RBA sync script trigger via db_sync_enabled TF variable

### DIFF
--- a/deployment/environments/terraform-rba.tfvars
+++ b/deployment/environments/terraform-rba.tfvars
@@ -76,6 +76,6 @@ instance_source = "rba"
 
 vpn_ec2_ami = "ami-0940c95b23a1f7cac"
 
-db_sync_enabled                   = true
+db_sync_enabled                   = false
 db_sync_schedule_expression       = "cron(0 7 * * ? *)" # (7:00 AM UTC)
 is_database_private_link_consumer = true

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -21,6 +21,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-2068](https://opensupplyhub.atlassian.net/browse/OSDEV-2068) - Enabled users to download their own data without impacting free & purchased data-download allowances. Introduced `is_same_contributor` field in the GET `/api/facilities-downloads` response.
 * [OSDEV-2122](https://opensupplyhub.atlassian.net/browse/OSDEV-2122) - Enhanced PATCH `/api/v1/production-locations/{os_id}/` endpoint validation to enforce required field constraints when coordinates are provided. Implemented automatic backfill of missing required fields (name, address, country) from existing facility data when no required fields are provided in PATCH requests.
 
+### Architecture/Environment changes
+* [Follow-up][OSDEV-2077](https://opensupplyhub.atlassian.net/browse/OSDEV-2077) - Disabled the RBA synchronization script trigger via the `db_sync_enabled` Terraform variable due to the temporary unnecessity of synchronization.
+
 ### What's new
 * [OSDEV-2164](https://opensupplyhub.atlassian.net/browse/OSDEV-2164) - Added search functionality for user email and contributor name in the Facility Download Limits admin page.
 * [OSDEV-2044](https://opensupplyhub.atlassian.net/browse/OSDEV-2044) - Added additional certifications to `Certifications/Standards/Regulations` on `Claim Profile`.


### PR DESCRIPTION
[Follow-up] [OSDEV-2077](https://opensupplyhub.atlassian.net/browse/OSDEV-2077) - Disabled the RBA synchronization script trigger via the `db_sync_enabled` Terraform variable due to the temporary unnecessity of synchronization.

[OSDEV-2077]: https://opensupplyhub.atlassian.net/browse/OSDEV-2077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ