### PR TITLE
[Backmerge][OSDEV-2564] Update constants and navbar labels for clarity and consistency

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -12,7 +12,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### What's new
 * [OSDEV-1227](https://opensupplyhub.atlassian.net/browse/OSDEV-1227) - Replaced "Rejected" with "Feedback Phase" on user-facing list status pages (My Lists table, list detail page, and status summary message) to use more welcoming language.
 * [OSDEV-2121](https://opensupplyhub.atlassian.net/browse/OSDEV-2121) - Updated the data download limits lead-in copy to not display when a user performs an unfiltered search without any search criteria or filters selected.
-* [OSDEV-2564](https://opensupplyhub.atlassian.net/browse/OSDEV-2564) - Renamed navbar labels ('Premium Features' → 'Featured Solutions', 'Data Cleaning Service' → 'Embedded Map', 'Pricing' → 'Solutions') and updated corresponding InfoPaths to align with new feature naming.
 
 ### Release instructions
 * Ensure that the following commands are included in the `post_deployment` command:
@@ -32,6 +31,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### What's new
 * [OSDEV-2557](https://opensupplyhub.atlassian.net/browse/OSDEV-2557) - Hyphenate Spotlight Partners description text in the **Understanding Data Sources** section.
+* [OSDEV-2564](https://opensupplyhub.atlassian.net/browse/OSDEV-2564) - Renamed navbar labels ('Premium Features' → 'Featured Solutions', 'Data Cleaning Service' → 'Embedded Map', 'Pricing' → 'Solutions') and updated corresponding InfoPaths to align with new feature naming.
 
 ### Release instructions
 * Ensure that no commands are included in the `post_deployment` command.

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### What's new
 * [OSDEV-1227](https://opensupplyhub.atlassian.net/browse/OSDEV-1227) - Replaced "Rejected" with "Feedback Phase" on user-facing list status pages (My Lists table, list detail page, and status summary message) to use more welcoming language.
 * [OSDEV-2121](https://opensupplyhub.atlassian.net/browse/OSDEV-2121) - Updated the data download limits lead-in copy to not display when a user performs an unfiltered search without any search criteria or filters selected.
+* [OSDEV-2564](https://opensupplyhub.atlassian.net/browse/OSDEV-2564) - Renamed navbar labels ('Premium Features' → 'Featured Solutions', 'Data Cleaning Service' → 'Embedded Map', 'Pricing' → 'Solutions') and updated corresponding InfoPaths to align with new feature naming.
 
 ### Release instructions
 * Ensure that the following commands are included in the `post_deployment` command:

--- a/src/react/src/util/constants.jsx
+++ b/src/react/src/util/constants.jsx
@@ -31,6 +31,7 @@ export const InfoPaths = {
     privacyPolicy: 'privacy-policy',
     spotlight: 'spotlight',
     preparingData: 'resources/preparing-data',
+    dataCleaningService: 'data-cleaning-service',
     dataQuality: 'resources/a-free-universal-id-matching-algorithm',
     claimedFacilities: 'stories-resources/claim-a-facility',
     termsOfService: 'terms-of-service',

--- a/src/react/src/util/constants.jsx
+++ b/src/react/src/util/constants.jsx
@@ -29,7 +29,7 @@ export const EMPTY_PLACEHOLDER = 'N/A';
 export const InfoPaths = {
     storiesResources: 'stories-resources',
     privacyPolicy: 'privacy-policy',
-    dataCleaningService: 'data-cleaning-service',
+    spotlight: 'spotlight',
     preparingData: 'resources/preparing-data',
     dataQuality: 'resources/a-free-universal-id-matching-algorithm',
     claimedFacilities: 'stories-resources/claim-a-facility',
@@ -868,7 +868,7 @@ export const NavbarItems = [
                     ],
                 },
                 {
-                    label: 'Premium Features',
+                    label: 'Featured Solutions',
                     items: [
                         {
                             type: 'link',
@@ -877,13 +877,13 @@ export const NavbarItems = [
                         },
                         {
                             type: 'link',
-                            label: 'Data Cleaning Service',
-                            href: `${InfoLink}/${InfoPaths.dataCleaningService}`,
+                            label: 'Embedded Map',
+                            href: `${InfoLink}/${InfoPaths.embeddedMap}`,
                         },
                         {
                             type: 'link',
-                            label: 'Embedded Map',
-                            href: `${InfoLink}/${InfoPaths.embeddedMap}`,
+                            label: 'Spotlight',
+                            href: `${InfoLink}/${InfoPaths.spotlight}`,
                         },
                     ],
                 },
@@ -969,7 +969,7 @@ export const NavbarItems = [
     },
     {
         type: 'link',
-        label: 'Pricing',
+        label: 'Solutions',
         href: `${InfoLink}/${InfoPaths.pricing}`,
     },
     { type: 'international' },


### PR DESCRIPTION
Backmerge of https://github.com/opensupplyhub/open-supply-hub/pull/980 (merged to `releases/v.2.22`) into `main`.

## What changed
- Navbar / `InfoPaths` updates in `constants.jsx` (same as #980).
- **Release notes:** **Release 2.22.2** matches the hotfix branch after #978 and #980: Introduction (April 29, 2026), **Bugfix** (OSDEV-2563), **What's new** (OSDEV-2557 hyphenation + OSDEV-2564 navbar labels), and release instructions (no `post_deployment` commands). Section order: **2.23.0** → **2.22.2** → **2.22.1**.

## Why
- Keeps `main` aligned with production hotfix documentation for OS Hub 2.22.2.

Related: [OSDEV-2564](https://opensupplyhub.atlassian.net/browse/OSDEV-2564)

[OSDEV-2564]: https://opensupplyhub.atlassian.net/browse/OSDEV-2564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ