### PR TITLE
[OSDEV-2525] Fixed Terraform apply: CloudFront TTL for /user-profile

### DIFF
--- a/deployment/terraform/cdn.tf
+++ b/deployment/terraform/cdn.tf
@@ -518,8 +518,8 @@ resource "aws_cloudfront_distribution" "cdn" {
 
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 120
-    default_ttl            = 240
+    min_ttl                = 0
+    default_ttl            = 0
     max_ttl                = 300
   }
 


### PR DESCRIPTION
Fix the **Terraform Apply for Development** failure on `Deploy to AWS` after merging profile/Spotlight work (see [failed apply job](https://github.com/opensupplyhub/open-supply-hub/actions/runs/24773740561/job/72486749631)).

## Problem

The `/user-profile/*` `ordered_cache_behavior` uses legacy `forwarded_values` with `headers = ["*"]` (forward all headers) and `cookies.forward = "all"`. For that configuration, CloudFront does not cache at the edge the way a normal static behavior does; raising `min_ttl` / `default_ttl` above zero is inconsistent with forwarding all headers and causes AWS to reject the distribution update during `terraform apply`.

## Change

Restore `min_ttl` and `default_ttl` to **0** for `/user-profile/*`, matching the other behaviors that forward all headers/cookies (still `max_ttl = 300`).

## Note on caching

API responses for the new profile list endpoints remain cached in Django for five minutes via `cache_page(..., cache="view_cache")`; this change only removes the invalid CloudFront edge TTL tweak.