### PR TITLE
Increase DedupeHub fargate memory allocation for prod and pre-prod fron 16 GB to 30 GB

### DIFF
--- a/deployment/environments/terraform-preprod.tfvars
+++ b/deployment/environments/terraform-preprod.tfvars
@@ -61,7 +61,7 @@ dedupe_hub_name = "deduplicate"
 dedupe_hub_version = 1
 app_cc_ecs_desired_count = 0
 app_dd_fargate_cpu = 4096
-app_dd_fargate_memory = 16384
+app_dd_fargate_memory = 30720
 app_dd_ecs_desired_count = 1
 
 opensearch_instance_type = "m6g.large.search"

--- a/deployment/environments/terraform-production.tfvars
+++ b/deployment/environments/terraform-production.tfvars
@@ -58,7 +58,7 @@ dedupe_hub_name               = "deduplicate"
 dedupe_hub_version            = 1
 app_cc_ecs_desired_count      = 0
 app_dd_fargate_cpu            = 4096
-app_dd_fargate_memory         = 16384
+app_dd_fargate_memory         = 30720
 app_dd_ecs_desired_count      = 1
 django_log_level              = "DEBUG"
 

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -15,6 +15,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * 0179_introduce_enable_v1_claims_flow.py - This migration introduces a new `enable_v1_claims_flow` feature flag that allows switching to the v1 claims flow.
 * 0180_add_unit_to_partner_field.py - This migration added new field `unit` to `PartnerField` model.
 
+### Architecture/Environment changes
+* [OSDEV-2054](https://opensupplyhub.atlassian.net/browse/OSDEV-2054) - Increased the memory allocation for the `DedupeHub` container from `16GB` to `30GB` in terraform deployment configuration to address memory overload issues during facility reindexing for `Production` & `Pre-Production` environments.
+
 ### What's new
 * [OSDEV-2176](https://opensupplyhub.atlassian.net/browse/OSDEV-2176) - Added feature flag for v1 claims flow.
 * [OSDEV-2065](https://opensupplyhub.atlassian.net/browse/OSDEV-2065) - Updated v1 production locations `POST/PATCH` endpoints to include partner fields:


### PR DESCRIPTION
Pre-release `v.2.13.0` fix [OSDEV-2054](https://opensupplyhub.atlassian.net/browse/OSDEV-2054)

Increased the memory allocation for the `DedupeHub` container from `16GB` to `30GB` in terraform deployment configuration to address memory overload issues during facility reindexing for `Production` & `Pre-Production` environments.

[OSDEV-2054]: https://opensupplyhub.atlassian.net/browse/OSDEV-2054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ