### PR TITLE
[Backmerge][OSDEV-2525] Simplify raw_values structure in FacilitiesViewSet

### DIFF
--- a/src/django/api/views/facility/facilities_view_set.py
+++ b/src/django/api/views/facility/facilities_view_set.py
@@ -446,8 +446,7 @@ class FacilitiesViewSet(ListModelMixin,
                                     "raw_values": {
                                         "status": "active",
                                         "start_date": "2026-01-29",
-                                        "end_date": "2026-01-29",
-                                        "attributes": "..."
+                                        "end_date": "2026-01-29"
                                     }
                                 }
                             }
@@ -458,8 +457,7 @@ class FacilitiesViewSet(ListModelMixin,
                                     "raw_values": {
                                         "status": "active",
                                         "active_since": "2022-06-01",
-                                        "end_date": "2022-06-01",
-                                        "attributes": "..."
+                                        "end_date": "2022-06-01"
                                     }
                                 }
                             }
@@ -469,8 +467,7 @@ class FacilitiesViewSet(ListModelMixin,
                                 "value": {
                                     "raw_values": {
                                         "wovo_active": "active",
-                                        "wovo_established_date": "2022-06-01",
-                                        "attributes": "..."
+                                        "wovo_established_date": "2022-06-01"
                                     }
                                 }
                             }


### PR DESCRIPTION
Backmerge of https://github.com/opensupplyhub/open-supply-hub/pull/972 (merged to `releases/v.2.22`) into `main`.

## What changed
- Same change as #972: simplified `raw_values` structure in `FacilitiesViewSet` (removed unnecessary `attributes` nesting).

## Why
- Keeps `main` aligned with the release-line fix from OSDEV-2525 / #972.

Related: [OSDEV-2525](https://opensupplyhub.atlassian.net/browse/OSDEV-2525)

[OSDEV-2525]: https://opensupplyhub.atlassian.net/browse/OSDEV-2525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ