### PR TITLE
Mark sensitive Terraform variables and redirect plan output from CI logs

### DIFF
--- a/.github/workflows/deploy_to_aws.yml
+++ b/.github/workflows/deploy_to_aws.yml
@@ -108,8 +108,21 @@ jobs:
           AWS_DEFAULT_REGION: "eu-west-1"
           SETTINGS_BUCKET: oshub-settings-${{ steps.get_env_name.outputs.lowercase }}
 
+      - name: Save the log for debugging purposes ${{ vars.ENV_NAME }}
+        if: always()
+        run: |
+          aws s3 cp "deployment/terraform/${{ env.SETTINGS_BUCKET }}.tfplan.log.txt" "s3://${{ env.SETTINGS_BUCKET }}/debug/${{ env.SETTINGS_BUCKET }}.tfplan.log.txt"
+          rm -f "deployment/terraform/${{ env.SETTINGS_BUCKET }}.tfplan.log.txt"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SETTINGS_BUCKET: oshub-settings-${{ steps.get_env_name.outputs.lowercase }}
+          AWS_DEFAULT_REGION: "eu-west-1"
+
       - name: Copy planfile to S3 bucket for ${{ vars.ENV_NAME }}
-        run: aws s3 cp "deployment/terraform/${{ env.SETTINGS_BUCKET }}.tfplan" "s3://${{ env.SETTINGS_BUCKET }}/terraform/${{ env.SETTINGS_BUCKET }}.tfplan"
+        run: |
+          aws s3 cp "deployment/terraform/${{ env.SETTINGS_BUCKET }}.tfplan" "s3://${{ env.SETTINGS_BUCKET }}/terraform/${{ env.SETTINGS_BUCKET }}.tfplan"
+          rm -f "deployment/terraform/${{ env.SETTINGS_BUCKET }}.tfplan"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -208,6 +221,16 @@ jobs:
       - name: Terraform Apply for ${{ vars.ENV_NAME }}
         run: |
           ./deployment/infra apply
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SETTINGS_BUCKET: oshub-settings-${{ steps.get_env_name.outputs.lowercase }}
+          AWS_DEFAULT_REGION: "eu-west-1"
+
+      - name: Delete debug log from S3 bucket for ${{ vars.ENV_NAME }}
+        if: always()
+        continue-on-error: true
+        run: aws s3 rm "s3://${{ env.SETTINGS_BUCKET }}/debug/${{ env.SETTINGS_BUCKET }}.tfplan.log.txt"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/deployment/infra
+++ b/deployment/infra
@@ -40,7 +40,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
         case "${1}" in
             plan)
-                echo "DEFAULT_BATCH_CE_DESIRED_CPU"
                 # DEFAULT_BATCH_CE_DESIRED_CPU=$(aws batch describe-compute-environments --output text --compute-environments "batch${OAR_DEPLOYMENT_ENVIRONMENT^}DefaultComputeEnvironment" --query "computeEnvironments[].computeResources.desiredvCpus")
 
                 # # Build Lambda function archives
@@ -58,7 +57,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                           -var="image_tag=${GIT_COMMIT}" \
                           -var="batch_default_ce_desired_vcpus=${DEFAULT_BATCH_CE_DESIRED_CPU:-0}" \
                           -var-file="${SETTINGS_BUCKET}.tfvars" \
-                          -out="${SETTINGS_BUCKET}.tfplan"
+                          -out="${SETTINGS_BUCKET}.tfplan" \
+                          > "${SETTINGS_BUCKET}.tfplan.log.txt" 2>&1
                 ;;
             apply)
                 echo "Terraform init"
@@ -69,15 +69,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 echo "Terraform apply"
                 ls -la
                 terraform apply "${SETTINGS_BUCKET}.tfplan"
-
-                # # Notify Rollbar of the deploy when running on Jenkins
-                # if [[ -n "${OAR_ROLLBAR_ACCESS_TOKEN}" && -n "${OAR_DEPLOYMENT_ENVIRONMENT}" ]]; then
-                #     curl -s https://api.rollbar.com/api/1/deploy/ \
-                #         -F "access_token=${OAR_ROLLBAR_ACCESS_TOKEN}" \
-                #         -F "environment=${OAR_DEPLOYMENT_ENVIRONMENT}" \
-                #         -F "revision=${GIT_COMMIT}" \
-                #         -F "local_username=jenkins"
-                # fi
                 ;;
             destroy)
                 terraform init \

--- a/deployment/infra
+++ b/deployment/infra
@@ -54,6 +54,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                   -backend-config="key=terraform/state"
                 echo "Terraform plan"
                 terraform plan \
+                          -no-color \
                           -var="image_tag=${GIT_COMMIT}" \
                           -var="batch_default_ce_desired_vcpus=${DEFAULT_BATCH_CE_DESIRED_CPU:-0}" \
                           -var-file="${SETTINGS_BUCKET}.tfvars" \

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -41,6 +41,7 @@ variable "cloudfront_price_class" {
 }
 
 variable "cloudfront_auth_token" {
+  sensitive = true
 }
 
 variable "api_facilities_cache_default_ttl" {
@@ -173,9 +174,11 @@ variable "rds_database_identifier" {
 }
 
 variable "rds_database_name" {
+  sensitive = true
 }
 
 variable "rds_database_username" {
+  sensitive = true
 }
 
 variable "rds_database_password" {
@@ -392,12 +395,15 @@ variable "django_secret_key" {
 }
 
 variable "default_from_email" {
+  sensitive = true
 }
 
 variable "data_from_email" {
+  sensitive = true
 }
 
 variable "notification_email_to" {
+  sensitive = true
 }
 
 variable "hubspot_api_key" {
@@ -407,6 +413,7 @@ variable "hubspot_api_key" {
 
 variable "hubspot_subscription_id" {
   default = ""
+  sensitive = true
 }
 
 variable "batch_default_ce_spot_fleet_bid_percentage" {
@@ -696,6 +703,7 @@ variable "anonymizer_schedule_expression" {
 variable "anonymizer_kms_key_admin_users" {
   type    = list(any)
   default = []
+  sensitive = true
 }
 
 variable "database_anonymizer_enabled" {
@@ -711,6 +719,7 @@ variable "anonymized_database_dump_enabled" {
 variable "anonymized_database_kms_key_id" {
   type    = string
   default = ""
+  sensitive = true
 }
 
 variable "anonymized_database_instance_type" {
@@ -731,11 +740,13 @@ variable "anonymized_database_schedule_expression" {
 variable "anonymized_database_name" {
   type    = string
   default = ""
+  sensitive = true
 }
 
 variable "anonymized_database_username" {
   type    = string
   default = ""
+  sensitive = true
 }
 
 variable "anonymized_database_password" {
@@ -844,12 +855,14 @@ variable "ip_whitelist" {
   type        = list(string)
   default     = []
   description = "List of IP addresses to allow through the AWS WAF"
+  sensitive   = true
 }
 
 variable "ip_denylist" {
   type        = list(string)
   default     = []
   description = "List of IP addresses to block through the AWS WAF"
+  sensitive   = true
 }
 
 variable "waf_enabled" {
@@ -863,6 +876,7 @@ variable "waf_enabled" {
 variable "direct_data_load_sheet_id" {
   type        = string
   description = "Google Sheet ID for direct data load"
+  sensitive   = true
 }
 
 variable "direct_data_load_contributor_name" {
@@ -873,6 +887,7 @@ variable "direct_data_load_contributor_name" {
 variable "direct_data_load_contributor_email" {
   type        = string
   description = "Contributor email for direct data load"
+  sensitive   = true
 }
 
 variable "direct_data_load_user_id" {
@@ -907,6 +922,7 @@ variable "stripe_webhook_secret" {
 variable "stripe_price_id" {
   type        = string
   description = "Stripe price ID for subscription plans"
+  sensitive   = true
 }
 
 # Dark visitors variables
@@ -914,6 +930,7 @@ variable "stripe_price_id" {
 variable "dark_visitors_project_key" {
   type        = string
   description = "Dark Visitors project key"
+  sensitive   = true
 }
 
 variable "dark_visitors_token" {
@@ -953,12 +970,14 @@ variable "source_db_name" {
   description = "Source database name"
   type        = string
   default     = ""
+  sensitive   = true
 }
 
 variable "source_db_user" {
   description = "Source database user"
   type        = string
   default     = ""
+  sensitive   = true
 }
 
 variable "source_db_password" {


### PR DESCRIPTION
Terraform plan output can expose the values of variables in CI logs. This change marks 20+ variables that hold secrets or PII (auth tokens, database credentials, email addresses, IP allowlists, API keys, KMS key IDs) as `sensitive = true` so Terraform redacts their values from plan and apply output if it ever occurs.

To further reduce exposure, the terraform plan output in the infra script is now redirected to a log file.