### PR TITLE
[Hotfix-v.2.22.2][OSDEV-2563] Fix partner fields data source in download serializer

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -3,6 +3,22 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). The format is based on the `RELEASE-NOTES-TEMPLATE.md` file.
 
+## Release 2.22.2
+
+## Introduction
+* Product name: Open Supply Hub
+* Release date: April 29, 2026
+
+### Bugfix
+* [OSDEV-2563](https://opensupplyhub.atlassian.net/browse/OSDEV-2563) - Fix partner fields in facility download to use unfiltered extended fields, and add 10-minute cache to the all_contributors endpoint.
+
+### What's new
+* [OSDEV-2557](https://opensupplyhub.atlassian.net/browse/OSDEV-2557) - Hyphenate Spotlight Partners description text in the **Understanding Data Sources** section.
+
+### Release instructions
+* Ensure that no commands are included in the `post_deployment` command.
+
+
 ## Release 2.22.1
 
 ## Introduction

--- a/src/django/api/management/commands/post_deployment.py
+++ b/src/django/api/management/commands/post_deployment.py
@@ -1,5 +1,4 @@
 from django.core.management.base import BaseCommand
-from django.core.management import call_command
 
 
 class Command(BaseCommand):
@@ -8,6 +7,4 @@ class Command(BaseCommand):
             'post-deployment tasks.')
 
     def handle(self, *args, **options):
-        call_command('migrate')
-        call_command('reindex_database')
-        call_command('reindex_locations_with_approved_claim')
+        pass

--- a/src/django/api/serializers/facility/facility_download_serializer.py
+++ b/src/django/api/serializers/facility/facility_download_serializer.py
@@ -34,7 +34,7 @@ class FacilityDownloadSerializer(FacilityDownloadSerializerBase):
             *self.get_claimed_fields(facility),
             self.get_is_closed(facility),
             *self.get_partner_fields_row(
-                extended_fields_raw,
+                facility.extended_fields,
                 FacilitiesDownloadService.get_active_partner_fields()
             ),
             *self.get_mit_living_wage_row(facility),

--- a/src/django/api/views/contributor/all_contributors.py
+++ b/src/django/api/views/contributor/all_contributors.py
@@ -1,3 +1,4 @@
+from django.views.decorators.cache import cache_page
 from rest_framework.decorators import api_view, throttle_classes
 from rest_framework.response import Response
 
@@ -6,6 +7,7 @@ from .active_contributors import active_contributors
 
 @api_view(['GET'])
 @throttle_classes([])
+@cache_page(60 * 10, cache="view_cache")
 def all_contributors(_):
     """
     Returns list contributors as a list of tuples of


### PR DESCRIPTION
Fix `FacilityDownloadSerializer.get_partner_fields_row` to use the unfiltered `facility.extended_fields` instead of `extended_fields_raw`, and add a 10-minute cache to the `all_contributors` view for improved performance.

The `get_partner_fields_row` call was incorrectly receiving `extended_fields_raw`, which filters out extended fields from non-claim contributors via `check_contributor`. Partner fields should consider all extended fields regardless of claim status, so the call now uses `facility.extended_fields` directly - matching how `get_mit_living_wage_row` and `get_wage_indicator_row` already work in the same method.

The `all_contributors` endpoint returns a simple list of contributor IDs, names, and types that changes infrequently. Adding `@cache_page(60 * 10, cache="view_cache")` avoids hitting the database on every request, reducing load on a frequently-called endpoint.