### PR TITLE
[OSDEV-2557] Hyphenate Spotlight Partners description

### DIFF
--- a/src/react/src/components/ProductionLocation/Heading/DataSourcesInfo/constants.js
+++ b/src/react/src/components/ProductionLocation/Heading/DataSourcesInfo/constants.js
@@ -34,7 +34,7 @@ export const DATA_SOURCES_ITEMS = Object.freeze([
         labelClassNameKey: 'labelPartner',
         title: 'Spotlight Partners',
         subsectionText:
-            'Additional information about facility operations or context shared by third party platforms',
+            'Additional information about facility operations or context shared by third-party platforms',
         learnMoreUrl: 'https://info.opensupplyhub.org/data-integrations',
     }),
 ]);


### PR DESCRIPTION
- Updated the Spotlight Partners description text in Understanding Data Sources to use hyphenated wording (`third-party`).
- Apply the editorial follow-up from [Jira comment 27329](https://opensupplyhub.atlassian.net/browse/OSDEV-2557?focusedCommentId=27329) on [OSDEV-2557](https://opensupplyhub.atlassian.net/browse/OSDEV-2557). 

[OSDEV-2557]: https://opensupplyhub.atlassian.net/browse/OSDEV-2557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ