### PR TITLE
[Backmerge][OSDEV-2563] Fix partner fields data source in download serializer

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * Product name: Open Supply Hub
 * Release date: May 9, 2026
 
+### Bugfix
+* [OSDEV-2563](https://opensupplyhub.atlassian.net/browse/OSDEV-2563) - Fix partner fields in facility download to use unfiltered extended fields, and add 10-minute cache to the all_contributors endpoint.
+
 ### What's new
 * [OSDEV-1227](https://opensupplyhub.atlassian.net/browse/OSDEV-1227) - Replaced "Rejected" with "Feedback Phase" on user-facing list status pages (My Lists table, list detail page, and status summary message) to use more welcoming language.
 * [OSDEV-2121](https://opensupplyhub.atlassian.net/browse/OSDEV-2121) - Updated the data download limits lead-in copy to not display when a user performs an unfiltered search without any search criteria or filters selected.

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -9,9 +9,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * Product name: Open Supply Hub
 * Release date: May 9, 2026
 
-### Bugfix
-* [OSDEV-2563](https://opensupplyhub.atlassian.net/browse/OSDEV-2563) - Fix partner fields in facility download to use unfiltered extended fields, and add 10-minute cache to the all_contributors endpoint.
-
 ### What's new
 * [OSDEV-1227](https://opensupplyhub.atlassian.net/browse/OSDEV-1227) - Replaced "Rejected" with "Feedback Phase" on user-facing list status pages (My Lists table, list detail page, and status summary message) to use more welcoming language.
 * [OSDEV-2121](https://opensupplyhub.atlassian.net/browse/OSDEV-2121) - Updated the data download limits lead-in copy to not display when a user performs an unfiltered search without any search criteria or filters selected.
@@ -21,6 +18,22 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
     * `migrate`
     * `reindex_database`
     * `reindex_locations_with_approved_claim`
+
+
+## Release 2.22.2
+
+## Introduction
+* Product name: Open Supply Hub
+* Release date: April 29, 2026
+
+### Bugfix
+* [OSDEV-2563](https://opensupplyhub.atlassian.net/browse/OSDEV-2563) - Fix partner fields in facility download to use unfiltered extended fields, and add 10-minute cache to the all_contributors endpoint.
+
+### What's new
+* [OSDEV-2557](https://opensupplyhub.atlassian.net/browse/OSDEV-2557) - Hyphenate Spotlight Partners description text in the **Understanding Data Sources** section.
+
+### Release instructions
+* Ensure that no commands are included in the `post_deployment` command.
 
 
 ## Release 2.22.1

--- a/src/django/api/serializers/facility/facility_download_serializer.py
+++ b/src/django/api/serializers/facility/facility_download_serializer.py
@@ -34,7 +34,7 @@ class FacilityDownloadSerializer(FacilityDownloadSerializerBase):
             *self.get_claimed_fields(facility),
             self.get_is_closed(facility),
             *self.get_partner_fields_row(
-                extended_fields_raw,
+                facility.extended_fields,
                 FacilitiesDownloadService.get_active_partner_fields()
             ),
             *self.get_mit_living_wage_row(facility),

--- a/src/django/api/views/contributor/all_contributors.py
+++ b/src/django/api/views/contributor/all_contributors.py
@@ -1,3 +1,4 @@
+from django.views.decorators.cache import cache_page
 from rest_framework.decorators import api_view, throttle_classes
 from rest_framework.response import Response
 
@@ -6,6 +7,7 @@ from .active_contributors import active_contributors
 
 @api_view(['GET'])
 @throttle_classes([])
+@cache_page(60 * 10, cache="view_cache")
 def all_contributors(_):
     """
     Returns list contributors as a list of tuples of


### PR DESCRIPTION
Backmerge of https://github.com/opensupplyhub/open-supply-hub/pull/978 (merged to `releases/v.2.22`) into `main`.

## What changed
- `FacilityDownloadSerializer.get_partner_fields_row` uses unfiltered `facility.extended_fields` instead of `extended_fields_raw` (same behavior intent as #978).
- 10-minute `cache_page` on the `all_contributors` view.
- **Release notes:** added the **Release 2.22.2** chapter exactly as in the hotfix PR (#978): Introduction (April 29, 2026), **Bugfix** (OSDEV-2563), **What's new** (OSDEV-2557 hyphenation), and release instructions (no `post_deployment` commands). Placed after **Release 2.23.0** and before **Release 2.22.1**.
- Hotfix-only `post_deployment` emptying from #978 was not applied on `main`; `main` keeps migrate/reindex instructions for **Release 2.23.0**.

## Why
- Aligns `main` with the production hotfix from OSDEV-2563 / #978.

Related: [OSDEV-2563](https://opensupplyhub.atlassian.net/browse/OSDEV-2563)

[OSDEV-2563]: https://opensupplyhub.atlassian.net/browse/OSDEV-2563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ