### PR TITLE
[Backmerge][OSDEV-2262] Prevent claim form submit on Enter keypress when Submit Claim button is not focused

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -57,6 +57,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-2213](https://opensupplyhub.atlassian.net/browse/OSDEV-2213) - Implemented dynamic claim flow link switching based on the `enable_v1_claims_flow` feature flag. When enabled by an admin, all claim-related links and CTAs throughout the platform and in emails automatically redirect to the new claim flow intro page (`/claim/{os_id}/`) instead of the old claim flow.
 * [OSDEV-2251](https://opensupplyhub.atlassian.net/browse/OSDEV-2251) - Added the `EmailAddress` model to the Django admin panel, allowing administrators to manage user email records directly. This ensures consistency between the `User` and `EmailAddress` tables when updating user email addresses.
 
+### Bugfix
+* [OSDEV-2262](https://opensupplyhub.atlassian.net/browse/OSDEV-2262): Prevented unintended submission of the last-step claim form when pressing Enter in an input while the Submit button is not focused. Updated `src/react/src/components/InitialClaimFlow/ClaimForm/ClaimForm.jsx` to remove implicit form submission and trigger Formik submission explicitly via the Submit button, aligning with Material UI semantics.
+
 ### Release instructions
 * Ensure that the following commands are included in the `post_deployment` command:
     * `migrate`

--- a/src/react/src/components/InitialClaimFlow/ClaimForm/ClaimForm.jsx
+++ b/src/react/src/components/InitialClaimFlow/ClaimForm/ClaimForm.jsx
@@ -270,10 +270,7 @@ const ClaimForm = ({
                 onStepClick={setStep}
             />
             <div className={classes.innerContainer}>
-                <form
-                    onSubmit={claimForm.handleSubmit}
-                    className={classes.form}
-                >
+                <form className={classes.form}>
                     <Paper className={classes.paper}>
                         <Typography
                             variant="title"
@@ -349,7 +346,8 @@ const ClaimForm = ({
                                 {isLastStep(activeStep) && (
                                     <Button
                                         variant="contained"
-                                        type="submit"
+                                        type="button"
+                                        onClick={claimForm.handleSubmit}
                                         className={classes.buttonPrimary}
                                         disabled={
                                             isButtonDisabled ||


### PR DESCRIPTION
Backmerge of https://github.com/opensupplyhub/open-supply-hub/pull/800

Prevented unintended submission of the last-step claim form when pressing Enter in an input while the Submit button is not focused. Updated `src/react/src/components/InitialClaimFlow/ClaimForm/ClaimForm.jsx` to remove implicit form submission and trigger Formik submission explicitly via the Submit button, aligning with Material UI semantics.