### PR TITLE
[Backmerge][OSDEV-2064] - Add strict date format for closed_at and op…

### DIFF
--- a/src/logstash/indexes/production_locations.json
+++ b/src/logstash/indexes/production_locations.json
@@ -220,10 +220,12 @@
           "type": "keyword"
         },
         "opened_at": {
-          "type": "date"
+          "type": "date",
+          "format": "yyyy"
         },
         "closed_at": {
-          "type": "date"
+          "type": "date",
+          "format": "yyyy-MM"
         },
         "estimated_annual_throughput": {
           "type": "float"

--- a/src/logstash/scripts/production_locations/closed_at.rb
+++ b/src/logstash/scripts/production_locations/closed_at.rb
@@ -1,29 +1,10 @@
+require_relative 'date_filter_helpers'
+
 def filter(event)
-  closed_at_value = event.get('closed_at_value')
-
-  if closed_at_value.nil?
-      return [event]
-  end
-
-  event.set('closed_at', closed_at_value)
-
-  return [event]
+  # Normalize to YYYY-MM format.
+  # Accepts values like '2023-12-01' or ISO8601 '2023-12-01T10:30:00Z'.
+  normalize_date_field(event, 'closed_at_value', 'closed_at', '%Y-%m')
+  [event]
 end
 
-test 'closed_at filter with valid value' do
-  in_event { { 'closed_at_value' => '2023-12-01T10:30:00Z' } }
-
-  expect('sets closed_at field with the provided value') do |events|
-      events.size == 1 &&
-      events[0].get('closed_at') == '2023-12-01T10:30:00Z'
-  end
-end
-
-test 'closed_at filter with nil value' do
-  in_event { { 'closed_at_value' => nil } }
-
-  expect('does not set closed_at field when value is nil') do |events|
-      events.size == 1 &&
-      !events[0].to_hash.key?('closed_at')
-  end
-end
+define_date_filter_tests('closed_at_value', 'closed_at', '2023-12')

--- a/src/logstash/scripts/production_locations/date_filter_helpers.rb
+++ b/src/logstash/scripts/production_locations/date_filter_helpers.rb
@@ -1,0 +1,67 @@
+# Shared helper for normalizing date fields in Logstash filters.
+#
+# @param event [LogStash::Event] The event object to modify
+# @param source_key [String] The key to read the date value from
+# @param target_key [String] The key to write the normalized date to
+# @param format [String] The strftime format string (e.g., '%Y-%m', '%Y')
+# @return [void]
+def normalize_date_field(event, source_key, target_key, format)
+  value = event.get(source_key)
+  return if value.nil?
+
+  begin
+    t = Time.parse(value.to_s)
+    event.set(target_key, t.strftime(format))
+  rescue StandardError => error
+    # Log parse failure and set to nil to avoid OpenSearch format mismatch.
+    if defined?(@logger) && @logger
+      @logger.warn("Failed to parse #{source_key}: '#{value}'. Error: #{error.message}")
+    end
+    event.set(target_key, nil)
+  end
+end
+
+# Generates standard test cases for date filter fields.
+#
+# @param source_key [String] The key to read the date value from
+# @param target_key [String] The key to write the normalized date to
+# @param expected_format [String] The expected output format (e.g., '2023-12', '2023')
+# @return [void]
+def define_date_filter_tests(source_key, target_key, expected_format)
+  test "#{target_key} filter with ISO datetime value" do
+    in_event { { source_key => '2023-12-01T10:30:00Z' } }
+
+    expect("sets #{target_key} field to normalized date") do |events|
+        events.size == 1 &&
+        events[0].get(target_key) == expected_format
+    end
+  end
+
+  test "#{target_key} filter with date string" do
+    in_event { { source_key => '2023-12-01' } }
+
+    expect("normalizes #{target_key} field") do |events|
+        events.size == 1 &&
+        events[0].get(target_key) == expected_format
+    end
+  end
+
+  test "#{target_key} filter with nil value" do
+    in_event { { source_key => nil } }
+
+    expect("does not set #{target_key} field when value is nil") do |events|
+        events.size == 1 &&
+        !events[0].to_hash.key?(target_key)
+    end
+  end
+
+  test "#{target_key} filter with invalid date string" do
+    in_event { { source_key => 'invalid-date' } }
+
+    expect("sets #{target_key} to nil and logs parse error") do |events|
+        events.size == 1 &&
+        events[0].get(target_key).nil?
+    end
+  end
+end
+

--- a/src/logstash/scripts/production_locations/opened_at.rb
+++ b/src/logstash/scripts/production_locations/opened_at.rb
@@ -1,29 +1,10 @@
+require_relative 'date_filter_helpers'
+
 def filter(event)
-  opened_at_value = event.get('opened_at_value')
-
-  if opened_at_value.nil?
-      return [event]
-  end
-
-  event.set('opened_at', opened_at_value)
-
-  return [event]
+  # Normalize to YYYY format.
+  # Accepts values like '2023-12-01' or ISO8601 '2023-12-01T10:30:00Z'.
+  normalize_date_field(event, 'opened_at_value', 'opened_at', '%Y')
+  [event]
 end
 
-test 'opened_at filter with valid value' do
-  in_event { { 'opened_at_value' => '2023-12-01T10:30:00Z' } }
-
-  expect('sets opened_at field with the provided value') do |events|
-      events.size == 1 &&
-      events[0].get('opened_at') == '2023-12-01T10:30:00Z'
-  end
-end
-
-test 'opened_at filter with nil value' do
-  in_event { { 'opened_at_value' => nil } }
-
-  expect('does not set opened_at field when value is nil') do |events|
-      events.size == 1 &&
-      !events[0].to_hash.key?('opened_at')
-  end
-end
+define_date_filter_tests('opened_at_value', 'opened_at', '2023')

--- a/src/tests/v1/test_production_locations.py
+++ b/src/tests/v1/test_production_locations.py
@@ -365,7 +365,7 @@ class ProductionLocationsTest(BaseAPITest):
             "claim_status": "claimed",
             "claimed_at": "2023-06-15T10:30:00Z"
         }
-        
+
         unclaimed_doc = {
             "sector": ["Apparel"],
             "address": "Unclaimed Facility Address",
@@ -375,7 +375,7 @@ class ProductionLocationsTest(BaseAPITest):
             "coordinates": {"lon": -79.3832, "lat": 43.6532},
             "claim_status": "unclaimed"
         }
-        
+
         pending_doc = {
             "sector": ["Apparel"],
             "address": "Pending Facility Address",
@@ -436,7 +436,7 @@ class ProductionLocationsTest(BaseAPITest):
             "claim_status": "claimed",
             "claimed_at": "2023-01-15T10:30:00Z"
         }
-        
+
         late_claimed_doc = {
             "sector": ["Apparel"],
             "address": "Late Claimed Facility",
@@ -802,8 +802,8 @@ class ProductionLocationsTest(BaseAPITest):
             "address": "Details Address",
             "country": {"alpha_2": "US"},
             "coordinates": {"lon": -74.0, "lat": 40.7},
-            "opened_at": "2024-03-01T00:00:00.000Z",
-            "closed_at": "2025-09-01T00:00:00.000Z",
+            "opened_at": "2023",
+            "closed_at": "2024-09",
             "estimated_annual_throughput": 122,
             "actual_annual_energy_consumption": [
                 {"amount": 111, "source": "Coal"},
@@ -835,8 +835,8 @@ class ProductionLocationsTest(BaseAPITest):
         self.assertEqual(response.status_code, 200)
         result = response.json()
         self.assertEqual(result["os_id"], os_id)
-        self.assertEqual(result["opened_at"], "2024-03-01T00:00:00.000Z")
-        self.assertEqual(result["closed_at"], "2025-09-01T00:00:00.000Z")
+        self.assertEqual(result["opened_at"], "2023")
+        self.assertEqual(result["closed_at"], "2024-09")
         self.assertEqual(result["estimated_annual_throughput"], 122)
         self.assertEqual(
             result["actual_annual_energy_consumption"],
@@ -861,8 +861,8 @@ class ProductionLocationsTest(BaseAPITest):
             "address": "Details Address 2",
             "country": {"alpha_2": "US"},
             "coordinates": {"lon": -73.9, "lat": 40.8},
-            "opened_at": "2024-03-01T00:00:00.000Z",
-            "closed_at": "2025-09-01T00:00:00.000Z",
+            "opened_at": "2024",
+            "closed_at": "2025-10",
             "estimated_annual_throughput": 122,
             "actual_annual_energy_consumption": [
                 {"amount": 111, "source": "Coal"},


### PR DESCRIPTION
…ened_at claim fields (#773)

Backmerge fix for
[OSDEV-2064](https://opensupplyhub.atlassian.net/browse/OSDEV-2064)

### 1. **opened_at.rb** - Reformatted to YYYY (Year only)
- Updated the filter to use `strftime('%Y')` instead of `strftime('%Y-%m-%d')`
- Updated all test cases to expect format `"2023"` instead of `"2023-12-01"`
   - Updated comments to reflect "year format (YYYY)"

### 2. **closed_at.rb** - Reformatted to YYYY-MM (Year-Month)
- Updated the filter to use `strftime('%Y-%m')` instead of `strftime('%Y-%m-%d')`
- Updated all test cases to expect format `"2023-12"` instead of `"2023-12-01"`
   - Updated comments to reflect "year-month format (YYYY-MM)"

### 3. **production_locations.json** - Updated OpenSearch Index Mappings
- Changed `opened_at` format from `"strict_date"` to `"yyyy"` to accept year-only format
- Changed `closed_at` format from `"strict_date"` to `"yyyy-MM"` to accept year-month format

[OSDEV-2064]:
https://opensupplyhub.atlassian.net/browse/OSDEV-2064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OSDEV-2064]: https://opensupplyhub.atlassian.net/browse/OSDEV-2064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OSDEV-2064]: https://opensupplyhub.atlassian.net/browse/OSDEV-2064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ