### PR TITLE
[OSDEV-2328] Make cache behavior stricter for api/facilities/

### DIFF
--- a/deployment/environments/terraform-preprod.tfvars
+++ b/deployment/environments/terraform-preprod.tfvars
@@ -10,10 +10,10 @@ r53_public_hosted_zone = "os-hub.net"
 
 cloudfront_price_class = "PriceClass_All"
 
-api_facilities_cache_default_ttl           = 1800
-api_facilities_cache_max_ttl               = 1800
-api_production_locations_cache_default_ttl = 1800
-api_production_locations_cache_max_ttl     = 1800
+api_facilities_cache_default_ttl           = 120
+api_facilities_cache_max_ttl               = 120
+api_production_locations_cache_default_ttl = 120
+api_production_locations_cache_max_ttl     = 120
 
 bastion_ami = "ami-0bb3fad3c0286ebd5"
 bastion_instance_type = "t3.nano"

--- a/deployment/environments/terraform-production.tfvars
+++ b/deployment/environments/terraform-production.tfvars
@@ -9,10 +9,10 @@ r53_public_hosted_zone  = "opensupplyhub.org"
 
 cloudfront_price_class = "PriceClass_All"
 
-api_facilities_cache_default_ttl           = 1800
-api_facilities_cache_max_ttl               = 1800
-api_production_locations_cache_default_ttl = 1800
-api_production_locations_cache_max_ttl     = 1800
+api_facilities_cache_default_ttl           = 120
+api_facilities_cache_max_ttl               = 120
+api_production_locations_cache_default_ttl = 120
+api_production_locations_cache_max_ttl     = 120
 
 bastion_ami           = "ami-0bb3fad3c0286ebd5"
 bastion_instance_type = "t3.nano"

--- a/deployment/environments/terraform-rba.tfvars
+++ b/deployment/environments/terraform-rba.tfvars
@@ -9,10 +9,10 @@ r53_public_hosted_zone  = "opensupplyhub.org"
 
 cloudfront_price_class = "PriceClass_All"
 
-api_facilities_cache_default_ttl           = 1800
-api_facilities_cache_max_ttl               = 1800
-api_production_locations_cache_default_ttl = 1800
-api_production_locations_cache_max_ttl     = 1800
+api_facilities_cache_default_ttl           = 120
+api_facilities_cache_max_ttl               = 120
+api_production_locations_cache_default_ttl = 120
+api_production_locations_cache_max_ttl     = 120
 
 bastion_ami           = "ami-0bb3fad3c0286ebd5"
 bastion_instance_type = "t3.nano"

--- a/deployment/environments/terraform-staging.tfvars
+++ b/deployment/environments/terraform-staging.tfvars
@@ -8,10 +8,10 @@ r53_public_hosted_zone = "staging.opensupplyhub.org"
 
 cloudfront_price_class = "PriceClass_All"
 
-api_facilities_cache_default_ttl           = 1800
-api_facilities_cache_max_ttl               = 1800
-api_production_locations_cache_default_ttl = 1800
-api_production_locations_cache_max_ttl     = 1800
+api_facilities_cache_default_ttl           = 120
+api_facilities_cache_max_ttl               = 120
+api_production_locations_cache_default_ttl = 120
+api_production_locations_cache_max_ttl     = 120
 
 bastion_ami = "ami-0bb3fad3c0286ebd5"
 bastion_instance_type = "t3.nano"

--- a/deployment/terraform/cdn.tf
+++ b/deployment/terraform/cdn.tf
@@ -2,7 +2,7 @@ locals {
   frontend_bucket_name = "${lower(replace(var.project, " ", ""))}-${lower(var.environment)}-frontend-${var.aws_region}"
   api_cache_behaviors = [
     {
-      path_pattern = "api/facilities*"
+      path_pattern = "api/facilities/*"
       default_ttl  = var.api_facilities_cache_default_ttl
       max_ttl      = var.api_facilities_cache_max_ttl
     },
@@ -213,15 +213,7 @@ resource "aws_cloudfront_distribution" "cdn" {
 
       forwarded_values {
         query_string = true
-        headers      = [
-              "Authorization",
-              "X-OAR-CLIENT-KEY",
-              "Referer",
-              "Origin",
-              "Access-Control-Request-Method",
-              "Access-Control-Request-Headers",
-              "X-CloudFront-Auth"
-        ]
+        headers      = ["Authorization", "X-OAR-CLIENT-KEY", "Referer"]
 
         cookies {
           forward           = "whitelist"

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -46,25 +46,25 @@ variable "cloudfront_auth_token" {
 variable "api_facilities_cache_default_ttl" {
   description = "Default TTL (seconds) for facilities OS ID detail endpoint"
   type        = number
-  default     = 1800
+  default     = 120
 }
 
 variable "api_facilities_cache_max_ttl" {
   description = "Max TTL (seconds) for facilities OS ID detail endpoint"
   type        = number
-  default     = 1800
+  default     = 120
 }
 
 variable "api_production_locations_cache_default_ttl" {
   description = "Default TTL (seconds) for production-locations OS ID detail endpoint"
   type        = number
-  default     = 1800
+  default     = 120
 }
 
 variable "api_production_locations_cache_max_ttl" {
   description = "Max TTL (seconds) for production-locations OS ID detail endpoint"
   type        = number
-  default     = 1800
+  default     = 120
 }
 
 variable "vpc_cidr_block" {


### PR DESCRIPTION
1. Tighen cache behaviour to `api/facilities/*` instead of `api/facilities*` so `api/facilities-downloads` won't be broken.
2. Reduce cache time for **Prod**, **Preprod**, **RBA** and **Staging** to 2 **mins**.