### PR TITLE
[OSDEV-2316] Update footer,  add empty line to the footer

### DIFF
--- a/src/react/src/components/Footer/FooterText.jsx
+++ b/src/react/src/components/Footer/FooterText.jsx
@@ -11,6 +11,7 @@ export default function FooterText() {
                 This site was designed for low energy usage and is hosted on
                 data centers using 100% renewable energy.
             </p>
+            <br />
             <p>
                 Open Supply Hub (OS Hub)&reg; is a registered trademark of Open
                 Supply Hub, Inc.


### PR DESCRIPTION
Add a small fix to the footer to make formatting similar to the info site
<img width="769" height="313" alt="Open Supply Hub - Pricing 2026-04-13 16-14-44" src="https://github.com/user-attachments/assets/4dc1c7af-6806-4bdc-9000-2cbbc723021e" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single presentational change to footer spacing with no business logic, data handling, or security impact.
> 
> **Overview**
> Adds an explicit line break (`<br />`) in `FooterText` to insert an empty line between the renewable-energy statement and the trademark notice, aligning footer formatting with the info site.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e761b56d8502d96f952e8d08dfcd2e6f0abf734. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->