### PR TITLE
[Quickfix][Osdev 2328] - Disable prevent destroy for msk cluster

### DIFF
--- a/deployment/terraform/kafka.tf
+++ b/deployment/terraform/kafka.tf
@@ -22,9 +22,8 @@ resource "aws_msk_configuration" "msk_config" {
   kafka_versions    = ["3.4.0", "3.9.x"]
   server_properties = ""
 
-  # Prevent Terraform from deleting the in-use MSK configuration.
   lifecycle {
-    prevent_destroy = true
+    prevent_destroy = false
     ignore_changes = [
       kafka_versions,
       server_properties,


### PR DESCRIPTION
Follow-up fix for [OSDEV-2318](https://opensupplyhub.atlassian.net/browse/OSDEV-2318)

Disable `prevent_destroy` for msk cluster to unblock `Pre-prod` deletion.

[OSDEV-2318]: https://opensupplyhub.atlassian.net/browse/OSDEV-2318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ