### PR TITLE
[OSDEV-2218] Fix sector dropdown to use validated Sector model instead of user-generated text

### DIFF
--- a/src/django/api/views/sectors.py
+++ b/src/django/api/views/sectors.py
@@ -1,11 +1,11 @@
-from django.db.models import F, Func
+from django.db.models import Func
 
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.decorators import api_view, throttle_classes
 from rest_framework.response import Response
 
 from api.constants import FacilityClaimStatuses
-from api.models.facility.facility_index import FacilityIndex
+from api.models.sector import Sector
 from api.models.sector_group import SectorGroup
 from api.views.sectors_swagger_schema import (
     sectors_manual_parameters,
@@ -84,12 +84,12 @@ def get_claim_sectors(contributor):
 
 
 def get_all_submitted_sectors():
+    """
+    Get all valid sectors from the Sector model.
+    This ensures only admin-managed, validated sectors are returned.
+    """
     return set(
-        FacilityIndex.objects.annotate(
-            all_sectors=Func(F('sector'), function='unnest')
-        )
-        .values_list('all_sectors', flat=True)
-        .distinct()
+        Sector.objects.values_list('name', flat=True)
     )
 
 


### PR DESCRIPTION
## Summary
Fixes the sector dropdown in the facility claims workflow to use only validated sectors from the master `Sector` model instead of including user-generated freeform text.

## Problem
The `/api/sectors/` endpoint was pulling from `FacilityIndex.sector` which aggregates data from both:
- ✅ `FacilityListItem.sector` - validated against the Sector model during upload
- ❌ `FacilityClaim.sector` - NOT validated - accepts any freeform text

This caused the sector dropdown to show invalid entries, product types, and other user-generated text mixed with valid sectors.

## Solution
Changed `get_all_submitted_sectors()` in `src/django/api/views/sectors.py` to query the `Sector` model directly:
```python
def get_all_submitted_sectors():
    return set(
        Sector.objects.values_list('name', flat=True)
    )
```

## Changes
- Updated `get_all_submitted_sectors()` to query `Sector` model instead of `FacilityIndex`
- Added docstring explaining the change
- Cleaned up unused imports (`FacilityIndex`, `F` from django.db.models)

## Impact
- Sector dropdown in claims workflow now shows only admin-managed, validated sectors
- Users will see a consistent, controlled list of sector options
- No more product types or freeform text in the sector dropdown

## Related Issue
https://opensupplyhub.atlassian.net/browse/OSDEV-2218

🤖 Generated with [Claude Code](https://claude.com/claude-code)