### PR TITLE
[OSDEV-2191] Updated release schedule for 2.18.0 release

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Introduction
 * Product name: Open Supply Hub
-* Release date: January 10, 2026
+* Release date: January 17, 2026
 
 ### Database changes
 

--- a/doc/release/RELEASE-PROTOCOL.md
+++ b/doc/release/RELEASE-PROTOCOL.md
@@ -78,7 +78,7 @@ This document outlines the SDLC pillars of the opensupplyhub monorepo, as well a
 | v2.15.0 | November 6, 2025 | November 8, 2025 | @Vadim Kovalenko |
 | v2.16.0 | November 25, 2025 | November 29, 2025 | @Roman Stolar |
 | v2.17.0 | December 9, 2025 | December 13, 2025 | @Vadim Kovalenko |
-| v2.18.0 | December 13, 2025 | December 17, 2025 | @Vlad Shapik |
+| v2.18.0 | January 13, 2026 | January 17, 2026 | @Vlad Shapik |
 
 ## General Information
 


### PR DESCRIPTION
[OSDEV-2191](https://opensupplyhub.atlassian.net/browse/OSDEV-2191)
Updated the release schedule for 2.18.0 to reflect the final release date.

[OSDEV-2191]: https://opensupplyhub.atlassian.net/browse/OSDEV-2191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ