### PR TITLE
[OSDEV-2589] Enhance FacilityDownloadSerializer to utilize schema defaults for missing partner field values

### DIFF
--- a/src/django/api/serializers/facility/facility_download_serializer_base.py
+++ b/src/django/api/serializers/facility/facility_download_serializer_base.py
@@ -189,7 +189,10 @@ class FacilityDownloadSerializerBase(Serializer):
 
             if paths:
                 row.extend(
-                    build_object_field_cells(entries, paths, separator)
+                    build_object_field_cells(
+                        entries, paths, separator,
+                        partner_field.json_schema,
+                    )
                 )
             else:
                 row.append(build_primitive_field_cell(entries, separator))

--- a/src/django/api/serializers/facility/partner_field_helper.py
+++ b/src/django/api/serializers/facility/partner_field_helper.py
@@ -123,6 +123,27 @@ def resolve_nested_value(
     return current
 
 
+def resolve_schema_default(
+    schema: Dict[str, Any],
+    path: Tuple[str, ...],
+) -> Any:
+    '''
+    Walk the JSON Schema along `path` and return the ``"default"`` value
+    from the leaf node, or ``None`` if no default exists or the leaf is
+    an object with nested properties (defaults only apply to primitive
+    leaves).
+    '''
+    current = schema
+    for key in path:
+        props = current.get("properties", {})
+        current = props.get(key)
+        if not isinstance(current, dict):
+            return None
+    if _has_nested_properties(current):
+        return None
+    return current.get("default")
+
+
 def group_extended_fields_by_name(
     extended_fields: List[Dict[str, Any]],
 ) -> Dict[str, List[Dict[str, Any]]]:
@@ -165,11 +186,15 @@ def build_object_field_cells(
     entries: List[Dict[str, Any]],
     paths: List[Tuple[str, ...]],
     separator: str,
+    schema: Dict[str, Any] = None,
 ) -> List[str]:
     '''
     Build one joined cell per leaf path for an object-typed partner
     field, walking each contribution's `raw_values` in declaration
     order and skipping empty values.
+
+    When *schema* is provided, missing leaf values are filled from the
+    schema ``"default"`` (non-object leaves only).
     '''
     collected: Dict[Tuple[str, ...], List[str]] = {
         path: [] for path in paths
@@ -178,7 +203,7 @@ def build_object_field_cells(
         raw_values = _entry_value_dict(entry).get("raw_values")
         if not isinstance(raw_values, dict):
             continue
-        _collect_path_values(raw_values, paths, collected)
+        _collect_path_values(raw_values, paths, collected, schema)
     return [separator.join(collected[path]) for path in paths]
 
 
@@ -186,9 +211,12 @@ def _collect_path_values(
     raw_values: Dict[str, Any],
     paths: List[Tuple[str, ...]],
     collected: Dict[Tuple[str, ...], List[str]],
+    schema: Dict[str, Any] = None,
 ) -> None:
     for path in paths:
         value = resolve_nested_value(raw_values, path)
+        if is_empty_partner_value(value) and schema:
+            value = resolve_schema_default(schema, path)
         if is_empty_partner_value(value):
             continue
         collected[path].append(str(value))

--- a/src/django/api/serializers/facility/partner_field_helper.py
+++ b/src/django/api/serializers/facility/partner_field_helper.py
@@ -222,6 +222,49 @@ def _collect_path_values(
         collected[path].append(str(value))
 
 
+def _set_nested_value(
+    data: Dict[str, Any],
+    path: Tuple[str, ...],
+    value: Any,
+) -> None:
+    '''
+    Walk *data* along *path*, creating intermediate dicts as needed,
+    and set the leaf key to *value*.
+    '''
+    current = data
+    for key in path[:-1]:
+        nxt = current.get(key)
+        if not isinstance(nxt, dict):
+            nxt = {}
+            current[key] = nxt
+        current = nxt
+    current[path[-1]] = value
+
+
+def apply_schema_defaults(
+    raw_values: Dict[str, Any],
+    schema: Dict[str, Any],
+) -> Dict[str, Any]:
+    '''
+    Mutate *raw_values* in place, filling missing non-object leaf
+    values with the ``"default"`` declared in *schema*. Returns
+    *raw_values* for convenience.
+    '''
+    if not isinstance(raw_values, dict) or not isinstance(schema, dict):
+        return raw_values
+    paths = collect_leaf_paths(schema)
+    for path in paths:
+        if not is_empty_partner_value(resolve_nested_value(
+            raw_values, path
+        )):
+            continue
+        default = resolve_schema_default(schema, path)
+        if is_empty_partner_value(default):
+            continue
+        _set_nested_value(raw_values, path, default)
+    return raw_values
+
+
 def build_primitive_field_cell(
     entries: List[Dict[str, Any]],
     separator: str,

--- a/src/django/api/serializers/facility/partner_field_helper.py
+++ b/src/django/api/serializers/facility/partner_field_helper.py
@@ -254,9 +254,8 @@ def apply_schema_defaults(
         return raw_values
     paths = collect_leaf_paths(schema)
     for path in paths:
-        if not is_empty_partner_value(resolve_nested_value(
-            raw_values, path
-        )):
+        nested_value = resolve_nested_value(raw_values, path)
+        if not is_empty_partner_value(nested_value):
             continue
         default = resolve_schema_default(schema, path)
         if is_empty_partner_value(default):

--- a/src/django/api/tests/test_facility_download_serializer.py
+++ b/src/django/api/tests/test_facility_download_serializer.py
@@ -8,6 +8,9 @@ from api.models.wage_indicator_country_data import WageIndicatorCountryData
 from api.serializers.facility.facility_download_serializer import (
     FacilityDownloadSerializer,
 )
+from api.serializers.facility.partner_field_helper import (
+    apply_schema_defaults,
+)
 
 CLAIM_HEADERS = [
     "claim_created_at",
@@ -440,3 +443,84 @@ class FacilityDownloadSerializerTest(TestCase):
             *EMPTY_PARTNER_FIELD_VALUES,
         ]
         self.assertEqual(row, expected_row)
+
+
+class ApplySchemaDefaultsTest(TestCase):
+    def test_fills_missing_leaf_values_with_defaults(self):
+        schema = {
+            'properties': {
+                'submission_date': {'type': 'string'},
+                'expiration_date': {
+                    'type': 'string',
+                    'default': 'N/A',
+                },
+                'rating': {
+                    'type': 'integer',
+                    'default': 0,
+                },
+            }
+        }
+        raw_values = {'submission_date': '2024-10-15'}
+        result = apply_schema_defaults(raw_values, schema)
+        self.assertEqual(result, {
+            'submission_date': '2024-10-15',
+            'expiration_date': 'N/A',
+            'rating': 0,
+        })
+        self.assertIs(result, raw_values)
+
+    def test_does_not_overwrite_existing_values(self):
+        schema = {
+            'properties': {
+                'rating': {
+                    'type': 'integer',
+                    'default': 0,
+                },
+            }
+        }
+        raw_values = {'rating': 5}
+        apply_schema_defaults(raw_values, schema)
+        self.assertEqual(raw_values['rating'], 5)
+
+    def test_ignores_defaults_on_object_sub_schemas(self):
+        schema = {
+            'properties': {
+                'nested': {
+                    'type': 'object',
+                    'default': {'should': 'be ignored'},
+                    'properties': {
+                        'leaf': {'type': 'string'},
+                    },
+                },
+            }
+        }
+        raw_values = {}
+        apply_schema_defaults(raw_values, schema)
+        self.assertNotIn('nested', raw_values)
+
+    def test_creates_intermediate_dicts_for_nested_defaults(self):
+        schema = {
+            'properties': {
+                'audit': {
+                    'type': 'object',
+                    'properties': {
+                        'status': {
+                            'type': 'string',
+                            'default': 'pending',
+                        },
+                    },
+                },
+            }
+        }
+        raw_values = {}
+        apply_schema_defaults(raw_values, schema)
+        self.assertEqual(raw_values, {'audit': {'status': 'pending'}})
+
+    def test_noop_when_raw_values_not_dict(self):
+        result = apply_schema_defaults('not a dict', {'properties': {}})
+        self.assertEqual(result, 'not a dict')
+
+    def test_noop_when_schema_not_dict(self):
+        raw_values = {'a': 1}
+        result = apply_schema_defaults(raw_values, None)
+        self.assertEqual(result, {'a': 1})

--- a/src/django/api/tests/test_facility_download_serializer.py
+++ b/src/django/api/tests/test_facility_download_serializer.py
@@ -343,6 +343,78 @@ class FacilityDownloadSerializerTest(TestCase):
             ],
         )
 
+    def test_partner_fields_use_schema_defaults_for_missing_leaves(self):
+        schema = {
+            'properties': {
+                'submission_date': {'type': 'string'},
+                'expiration_date': {
+                    'type': 'string',
+                    'default': 'N/A',
+                },
+                'rating': {
+                    'type': 'integer',
+                    'default': 0,
+                },
+            }
+        }
+        partner_fields = [
+            SimpleNamespace(
+                name='audit_info',
+                type=PartnerField.OBJECT,
+                json_schema=schema,
+            ),
+        ]
+        extended_fields = [
+            {
+                'field_name': 'audit_info',
+                'value': {
+                    'raw_values': {
+                        'submission_date': '2024-10-15',
+                    }
+                },
+                'contributor': {'id': 1},
+            },
+        ]
+        serializer = FacilityDownloadSerializer()
+        row = serializer.get_partner_fields_row(
+            extended_fields, partner_fields
+        )
+        self.assertEqual(row, ['2024-10-15', 'N/A', '0'])
+
+    def test_partner_fields_ignores_defaults_on_object_sub_schemas(self):
+        schema = {
+            'properties': {
+                'nested_obj': {
+                    'type': 'object',
+                    'default': {'should': 'be ignored'},
+                    'properties': {
+                        'leaf': {'type': 'string'},
+                    },
+                },
+            }
+        }
+        partner_fields = [
+            SimpleNamespace(
+                name='complex_field',
+                type=PartnerField.OBJECT,
+                json_schema=schema,
+            ),
+        ]
+        extended_fields = [
+            {
+                'field_name': 'complex_field',
+                'value': {
+                    'raw_values': {}
+                },
+                'contributor': {'id': 1},
+            },
+        ]
+        serializer = FacilityDownloadSerializer()
+        row = serializer.get_partner_fields_row(
+            extended_fields, partner_fields
+        )
+        self.assertEqual(row, [''])
+
     def test_get_row_with_claim_from_contributor_without_extended_fields(self):
         serializer = FacilityDownloadSerializer()
         row = serializer.get_row(self.facility_three)

--- a/src/django/api/views/v1/production_locations.py
+++ b/src/django/api/views/v1/production_locations.py
@@ -2,7 +2,6 @@ from typing import Tuple, List
 
 from django.http import QueryDict
 from django.db import transaction
-from django.core.cache import cache
 
 from rest_framework import status
 from rest_framework.viewsets import ViewSet
@@ -31,7 +30,6 @@ from api.moderation_event_actions.creation.dtos.create_moderation_event_dto \
     import CreateModerationEventDTO
 from api.models.moderation_event import ModerationEvent
 from api.models.facility.facility import Facility
-from api.models.partner_field import PartnerField
 from api.models.extended_field import ExtendedField
 from api.throttles import (
     DataUploadThrottle,
@@ -41,7 +39,10 @@ from api.constants import (
     APIV1CommonErrorMessages,
     NON_FIELD_ERRORS_KEY,
     APIV1LocationContributionErrorMessages,
-    PARTNER_FIELD_NAMES_KEY,
+)
+from api.serializers.facility.partner_field_helper import (
+    apply_schema_defaults,
+    get_cached_all_partner_fields,
 )
 from api.exceptions import ServiceUnavailableException
 from api.mail import (
@@ -285,7 +286,8 @@ class ProductionLocations(ViewSet):
         production location object by its ID or
         by the provided Facility instance.
 
-        Caches the list of partner field names for one hour.
+        Uses the shared partner-field cache so schemas are available
+        for filling default values on object-typed fields.
         Returns a dictionary of the form:
             {
                 "field_name_1": value_1,
@@ -293,14 +295,13 @@ class ProductionLocations(ViewSet):
                 ...
             }
         """
-        cache_key = PARTNER_FIELD_NAMES_KEY
-        partner_field_names = cache.get(cache_key)
-
-        if partner_field_names is None:
-            partner_field_names = list(
-                PartnerField.objects.values_list('name', flat=True)
-            )
-            cache.set(cache_key, partner_field_names, 60 * 60)
+        all_partner_fields = get_cached_all_partner_fields()
+        schema_by_name = {
+            pf.name: pf.json_schema
+            for pf in all_partner_fields
+            if pf.json_schema
+        }
+        partner_field_names = [pf.name for pf in all_partner_fields]
 
         partner_extended_fields = {}
 
@@ -315,6 +316,7 @@ class ProductionLocations(ViewSet):
                     partner_extended_fields,
                     field.get('field_name'),
                     field.get('value'),
+                    schema_by_name,
                 )
 
         facility = Facility.objects.filter(id=pk).only(
@@ -340,14 +342,19 @@ class ProductionLocations(ViewSet):
                     partner_extended_fields,
                     field_name,
                     provider_value,
+                    schema_by_name,
                 )
 
         return partner_extended_fields
 
     @staticmethod
-    def __add_partner_field_value(partner_extended_fields, field_name, value):
+    def __add_partner_field_value(
+        partner_extended_fields, field_name, value, schema_by_name
+    ):
         """
         Extract and add partner field value to the response dictionary.
+        When a JSON Schema with defaults exists for this field and the
+        payload is a dict, missing non-object leaves are filled.
         """
         if not field_name or not isinstance(value, dict):
             return
@@ -363,5 +370,9 @@ class ProductionLocations(ViewSet):
 
         if payload is None:
             return
+
+        schema = schema_by_name.get(field_name)
+        if schema and isinstance(payload, dict):
+            apply_schema_defaults(payload, schema)
 
         partner_extended_fields[field_name] = payload


### PR DESCRIPTION
Updated the `build_object_field_cells` and `_collect_path_values` methods to incorporate schema defaults when partner field values are missing. Introduced a new `resolve_schema_default` function to retrieve default values from the JSON schema. Added tests to verify that missing leaves in partner fields correctly use schema defaults and that defaults are ignored for object sub-schemas.