### PR TITLE
[Hotfix-v.2.22.1][OSDEV-2557] Updated Spotlight and data sources copy to remove social or environmental framing

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
     * `reindex_database`
     * `reindex_locations_with_approved_claim`
 
+
 ## Release 2.22.0
 
 ## Introduction

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -3,6 +3,24 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). The format is based on the `RELEASE-NOTES-TEMPLATE.md` file.
 
+## Release 2.22.1
+
+## Introduction
+* Product name: Open Supply Hub
+* Release date: April 28, 2026
+
+### What's new
+* [OSDEV-2557](https://opensupplyhub.atlassian.net/browse/OSDEV-2557) - Updated Production Location page copy in the Spotlight section and in **Understanding Data Sources** so language stays inclusive as Spotlight expands beyond strictly social or environmental data:
+    * **Spotlight (data present)** — The section subheading no longer limits partner-hosted data to “social or environmental”; it now describes additional data about the location, its context, and/or operations in general terms.
+    * **Spotlight (no partner data)** — The empty state text no longer describes partner data as “social and environmental”; it now uses the same broader “additional data” wording, with the “no partner data” callout unchanged.
+    * **Understanding Data Sources → Spotlight Partners** — The short description for Spotlight Partners now reads: *Additional information about facility operations or context shared by third party platforms* (replacing the prior “social or environmental” framing). These are text-only changes intended for a midweek hotfix.
+
+### Release instructions
+* Ensure that the following commands are included in the `post_deployment` command:
+    * `migrate`
+    * `reindex_database`
+    * `reindex_locations_with_approved_claim`
+
 ## Release 2.22.0
 
 ## Introduction

--- a/src/react/src/components/ProductionLocation/Heading/DataSourcesInfo/constants.js
+++ b/src/react/src/components/ProductionLocation/Heading/DataSourcesInfo/constants.js
@@ -34,7 +34,7 @@ export const DATA_SOURCES_ITEMS = Object.freeze([
         labelClassNameKey: 'labelPartner',
         title: 'Spotlight Partners',
         subsectionText:
-            'Additional social or environmental information shared by third party platforms',
+            'Additional information about facility operations or context shared by third party platforms',
         learnMoreUrl: 'https://info.opensupplyhub.org/data-integrations',
     }),
 ]);

--- a/src/react/src/components/ProductionLocation/PartnerSection/PartnerDataContainer/PartnerDataContainer.jsx
+++ b/src/react/src/components/ProductionLocation/PartnerSection/PartnerDataContainer/PartnerDataContainer.jsx
@@ -83,9 +83,9 @@ function PartnerDataContainer({
                             className={classes.description}
                         >
                             The following information is provided by third-party
-                            partners who host additional social or environmental
-                            data related to this production location, its
-                            context, and/or its operations.{' '}
+                            partners who host additional data related to this
+                            production location, its context, and/or its
+                            operations.{' '}
                             <a
                                 href="https://info.opensupplyhub.org/data-integrations"
                                 target="_blank"
@@ -101,9 +101,8 @@ function PartnerDataContainer({
                             className={classes.description}
                         >
                             Open Supply Hub works with third-party partners who
-                            provide additional social and environmental data
-                            related to production locations, their context,
-                            and/or their operations.{' '}
+                            provide additional data related to production
+                            locations, their context, and/or their operations.{' '}
                             <b>
                                 No partner data is currently available for this
                                 facility.


### PR DESCRIPTION
Update copy on the Production Location page for Spotlight and the **Understanding Data Sources** explainer so messaging does not frame partner data as only social or environmental, ahead of a broader Spotlight launch.

**Why:** The product needs inclusive language for third-party partner data; the ticket ([OSDEV-2557](https://opensupplyhub.atlassian.net/browse/OSDEV-2557)) is a text-only hotfix (no API or schema changes).

**What:** Adjusts the Spotlight subheading and empty-state strings in `PartnerDataContainer`, and the Spotlight Partners line in `DataSourcesInfo` constants. Release **2.22.1** is documented in `doc/release/RELEASE-NOTES.md` (What's new + same release instructions as 2.22.0).

[OSDEV-2557]: https://opensupplyhub.atlassian.net/browse/OSDEV-2557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ