### PR TITLE
TEST, DO NOT APPROVE - Create non-Latin characters check SLC prototype

### DIFF
--- a/src/react/src/__tests__/utils/slcValidationSchema.test.js
+++ b/src/react/src/__tests__/utils/slcValidationSchema.test.js
@@ -1,0 +1,248 @@
+import { slcValidationSchema } from '../../util/util';
+
+// Minimal valid base values — only name, address, and country are required.
+// Optional string fields use undefined so Yup skips their tests (empty string
+// fails the meaningful-characters check for non-required slcTextFieldValidation
+// fields, and fails the format-and-range check for numberOfWorkers).
+const validBase = {
+    name: 'Test Facility',
+    address: '123 Main Street',
+    country: { value: 'US', label: 'United States' },
+    sector: [],
+    productType: [],
+    locationType: [],
+    processingType: [],
+    numberOfWorkers: undefined,
+    parentCompany: undefined,
+};
+
+// Helper: validate a partial override against the full schema.
+const validate = (overrides = {}) =>
+    slcValidationSchema.validate(
+        { ...validBase, ...overrides },
+        { abortEarly: true },
+    );
+
+const isValid = (overrides = {}) =>
+    slcValidationSchema.isValid({ ...validBase, ...overrides });
+
+describe('slcValidationSchema — non-Latin character validation', () => {
+    // -------------------------------------------------------------------------
+    // name
+    // -------------------------------------------------------------------------
+    describe('name field', () => {
+        it('accepts plain ASCII text', async () => {
+            await expect(isValid({ name: 'Acme Factory' })).resolves.toBe(true);
+        });
+
+        it('accepts accented Latin characters (é, ü, ñ, ø)', async () => {
+            await expect(
+                isValid({ name: 'Ärger über niño café' }),
+            ).resolves.toBe(true);
+        });
+
+        it('rejects Chinese characters', async () => {
+            await expect(
+                validate({ name: '工厂名称' }),
+            ).rejects.toThrow('must contain only Latin characters');
+        });
+
+        it('rejects Cyrillic characters', async () => {
+            await expect(
+                validate({ name: 'Фабрика' }),
+            ).rejects.toThrow('must contain only Latin characters');
+        });
+
+        it('rejects Arabic characters', async () => {
+            await expect(
+                validate({ name: 'مصنع' }),
+            ).rejects.toThrow('must contain only Latin characters');
+        });
+
+        it('rejects a mixed Latin and non-Latin string', async () => {
+            await expect(
+                validate({ name: 'Acme 工厂' }),
+            ).rejects.toThrow('must contain only Latin characters');
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // address
+    // -------------------------------------------------------------------------
+    describe('address field', () => {
+        it('accepts a standard Latin address', async () => {
+            await expect(
+                isValid({ address: '10 Downing Street, London' }),
+            ).resolves.toBe(true);
+        });
+
+        it('accepts accented Latin characters in address', async () => {
+            await expect(
+                isValid({ address: '12 Rue de l\'Église, Montréal' }),
+            ).resolves.toBe(true);
+        });
+
+        it('rejects Chinese characters in address', async () => {
+            await expect(
+                validate({ address: '北京市朝阳区' }),
+            ).rejects.toThrow('must contain only Latin characters');
+        });
+
+        it('rejects Arabic characters in address', async () => {
+            await expect(
+                validate({ address: 'شارع الملك فهد' }),
+            ).rejects.toThrow('must contain only Latin characters');
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // parentCompany
+    // -------------------------------------------------------------------------
+    describe('parentCompany field', () => {
+        it('accepts a Latin parent company name', async () => {
+            await expect(
+                isValid({ parentCompany: 'Global Holdings Ltd.' }),
+            ).resolves.toBe(true);
+        });
+
+        it('accepts accented Latin characters in parent company', async () => {
+            await expect(
+                isValid({ parentCompany: 'Société Générale' }),
+            ).resolves.toBe(true);
+        });
+
+        it('rejects Japanese characters in parent company', async () => {
+            await expect(
+                validate({ parentCompany: '株式会社' }),
+            ).rejects.toThrow('must contain only Latin characters');
+        });
+
+        it('rejects Cyrillic characters in parent company', async () => {
+            await expect(
+                validate({ parentCompany: 'Компания' }),
+            ).rejects.toThrow('must contain only Latin characters');
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // numberOfWorkers
+    // -------------------------------------------------------------------------
+    describe('numberOfWorkers field', () => {
+        it('accepts standard ASCII digits', async () => {
+            await expect(isValid({ numberOfWorkers: '500' })).resolves.toBe(
+                true,
+            );
+        });
+
+        it('accepts a valid range with ASCII digits', async () => {
+            await expect(
+                isValid({ numberOfWorkers: '100-500' }),
+            ).resolves.toBe(true);
+        });
+
+        it('rejects fullwidth (Japanese) digits', async () => {
+            await expect(
+                validate({ numberOfWorkers: '１００' }),
+            ).rejects.toThrow('Only Latin characters are accepted');
+        });
+
+        it('rejects Arabic-Indic digits', async () => {
+            await expect(
+                validate({ numberOfWorkers: '١٠٠' }),
+            ).rejects.toThrow('Only Latin characters are accepted');
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // productType (array of { label, value } objects)
+    // -------------------------------------------------------------------------
+    describe('productType field', () => {
+        it('accepts an empty array', async () => {
+            await expect(isValid({ productType: [] })).resolves.toBe(true);
+        });
+
+        it('accepts items with Latin labels', async () => {
+            await expect(
+                isValid({
+                    productType: [
+                        { label: 'Shirts', value: 'Shirts' },
+                        { label: 'Trousers', value: 'Trousers' },
+                    ],
+                }),
+            ).resolves.toBe(true);
+        });
+
+        it('rejects an item with a Chinese label', async () => {
+            await expect(
+                validate({
+                    productType: [{ label: '衬衫', value: '衬衫' }],
+                }),
+            ).rejects.toThrow('must contain only Latin characters');
+        });
+
+        it('rejects when only one item in the list is non-Latin', async () => {
+            await expect(
+                validate({
+                    productType: [
+                        { label: 'Shirts', value: 'Shirts' },
+                        { label: 'Рубашки', value: 'Рубашки' },
+                    ],
+                }),
+            ).rejects.toThrow('must contain only Latin characters');
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // locationType (array of { label, value } objects)
+    // -------------------------------------------------------------------------
+    describe('locationType field', () => {
+        it('accepts an empty array', async () => {
+            await expect(isValid({ locationType: [] })).resolves.toBe(true);
+        });
+
+        it('accepts items with Latin labels', async () => {
+            await expect(
+                isValid({
+                    locationType: [
+                        { label: 'Final Assembly', value: 'Final Assembly' },
+                    ],
+                }),
+            ).resolves.toBe(true);
+        });
+
+        it('rejects an item with a non-Latin label', async () => {
+            await expect(
+                validate({
+                    locationType: [{ label: '组装', value: '组装' }],
+                }),
+            ).rejects.toThrow('must contain only Latin characters');
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // processingType (array of { label, value } objects)
+    // -------------------------------------------------------------------------
+    describe('processingType field', () => {
+        it('accepts an empty array', async () => {
+            await expect(isValid({ processingType: [] })).resolves.toBe(true);
+        });
+
+        it('accepts items with Latin labels', async () => {
+            await expect(
+                isValid({
+                    processingType: [
+                        { label: 'Printing', value: 'Printing' },
+                    ],
+                }),
+            ).resolves.toBe(true);
+        });
+
+        it('rejects an item with a non-Latin label', async () => {
+            await expect(
+                validate({
+                    processingType: [{ label: 'طباعة', value: 'طباعة' }],
+                }),
+            ).rejects.toThrow('must contain only Latin characters');
+        });
+    });
+});

--- a/src/react/src/components/Contribute/ProductionLocationInfo.jsx
+++ b/src/react/src/components/Contribute/ProductionLocationInfo.jsx
@@ -799,13 +799,23 @@ const ProductionLocationInfo = ({
                                                 contributionForm.values
                                                     .locationType
                                             }
-                                            onChange={value =>
+                                            onChange={value => {
                                                 contributionForm.setFieldValue(
                                                     'locationType',
                                                     value,
-                                                )
-                                            }
-                                            styles={getSelectStyles()}
+                                                );
+                                                contributionForm.setFieldTouched(
+                                                    'locationType',
+                                                    true,
+                                                    false,
+                                                );
+                                            }}
+                                            styles={getSelectStyles(
+                                                contributionForm.touched
+                                                    .locationType &&
+                                                    !!contributionForm.errors
+                                                        .locationType,
+                                            )}
                                             className={classes.selectStyles}
                                             placeholder="Select location type(s)"
                                         />
@@ -817,19 +827,45 @@ const ProductionLocationInfo = ({
                                                 contributionForm.values
                                                     .locationType
                                             }
-                                            onChange={value =>
+                                            onChange={value => {
                                                 contributionForm.setFieldValue(
                                                     'locationType',
                                                     value,
-                                                )
-                                            }
+                                                );
+                                                contributionForm.setFieldTouched(
+                                                    'locationType',
+                                                    true,
+                                                    false,
+                                                );
+                                            }}
                                             placeholder="Enter location type(s)"
                                             aria-label="Location type"
-                                            styles={getSelectStyles()}
+                                            styles={getSelectStyles(
+                                                contributionForm.touched
+                                                    .locationType &&
+                                                    !!contributionForm.errors
+                                                        .locationType,
+                                            )}
                                             className={classes.selectStyles}
                                             components={customSelectComponents}
                                         />
                                     )}
+                                    {contributionForm.touched.locationType &&
+                                        contributionForm.errors
+                                            .locationType && (
+                                            <div
+                                                className={
+                                                    classes.errorWrapStyles
+                                                }
+                                            >
+                                                <InputErrorText
+                                                    text={
+                                                        contributionForm.errors
+                                                            .locationType
+                                                    }
+                                                />
+                                            </div>
+                                        )}
                                 </div>
                                 <div
                                     className={`${classes.inputSectionWrapStyles} ${classes.wrapStyles}`}
@@ -864,13 +900,23 @@ const ProductionLocationInfo = ({
                                                 contributionForm.values
                                                     .processingType
                                             }
-                                            onChange={value =>
+                                            onChange={value => {
                                                 contributionForm.setFieldValue(
                                                     'processingType',
                                                     value,
-                                                )
-                                            }
-                                            styles={getSelectStyles()}
+                                                );
+                                                contributionForm.setFieldTouched(
+                                                    'processingType',
+                                                    true,
+                                                    false,
+                                                );
+                                            }}
+                                            styles={getSelectStyles(
+                                                contributionForm.touched
+                                                    .processingType &&
+                                                    !!contributionForm.errors
+                                                        .processingType,
+                                            )}
                                             className={classes.selectStyles}
                                             placeholder="Select processing type(s)"
                                         />
@@ -882,19 +928,45 @@ const ProductionLocationInfo = ({
                                                 contributionForm.values
                                                     .processingType
                                             }
-                                            onChange={value =>
+                                            onChange={value => {
                                                 contributionForm.setFieldValue(
                                                     'processingType',
                                                     value,
-                                                )
-                                            }
+                                                );
+                                                contributionForm.setFieldTouched(
+                                                    'processingType',
+                                                    true,
+                                                    false,
+                                                );
+                                            }}
                                             placeholder="Enter processing type(s)"
                                             aria-label="Processing Type"
-                                            styles={getSelectStyles()}
+                                            styles={getSelectStyles(
+                                                contributionForm.touched
+                                                    .processingType &&
+                                                    !!contributionForm.errors
+                                                        .processingType,
+                                            )}
                                             className={classes.selectStyles}
                                             components={customSelectComponents}
                                         />
                                     )}
+                                    {contributionForm.touched.processingType &&
+                                        contributionForm.errors
+                                            .processingType && (
+                                            <div
+                                                className={
+                                                    classes.errorWrapStyles
+                                                }
+                                            >
+                                                <InputErrorText
+                                                    text={
+                                                        contributionForm.errors
+                                                            .processingType
+                                                    }
+                                                />
+                                            </div>
+                                        )}
                                 </div>
                                 <div
                                     className={`${classes.inputSectionWrapStyles} ${classes.wrapStyles}`}

--- a/src/react/src/util/util.js
+++ b/src/react/src/util/util.js
@@ -1739,6 +1739,17 @@ const isCleanValueMeaningful = value => {
     return cleaned.length > 0;
 };
 
+// Allows Latin Unicode blocks: Basic Latin through Latin Extended-B
+// (U+0000-U+024F) and Latin Extended Additional (U+1E00-U+1EFF).
+// Covers accented characters like é, ü, ñ, ø, etc.
+const containsOnlyLatinCharacters = value => {
+    if (typeof value !== 'string') return true;
+    return Array.from(value).every(char => {
+        const code = char.codePointAt(0);
+        return code <= 0x024f || (code >= 0x1e00 && code <= 0x1eff);
+    });
+};
+
 const slcTextFieldValidation = stringYup()
     .test(
         'is-trimmed',
@@ -1760,6 +1771,12 @@ const slcTextFieldValidation = stringYup()
         ({ label }) => `${label} cannot contain only spaces or symbols.`,
         value => value == null || isCleanValueMeaningful(value),
     )
+    .test(
+        'latin-characters-only',
+        ({ label }) =>
+            `${label} must contain only Latin characters. Remove any non-Latin characters (e.g. Chinese, Arabic, Cyrillic).`,
+        value => value == null || containsOnlyLatinCharacters(value),
+    )
     .max(
         SLC_FORM_CONSTRAINTS.MAX_STRING_LENGTH,
         ({ label }) =>
@@ -1772,15 +1789,42 @@ export const slcValidationSchema = objectYup({
         .required('Address is required.')
         .label('Address'),
     country: objectYup().nullable().required('Country is required.'),
-    productType: arrayYup().max(
-        SLC_FORM_CONSTRAINTS.MAX_PRODUCT_TYPE_COUNT,
-        `Maximum of ${SLC_FORM_CONSTRAINTS.MAX_PRODUCT_TYPE_COUNT} product types allowed.`,
+    productType: arrayYup()
+        .max(
+            SLC_FORM_CONSTRAINTS.MAX_PRODUCT_TYPE_COUNT,
+            `Maximum of ${SLC_FORM_CONSTRAINTS.MAX_PRODUCT_TYPE_COUNT} product types allowed.`,
+        )
+        .test(
+            'latin-characters-only',
+            'Product type(s) must contain only Latin characters. Remove any non-Latin characters (e.g. Chinese, Arabic, Cyrillic).',
+            value =>
+                !value ||
+                value.every(item => containsOnlyLatinCharacters(item?.label)),
+        ),
+    locationType: arrayYup().test(
+        'latin-characters-only',
+        'Location type(s) must contain only Latin characters. Remove any non-Latin characters (e.g. Chinese, Arabic, Cyrillic).',
+        value =>
+            !value ||
+            value.every(item => containsOnlyLatinCharacters(item?.label)),
+    ),
+    processingType: arrayYup().test(
+        'latin-characters-only',
+        'Processing type(s) must contain only Latin characters. Remove any non-Latin characters (e.g. Chinese, Arabic, Cyrillic).',
+        value =>
+            !value ||
+            value.every(item => containsOnlyLatinCharacters(item?.label)),
     ),
     numberOfWorkers: stringYup()
         .test(
             'is-trimmed',
             'Remove spaces at start and end of entry.',
             value => value == null || value === value.trim(),
+        )
+        .test(
+            'latin-characters-only',
+            'Only Latin characters are accepted. Use standard digits (e.g., 5 or 3-10).',
+            value => value == null || containsOnlyLatinCharacters(value),
         )
         .test(
             'valid-format-and-range',

--- a/src/react/src/util/util.js
+++ b/src/react/src/util/util.js
@@ -1744,10 +1744,8 @@ const isCleanValueMeaningful = value => {
 // Covers accented characters like é, ü, ñ, ø, etc.
 const containsOnlyLatinCharacters = value => {
     if (typeof value !== 'string') return true;
-    return Array.from(value).every(char => {
-        const code = char.codePointAt(0);
-        return code <= 0x024f || (code >= 0x1e00 && code <= 0x1eff);
-    });
+    const normalized = value.normalize('NFC');
+    return !/[\u0250-\u1FFF\u2070-\u2E7F\u2E80-\uFFFF]/g.test(normalized);
 };
 
 const slcTextFieldValidation = stringYup()
@@ -1783,48 +1781,32 @@ const slcTextFieldValidation = stringYup()
             `${label} cannot exceed ${SLC_FORM_CONSTRAINTS.MAX_STRING_LENGTH} characters.`,
     );
 
+const latinOnlyArrayTest = fieldName =>
+    arrayYup().test(
+        'latin-characters-only',
+        `${fieldName} must contain only Latin characters. Remove any non-Latin characters (e.g. Chinese, Arabic, Cyrillic).`,
+        value =>
+            !value ||
+            value.every(item => containsOnlyLatinCharacters(item?.label)),
+    );
+
 export const slcValidationSchema = objectYup({
     name: slcTextFieldValidation.required('Name is required.').label('Name'),
     address: slcTextFieldValidation
         .required('Address is required.')
         .label('Address'),
     country: objectYup().nullable().required('Country is required.'),
-    productType: arrayYup()
-        .max(
-            SLC_FORM_CONSTRAINTS.MAX_PRODUCT_TYPE_COUNT,
-            `Maximum of ${SLC_FORM_CONSTRAINTS.MAX_PRODUCT_TYPE_COUNT} product types allowed.`,
-        )
-        .test(
-            'latin-characters-only',
-            'Product type(s) must contain only Latin characters. Remove any non-Latin characters (e.g. Chinese, Arabic, Cyrillic).',
-            value =>
-                !value ||
-                value.every(item => containsOnlyLatinCharacters(item?.label)),
-        ),
-    locationType: arrayYup().test(
-        'latin-characters-only',
-        'Location type(s) must contain only Latin characters. Remove any non-Latin characters (e.g. Chinese, Arabic, Cyrillic).',
-        value =>
-            !value ||
-            value.every(item => containsOnlyLatinCharacters(item?.label)),
+    productType: latinOnlyArrayTest('Product type(s)').max(
+        SLC_FORM_CONSTRAINTS.MAX_PRODUCT_TYPE_COUNT,
+        `Maximum of ${SLC_FORM_CONSTRAINTS.MAX_PRODUCT_TYPE_COUNT} product types allowed.`,
     ),
-    processingType: arrayYup().test(
-        'latin-characters-only',
-        'Processing type(s) must contain only Latin characters. Remove any non-Latin characters (e.g. Chinese, Arabic, Cyrillic).',
-        value =>
-            !value ||
-            value.every(item => containsOnlyLatinCharacters(item?.label)),
-    ),
+    locationType: latinOnlyArrayTest('Location type(s)'),
+    processingType: latinOnlyArrayTest('Processing type(s)'),
     numberOfWorkers: stringYup()
         .test(
             'is-trimmed',
             'Remove spaces at start and end of entry.',
             value => value == null || value === value.trim(),
-        )
-        .test(
-            'latin-characters-only',
-            'Only Latin characters are accepted. Use standard digits (e.g., 5 or 3-10).',
-            value => value == null || containsOnlyLatinCharacters(value),
         )
         .test(
             'valid-format-and-range',
@@ -1855,7 +1837,8 @@ export const slcValidationSchema = objectYup({
 
                 return false;
             },
-        ),
+        )
+        .label('Number of workers'),
     parentCompany: slcTextFieldValidation.label('Parent company'),
 });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new validation constraints to multiple SLC contribution fields, which can block previously-accepted user input and impact submissions; UI feedback changes are localized but affect key form fields.
> 
> **Overview**
> Adds *Latin-only* character validation to the SLC Yup schema via a new `containsOnlyLatinCharacters` helper, applying it to `name`, `address`, `parentCompany`, `productType`, `locationType`, `processingType`, and `numberOfWorkers` (including rejecting non-ASCII digit sets).
> 
> Updates `ProductionLocationInfo` so `locationType`/`processingType` selects are marked touched on change, pass error state into `getSelectStyles`, and render inline error text when invalid.
> 
> Introduces a new Jest test suite (`slcValidationSchema.test.js`) that asserts accented Latin characters are allowed and non-Latin scripts/digits are rejected across the affected fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b455248061fbec8cb937806265fa3575c71f82ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->