### PR TITLE
[OSDEV-2318] Bump Terraform version to 1.13.3

### DIFF
--- a/.github/workflows/deploy_to_aws.yml
+++ b/.github/workflows/deploy_to_aws.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.5.0
+          terraform_version: 1.13.3
           terraform_wrapper: false
 
       - name: Validate whitelist and denylist usage
@@ -191,7 +191,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.5.0
+          terraform_version: 1.13.3
           terraform_wrapper: false
 
       - name: Checkout

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.5.0
+          terraform_version: 1.13.3
           terraform_wrapper: false
 
       - name: Terraform destroy for ${{ vars.ENV_NAME }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/
 *.tfstate
 *.tfstate.backup
 .terraform.lock*
+deployment/environments/ci-deployment/*.tfvars
 
 
 # Ansible


### PR DESCRIPTION
Folllow-up fix for: [OSDEV-2318](https://opensupplyhub.atlassian.net/browse/OSDEV-2318)
Bump Terraform version from `1.5` to `1.13.3`

[OSDEV-2318]: https://opensupplyhub.atlassian.net/browse/OSDEV-2318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ