### PR TITLE
[OSDEV-2250] Integrated enable_v1_claims_flow feature flag in email claim URLs

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -54,7 +54,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   - Integrated emissions estimation fields allowing claimants to provide energy consumption data by source type, facility opening/closing dates, and estimated annual throughput.
   - Added Beta labels with tooltips to premium fields (Company Phone, Production Location Description, Minimum Order Quantity, Average Lead Time, Affiliations, and Certifications) to indicate future Premium offering features.
   - Implemented form submission functionality with success dialog popup showing "View My Approved Claims" and "Search OS Hub" action buttons upon successful claim submission.
-* [OSDEV-2213](https://opensupplyhub.atlassian.net/browse/OSDEV-2213) - Implemented dynamic claim flow link switching based on the `enable_v1_claims_flow` feature flag. When enabled by an admin, all claim-related links and CTAs throughout the platform automatically redirect to the new claim flow intro page (`/claim/{os_id}/`) instead of the old claim flow.
+* [OSDEV-2213](https://opensupplyhub.atlassian.net/browse/OSDEV-2213) - Implemented dynamic claim flow link switching based on the `enable_v1_claims_flow` feature flag. When enabled by an admin, all claim-related links and CTAs throughout the platform and in emails automatically redirect to the new claim flow intro page (`/claim/{os_id}/`) instead of the old claim flow.
 
 ### Release instructions
 * Ensure that the following commands are included in the `post_deployment` command:

--- a/src/django/api/mail.py
+++ b/src/django/api/mail.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from django.core.mail import send_mail
 from django.conf import settings
 from django.template.loader import get_template
+from waffle import switch_is_active
 from api.models import (
     FacilityList,
     FacilityClaim,
@@ -37,12 +38,13 @@ def make_facility_list_url(request, list_id):
     return '{}/lists/{}'.format(make_oshub_url(request), list_id)
 
 
-def make_claimed_url(request):
-    return '{}/claimed'.format(make_oshub_url(request))
-
-
 def make_claim_url(request: Request, location: Facility):
-    return '{}/claim'.format(make_facility_url(request, location))
+    if switch_is_active('enable_v1_claims_flow'):
+        # New claim flow: /claim/{os_id}.
+        return '{}/claim/{}'.format(make_oshub_url(request), location.id)
+    else:
+        # Old claim flow: /facilities/{os_id}/claim.
+        return '{}/claim'.format(make_facility_url(request, location))
 
 
 def make_pl_search_url(request):


### PR DESCRIPTION
[OSDEV-2250](https://opensupplyhub.atlassian.net/browse/OSDEV-2250)
1. Updated the `make_claim_url` function in `mail.py` to dynamically generate claim URLs based on the `enable_v1_claims_flow` feature flag. When the flag is enabled, emails will contain the new v1 claim flow URL format (`/claim/{os_id}`), and when disabled, they will use the legacy format (`/facilities/{os_id}/claim`).
2. This change ensures that all claim-related emails will direct users to the correct claim interface matching the feature flag state, maintaining consistency between the frontend routing and backend-generated email links.

[OSDEV-2250]: https://opensupplyhub.atlassian.net/browse/OSDEV-2250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ