### PR TITLE
[OSDEV-2180] Update Production Location Profile page to display dynamic partner field

### DIFF
--- a/src/django/api/models/extended_field.py
+++ b/src/django/api/models/extended_field.py
@@ -22,8 +22,6 @@ class ExtendedField(models.Model):
     DUNS_ID = 'duns_id'
     LEI_ID = 'lei_id'
     RBA_ID = 'rba_id'
-    ESTIMATED_EMISSIONS_ACTIVITY = 'estimated_emissions_activity'
-    ESTIMATED_ANNUAL_ENERGY_CONSUMPTION = 'estimated_annual_energy_consumption'
 
     FIELD_CHOICES = (
         (NAME, NAME),
@@ -37,15 +35,7 @@ class ExtendedField(models.Model):
         (PARENT_COMPANY_OS_ID, PARENT_COMPANY_OS_ID),
         (DUNS_ID, DUNS_ID),
         (LEI_ID, LEI_ID),
-        (RBA_ID, RBA_ID),
-        (
-            ESTIMATED_EMISSIONS_ACTIVITY,
-            ESTIMATED_EMISSIONS_ACTIVITY
-        ),
-        (
-            ESTIMATED_ANNUAL_ENERGY_CONSUMPTION,
-            ESTIMATED_ANNUAL_ENERGY_CONSUMPTION
-        )
+        (RBA_ID, RBA_ID)
     )
 
     uuid = models.UUIDField(

--- a/src/django/api/serializers/facility/facility_index_details_serializer.py
+++ b/src/django/api/serializers/facility/facility_index_details_serializer.py
@@ -37,6 +37,7 @@ class FacilityIndexDetailsSerializer(FacilityIndexSerializer):
     created_from = SerializerMethodField()
     sector = SerializerMethodField()
     is_claimed = SerializerMethodField()
+    partner_fields = SerializerMethodField()
 
     class Meta:
         model = FacilityIndex
@@ -62,6 +63,7 @@ class FacilityIndexDetailsSerializer(FacilityIndexSerializer):
             'created_from',
             'sector',
             'is_claimed',
+            'partner_fields',
         )
         geo_field = 'location'
 

--- a/src/react/src/util/constants.jsx
+++ b/src/react/src/util/constants.jsx
@@ -1123,16 +1123,6 @@ export const EXTENDED_FIELD_TYPES = [
         fieldName: 'parent_company_os_id',
         formatValue: value => value.raw_values,
     },
-    {
-        label: 'Estimated Emissions Activity',
-        fieldName: 'estimated_emissions_activity',
-        formatValue: value => value.raw_value,
-    },
-    {
-        label: 'Estimated Annual Energy Consumption',
-        fieldName: 'estimated_annual_energy_consumption',
-        formatValue: value => value.raw_value,
-    },
 ];
 
 export const ADDITIONAL_IDENTIFIERS = Object.freeze([

--- a/src/react/src/util/util.js
+++ b/src/react/src/util/util.js
@@ -1761,3 +1761,16 @@ export const processDromoResults = (
         updateFileName(fileInput);
     }
 };
+
+export const formatPartnerFieldValue = value => {
+    if (value.raw_values !== undefined) {
+        if (Array.isArray(value.raw_values)) {
+            return value.raw_values;
+        }
+        return value.raw_values.toString().split('|');
+    }
+    if (value.raw_value !== undefined) {
+        return value.raw_value;
+    }
+    return value;
+};


### PR DESCRIPTION
**[OSDEV-2180](https://opensupplyhub.atlassian.net/browse/OSDEV-2180) Update Production Location Profile page to display dynamic partner field**
- Introduces logic to return `partner_fields` for both `/facilities/os_id` and `/facilities/` endpoints.
- Also implements dynamic rendering of any partner fields returned by the API, ensuring that new or custom fields are displayed automatically without additional frontend or backend updates.