### PR TITLE
[OSDEV-2294] Show only unique entries of isic 4 contribution

### DIFF
--- a/src/react/src/__tests__/components/FacilityDetailsGeneralFields.test.js
+++ b/src/react/src/__tests__/components/FacilityDetailsGeneralFields.test.js
@@ -310,6 +310,80 @@ describe('FacilityDetailsGeneralFields component', () => {
         expect(dividers.length).toBeGreaterThanOrEqual(1);
     });
 
+    test('deduplicates repeated ISIC 4 entries from the same contribution', () => {
+        const duplicateIsicData = {
+            ...mockData,
+            properties: {
+                ...mockData.properties,
+                extended_fields: {
+                    ...mockData.properties.extended_fields,
+                    isic_4: [
+                        {
+                            id: 90002,
+                            is_verified: false,
+                            value: {
+                                raw_value: [
+                                    {
+                                        section:
+                                            'J - Information and communication',
+                                        division:
+                                            '62 - Computer programming, consultancy and related activities',
+                                        group:
+                                            '62 - Computer programming, consultancy and related activities',
+                                        class:
+                                            '620 - Computer programming, consultancy and related activities',
+                                    },
+                                    {
+                                        section:
+                                            'J - Information and communication',
+                                        division:
+                                            '62 - Computer programming, consultancy and related activities',
+                                        group:
+                                            '62 - Computer programming, consultancy and related activities',
+                                        class:
+                                            '620 - Computer programming, consultancy and related activities',
+                                    },
+                                    {
+                                        section:
+                                            'G - Wholesale and retail trade; repair of motor vehicles and motorcycles',
+                                        division:
+                                            '47 - Retail trade, except motor vehicles and motorcycles',
+                                        group:
+                                            '47 - Retail trade, except motor vehicles and motorcycles',
+                                        class:
+                                            '471 - Retail sale in non-specialized stores with food, beverages or tobacco predominating',
+                                    },
+                                ],
+                            },
+                            created_at: '2025-05-01T10:49:15.174025Z',
+                            updated_at: '2025-05-01T10:58:25.043413Z',
+                            contributor_name: 'Test Org',
+                            contributor_id: 1139,
+                            value_count: 1,
+                            is_from_claim: false,
+                            field_name: 'isic_4',
+                            verified_count: 0,
+                        },
+                    ],
+                },
+            },
+        };
+
+        const { getAllByRole, getAllByText } = renderComponent({
+            data: duplicateIsicData,
+        });
+
+        expect(
+            getAllByText('Section: J - Information and communication').length,
+        ).toBe(1);
+        expect(
+            getAllByText(
+                'Section: G - Wholesale and retail trade; repair of motor vehicles and motorcycles',
+            ).length,
+        ).toBe(1);
+        expect(getAllByRole('separator').length).toBe(1);
+    });
+
     test('renders only non-additional identifier extended fields when the show_additional_identifiers feature flag is false', () => {
         const preloadedState = {
             featureFlags: {

--- a/src/react/src/util/constants.jsx
+++ b/src/react/src/util/constants.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import ArrowUpwardIcon from '@material-ui/icons/ArrowUpward';
 import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
+import uniqWith from 'lodash/uniqWith';
+import isEqual from 'lodash/isEqual';
 import COLOURS from './COLOURS';
 import { CONTRIBUTION_DATA_DIVIDER } from './renderUtils';
 
@@ -1135,7 +1137,9 @@ export const EXTENDED_FIELD_TYPES = [
             const rawValue = value?.raw_value ?? value ?? {};
             const entries = Array.isArray(rawValue) ? rawValue : [rawValue];
 
-            return entries.reduce((acc, entry) => {
+            const dedupedEntries = uniqWith(entries, isEqual);
+
+            return dedupedEntries.reduce((acc, entry) => {
                 const { section, division, group, class: isicClass } =
                     entry || {};
                 const lines = [


### PR DESCRIPTION
Fix [OSDEV-2294](https://opensupplyhub.atlassian.net/browse/OSDEV-2294)
Show only unique entries of `isic 4` contribution on the FE (if BE contains duplicates, keep them).

[OSDEV-2294]: https://opensupplyhub.atlassian.net/browse/OSDEV-2294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ