### PR TITLE
[Bugfix] [OSDEV-2284] Logstash fix for java heap space error

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -20,6 +20,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Architecture/Environment changes
 * [OSDEV-2244](https://opensupplyhub.atlassian.net/browse/OSDEV-2244) - Added `backfill_isic_4_extended_fields.py` to insert `isic_4` to `api_extendedfield` table of RBA instance. Show `isic_4` field in `GET api/facilities` response.
 
+### Bugfix
+* [OSDEV-2284](https://opensupplyhub.atlassian.net/browse/OSDEV-2284) - Temporarily increase heap size for logstash plugin installation.
+
 ### What's new
 * [OSDEV-2112](https://opensupplyhub.atlassian.net/browse/OSDEV-2112) - Moved "Recruitment Agency" (previously classified as a location type) under the "Office / HQ" location type as a processing type. Also introduced a new processing type, "Union Headquarters/Office", under the "Office / HQ" location type. This update affects both search and newly contributed data: from now on, "Union Headquarters/Office" and "Recruitment Agency" will appear under the "Office / HQ" location type when displayed in search dropdowns or shown on location profiles for **newly** added locations.
 * [OSDEV-2244](https://opensupplyhub.atlassian.net/browse/OSDEV-2244) - Implemented frontend formatting for the ISIC 4 extended field to display Section, Division, Group, and Class as separate labeled entries, building the full ISIC 4 hierarchy on production location profile pages.

--- a/src/logstash/Dockerfile
+++ b/src/logstash/Dockerfile
@@ -1,7 +1,7 @@
 FROM logstash:8.15.3
 
 # Install a specific version of the OpenSearch output plugin for Logstash.
-# Temporarily increase heap size for plugin installation
+# Temporarily increase heap size for plugin installation.
 RUN LS_JAVA_OPTS="-Xmx2g" bin/logstash-plugin install --version 2.0.2 logstash-output-opensearch
 
 ENV LS_JAVA_OPTS="-XX:MaxDirectMemorySize=512m"


### PR DESCRIPTION
**[Bugfix] [OSDEV-2284](https://opensupplyhub.atlassian.net/browse/OSDEV-2284) Logstash fix for java heap space error**

- Temporarily increase heap size for logstash plugin installation.

[OSDEV-2284]: https://opensupplyhub.atlassian.net/browse/OSDEV-2284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ