### PR TITLE
[OSDEV-2547] Create automatic feedback in SLC submission form

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### What's new
 * [OSDEV-1227](https://opensupplyhub.atlassian.net/browse/OSDEV-1227) - Replaced "Rejected" with "Feedback Phase" on user-facing list status pages (My Lists table, list detail page, and status summary message) to use more welcoming language.
 * [OSDEV-2121](https://opensupplyhub.atlassian.net/browse/OSDEV-2121) - Updated the data download limits lead-in copy to not display when a user performs an unfiltered search without any search criteria or filters selected.
+* [OSDEV-2547](https://opensupplyhub.atlassian.net/browse/OSDEV-2547) - Refactored field tests and added warning pop-ups for the SLC submission form.
 
 ### Release instructions
 * Ensure that the following commands are included in the `post_deployment` command:

--- a/src/react/src/__tests__/utils.tests.js
+++ b/src/react/src/__tests__/utils.tests.js
@@ -2473,7 +2473,7 @@ describe('slcValidationSchema', () => {
             numberOfWorkers: '1 '
         };
         await expect(slcValidationSchema.validate(data)).rejects.toThrow(
-            'Remove spaces at start and end of entry.'
+            'Remove spaces at start and end of text.'
         );
     });
 

--- a/src/react/src/__tests__/utils/slcValidationSchema.test.js
+++ b/src/react/src/__tests__/utils/slcValidationSchema.test.js
@@ -1,0 +1,248 @@
+import { slcValidationSchema } from '../../util/util';
+
+// Minimal valid base values — only name, address, and country are required.
+// Optional string fields use undefined so Yup skips their tests (empty string
+// fails the meaningful-characters check for non-required slcTextFieldValidation
+// fields, and fails the format-and-range check for numberOfWorkers).
+const validBase = {
+    name: 'Test Facility',
+    address: '123 Main Street',
+    country: { value: 'US', label: 'United States' },
+    sector: [],
+    productType: [],
+    locationType: [],
+    processingType: [],
+    numberOfWorkers: undefined,
+    parentCompany: undefined,
+};
+
+// Helper: validate a partial override against the full schema.
+const validate = (overrides = {}) =>
+    slcValidationSchema.validate(
+        { ...validBase, ...overrides },
+        { abortEarly: true },
+    );
+
+const isValid = (overrides = {}) =>
+    slcValidationSchema.isValid({ ...validBase, ...overrides });
+
+describe('slcValidationSchema — non-Latin character validation', () => {
+    // -------------------------------------------------------------------------
+    // name
+    // -------------------------------------------------------------------------
+    describe('name field', () => {
+        it('accepts plain ASCII text', async () => {
+            await expect(isValid({ name: 'Acme Factory' })).resolves.toBe(true);
+        });
+
+        it('accepts accented Latin characters (é, ü, ñ, ø)', async () => {
+            await expect(
+                isValid({ name: 'Ärger über niño café' }),
+            ).resolves.toBe(true);
+        });
+
+        it('rejects Chinese characters', async () => {
+            await expect(
+                validate({ name: '工厂名称' }),
+            ).rejects.toThrow('must contain only Latin characters');
+        });
+
+        it('rejects Cyrillic characters', async () => {
+            await expect(
+                validate({ name: 'Фабрика' }),
+            ).rejects.toThrow('must contain only Latin characters');
+        });
+
+        it('rejects Arabic characters', async () => {
+            await expect(
+                validate({ name: 'مصنع' }),
+            ).rejects.toThrow('must contain only Latin characters');
+        });
+
+        it('rejects a mixed Latin and non-Latin string', async () => {
+            await expect(
+                validate({ name: 'Acme 工厂' }),
+            ).rejects.toThrow('must contain only Latin characters');
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // address
+    // -------------------------------------------------------------------------
+    describe('address field', () => {
+        it('accepts a standard Latin address', async () => {
+            await expect(
+                isValid({ address: '10 Downing Street, London' }),
+            ).resolves.toBe(true);
+        });
+
+        it('accepts accented Latin characters in address', async () => {
+            await expect(
+                isValid({ address: '12 Rue de l\'Église, Montréal' }),
+            ).resolves.toBe(true);
+        });
+
+        it('rejects Chinese characters in address', async () => {
+            await expect(
+                validate({ address: '北京市朝阳区' }),
+            ).rejects.toThrow('must contain only Latin characters');
+        });
+
+        it('rejects Arabic characters in address', async () => {
+            await expect(
+                validate({ address: 'شارع الملك فهد' }),
+            ).rejects.toThrow('must contain only Latin characters');
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // parentCompany
+    // -------------------------------------------------------------------------
+    describe('parentCompany field', () => {
+        it('accepts a Latin parent company name', async () => {
+            await expect(
+                isValid({ parentCompany: 'Global Holdings Ltd.' }),
+            ).resolves.toBe(true);
+        });
+
+        it('accepts accented Latin characters in parent company', async () => {
+            await expect(
+                isValid({ parentCompany: 'Société Générale' }),
+            ).resolves.toBe(true);
+        });
+
+        it('rejects Japanese characters in parent company', async () => {
+            await expect(
+                validate({ parentCompany: '株式会社' }),
+            ).rejects.toThrow('must contain only Latin characters');
+        });
+
+        it('rejects Cyrillic characters in parent company', async () => {
+            await expect(
+                validate({ parentCompany: 'Компания' }),
+            ).rejects.toThrow('must contain only Latin characters');
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // numberOfWorkers
+    // -------------------------------------------------------------------------
+    describe('numberOfWorkers field', () => {
+        it('accepts standard ASCII digits', async () => {
+            await expect(isValid({ numberOfWorkers: '500' })).resolves.toBe(
+                true,
+            );
+        });
+
+        it('accepts a valid range with ASCII digits', async () => {
+            await expect(
+                isValid({ numberOfWorkers: '100-500' }),
+            ).resolves.toBe(true);
+        });
+
+        it('rejects fullwidth (Japanese) digits', async () => {
+            await expect(
+                validate({ numberOfWorkers: '１００' }),
+            ).rejects.toThrow('Only Latin characters are accepted');
+        });
+
+        it('rejects Arabic-Indic digits', async () => {
+            await expect(
+                validate({ numberOfWorkers: '١٠٠' }),
+            ).rejects.toThrow('Only Latin characters are accepted');
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // productType (array of { label, value } objects)
+    // -------------------------------------------------------------------------
+    describe('productType field', () => {
+        it('accepts an empty array', async () => {
+            await expect(isValid({ productType: [] })).resolves.toBe(true);
+        });
+
+        it('accepts items with Latin labels', async () => {
+            await expect(
+                isValid({
+                    productType: [
+                        { label: 'Shirts', value: 'Shirts' },
+                        { label: 'Trousers', value: 'Trousers' },
+                    ],
+                }),
+            ).resolves.toBe(true);
+        });
+
+        it('rejects an item with a Chinese label', async () => {
+            await expect(
+                validate({
+                    productType: [{ label: '衬衫', value: '衬衫' }],
+                }),
+            ).rejects.toThrow('must contain only Latin characters');
+        });
+
+        it('rejects when only one item in the list is non-Latin', async () => {
+            await expect(
+                validate({
+                    productType: [
+                        { label: 'Shirts', value: 'Shirts' },
+                        { label: 'Рубашки', value: 'Рубашки' },
+                    ],
+                }),
+            ).rejects.toThrow('must contain only Latin characters');
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // locationType (array of { label, value } objects)
+    // -------------------------------------------------------------------------
+    describe('locationType field', () => {
+        it('accepts an empty array', async () => {
+            await expect(isValid({ locationType: [] })).resolves.toBe(true);
+        });
+
+        it('accepts items with Latin labels', async () => {
+            await expect(
+                isValid({
+                    locationType: [
+                        { label: 'Final Assembly', value: 'Final Assembly' },
+                    ],
+                }),
+            ).resolves.toBe(true);
+        });
+
+        it('rejects an item with a non-Latin label', async () => {
+            await expect(
+                validate({
+                    locationType: [{ label: '组装', value: '组装' }],
+                }),
+            ).rejects.toThrow('must contain only Latin characters');
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // processingType (array of { label, value } objects)
+    // -------------------------------------------------------------------------
+    describe('processingType field', () => {
+        it('accepts an empty array', async () => {
+            await expect(isValid({ processingType: [] })).resolves.toBe(true);
+        });
+
+        it('accepts items with Latin labels', async () => {
+            await expect(
+                isValid({
+                    processingType: [
+                        { label: 'Printing', value: 'Printing' },
+                    ],
+                }),
+            ).resolves.toBe(true);
+        });
+
+        it('rejects an item with a non-Latin label', async () => {
+            await expect(
+                validate({
+                    processingType: [{ label: 'طباعة', value: 'طباعة' }],
+                }),
+            ).rejects.toThrow('must contain only Latin characters');
+        });
+    });
+});

--- a/src/react/src/__tests__/utils/slcValidationSchema.test.js
+++ b/src/react/src/__tests__/utils/slcValidationSchema.test.js
@@ -35,9 +35,6 @@ const makeItems = count =>
     }));
 
 describe('slcValidationSchema', () => {
-    // -------------------------------------------------------------------------
-    // name
-    // -------------------------------------------------------------------------
     describe('name field', () => {
         it('accepts plain ASCII text', async () => {
             await expect(isValid({ name: 'Acme Factory' })).resolves.toBe(true);
@@ -74,9 +71,6 @@ describe('slcValidationSchema', () => {
         });
     });
 
-    // -------------------------------------------------------------------------
-    // address
-    // -------------------------------------------------------------------------
     describe('address field', () => {
         it('accepts a standard Latin address', async () => {
             await expect(
@@ -115,9 +109,6 @@ describe('slcValidationSchema', () => {
         });
     });
 
-    // -------------------------------------------------------------------------
-    // parentCompany
-    // -------------------------------------------------------------------------
     describe('parentCompany field', () => {
         it('accepts a Latin parent company name', async () => {
             await expect(
@@ -144,10 +135,13 @@ describe('slcValidationSchema', () => {
         });
     });
 
-    // -------------------------------------------------------------------------
-    // numberOfWorkers
-    // -------------------------------------------------------------------------
     describe('numberOfWorkers field', () => {
+        it('accepts an empty optional field (real initial value)', async () => {
+            await expect(isValid({ parentCompany: '', numberOfWorkers: '' })).resolves.toBe(
+                true
+            );
+        });
+
         it('accepts standard ASCII digits', async () => {
             await expect(isValid({ numberOfWorkers: '500' })).resolves.toBe(
                 true,
@@ -173,9 +167,6 @@ describe('slcValidationSchema', () => {
         });
     });
 
-    // -------------------------------------------------------------------------
-    // productType (array of { label, value } objects)
-    // -------------------------------------------------------------------------
     describe('productType field', () => {
         it('accepts an empty array', async () => {
             await expect(isValid({ productType: [] })).resolves.toBe(true);
@@ -232,9 +223,6 @@ describe('slcValidationSchema', () => {
         });
     });
 
-    // -------------------------------------------------------------------------
-    // locationType (array of { label, value } objects)
-    // -------------------------------------------------------------------------
     describe('locationType field', () => {
         it('accepts an empty array', async () => {
             await expect(isValid({ locationType: [] })).resolves.toBe(true);
@@ -259,9 +247,6 @@ describe('slcValidationSchema', () => {
         });
     });
 
-    // -------------------------------------------------------------------------
-    // processingType (array of { label, value } objects)
-    // -------------------------------------------------------------------------
     describe('processingType field', () => {
         it('accepts an empty array', async () => {
             await expect(isValid({ processingType: [] })).resolves.toBe(true);

--- a/src/react/src/__tests__/utils/slcValidationSchema.test.js
+++ b/src/react/src/__tests__/utils/slcValidationSchema.test.js
@@ -1,9 +1,10 @@
 import { slcValidationSchema } from '../../util/util';
+import { SLC_FORM_CONSTRAINTS } from '../../util/constants';
 
 // Minimal valid base values — only name, address, and country are required.
 // Optional string fields use undefined so Yup skips their tests (empty string
-// fails the meaningful-characters check for non-required slcTextFieldValidation
-// fields, and fails the format-and-range check for numberOfWorkers).
+// fails the meaningful-characters check for non-required text fields, and
+// fails the format-and-range check for numberOfWorkers).
 const validBase = {
     name: 'Test Facility',
     address: '123 Main Street',
@@ -26,7 +27,14 @@ const validate = (overrides = {}) =>
 const isValid = (overrides = {}) =>
     slcValidationSchema.isValid({ ...validBase, ...overrides });
 
-describe('slcValidationSchema — non-Latin character validation', () => {
+// Helper: build an array of N valid { label, value } items.
+const makeItems = count =>
+    Array.from({ length: count }, (_, i) => ({
+        label: `Item ${i + 1}`,
+        value: `item-${i + 1}`,
+    }));
+
+describe('slcValidationSchema', () => {
     // -------------------------------------------------------------------------
     // name
     // -------------------------------------------------------------------------
@@ -78,8 +86,20 @@ describe('slcValidationSchema — non-Latin character validation', () => {
 
         it('accepts accented Latin characters in address', async () => {
             await expect(
-                isValid({ address: '12 Rue de l\'Église, Montréal' }),
+                isValid({ address: "12 Rue de l'Église, Montréal" }),
             ).resolves.toBe(true);
+        });
+
+        it('accepts an address of exactly 200 characters', async () => {
+            await expect(
+                isValid({ address: 'A'.repeat(200) }),
+            ).resolves.toBe(true);
+        });
+
+        it('rejects an address exceeding 200 characters', async () => {
+            await expect(
+                validate({ address: 'A'.repeat(201) }),
+            ).rejects.toThrow('cannot exceed 200 characters');
         });
 
         it('rejects Chinese characters in address', async () => {
@@ -143,13 +163,13 @@ describe('slcValidationSchema — non-Latin character validation', () => {
         it('rejects fullwidth (Japanese) digits', async () => {
             await expect(
                 validate({ numberOfWorkers: '１００' }),
-            ).rejects.toThrow('Only Latin characters are accepted');
+            ).rejects.toThrow('Enter a single positive number');
         });
 
         it('rejects Arabic-Indic digits', async () => {
             await expect(
                 validate({ numberOfWorkers: '١٠٠' }),
-            ).rejects.toThrow('Only Latin characters are accepted');
+            ).rejects.toThrow('Enter a single positive number');
         });
     });
 
@@ -172,12 +192,32 @@ describe('slcValidationSchema — non-Latin character validation', () => {
             ).resolves.toBe(true);
         });
 
+        it(`accepts exactly ${SLC_FORM_CONSTRAINTS.MAX_PRODUCT_TYPE_COUNT} items`, async () => {
+            await expect(
+                isValid({
+                    productType: makeItems(
+                        SLC_FORM_CONSTRAINTS.MAX_PRODUCT_TYPE_COUNT,
+                    ),
+                }),
+            ).resolves.toBe(true);
+        });
+
+        it(`rejects more than ${SLC_FORM_CONSTRAINTS.MAX_PRODUCT_TYPE_COUNT} items`, async () => {
+            await expect(
+                validate({
+                    productType: makeItems(
+                        SLC_FORM_CONSTRAINTS.MAX_PRODUCT_TYPE_COUNT + 1,
+                    ),
+                }),
+            ).rejects.toThrow('product types allowed');
+        });
+
         it('rejects an item with a Chinese label', async () => {
             await expect(
                 validate({
                     productType: [{ label: '衬衫', value: '衬衫' }],
                 }),
-            ).rejects.toThrow('must contain only Latin characters');
+            ).rejects.toThrow('Product type(s) must contain only Latin characters');
         });
 
         it('rejects when only one item in the list is non-Latin', async () => {
@@ -215,7 +255,7 @@ describe('slcValidationSchema — non-Latin character validation', () => {
                 validate({
                     locationType: [{ label: '组装', value: '组装' }],
                 }),
-            ).rejects.toThrow('must contain only Latin characters');
+            ).rejects.toThrow('Location type(s) must contain only Latin characters');
         });
     });
 
@@ -242,7 +282,7 @@ describe('slcValidationSchema — non-Latin character validation', () => {
                 validate({
                     processingType: [{ label: 'طباعة', value: 'طباعة' }],
                 }),
-            ).rejects.toThrow('must contain only Latin characters');
+            ).rejects.toThrow('Processing type(s) must contain only Latin characters');
         });
     });
 });

--- a/src/react/src/components/Contribute/ContributionWarningDialog.jsx
+++ b/src/react/src/components/Contribute/ContributionWarningDialog.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { bool, func, object, string } from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+import Dialog from '@material-ui/core/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogActions from '@material-ui/core/DialogActions';
+import Button from '@material-ui/core/Button';
+import IconButton from '@material-ui/core/IconButton';
+import CloseIcon from '@material-ui/icons/Close';
+import Typography from '@material-ui/core/Typography';
+import { makeContributionWarningDialogStyles } from '../../util/styles';
+
+const ContributionWarningDialog = ({
+    open,
+    onClose,
+    onSubmitAnyway,
+    title,
+    message,
+    classes,
+}) => (
+    <Dialog
+        classes={{ paper: classes.dialogPaperStyles }}
+        open={open}
+        onClose={onClose}
+        aria-labelledby="contribution-warning-dialog-title"
+    >
+        <IconButton
+            aria-label="Close"
+            className={classes.closeButtonStyles}
+            onClick={onClose}
+        >
+            <CloseIcon />
+        </IconButton>
+        <DialogTitle id="contribution-warning-dialog-title" disableTypography>
+            <Typography className={classes.dialogTitleStyles}>
+                {title}
+            </Typography>
+        </DialogTitle>
+        <DialogContent>
+            <Typography className={classes.dialogBodyStyles}>
+                {message}
+            </Typography>
+        </DialogContent>
+        <DialogActions className={classes.dialogActionsStyles}>
+            <Button
+                variant="contained"
+                color="secondary"
+                onClick={onClose}
+                classes={{
+                    root: classes.buttonBaseStyles,
+                    label: classes.buttonLabelStyles,
+                }}
+            >
+                Go back and edit
+            </Button>
+            <Button
+                variant="contained"
+                onClick={onSubmitAnyway}
+                classes={{
+                    root: `${classes.buttonBaseStyles} ${classes.submitAnywayButtonStyles}`,
+                    label: classes.buttonLabelStyles,
+                }}
+            >
+                Submit anyway
+            </Button>
+        </DialogActions>
+    </Dialog>
+);
+
+ContributionWarningDialog.propTypes = {
+    open: bool.isRequired,
+    onClose: func.isRequired,
+    onSubmitAnyway: func.isRequired,
+    title: string.isRequired,
+    message: string.isRequired,
+    classes: object.isRequired,
+};
+
+export default withStyles(makeContributionWarningDialogStyles)(
+    ContributionWarningDialog,
+);

--- a/src/react/src/components/Contribute/ProductionLocationInfo.jsx
+++ b/src/react/src/components/Contribute/ProductionLocationInfo.jsx
@@ -799,13 +799,23 @@ const ProductionLocationInfo = ({
                                                 contributionForm.values
                                                     .locationType
                                             }
-                                            onChange={value =>
+                                            onChange={value => {
                                                 contributionForm.setFieldValue(
                                                     'locationType',
                                                     value,
-                                                )
-                                            }
-                                            styles={getSelectStyles()}
+                                                );
+                                                contributionForm.setFieldTouched(
+                                                    'locationType',
+                                                    true,
+                                                    false,
+                                                );
+                                            }}
+                                            styles={getSelectStyles(
+                                                contributionForm.touched
+                                                    .locationType &&
+                                                    !!contributionForm.errors
+                                                        .locationType,
+                                            )}
                                             className={classes.selectStyles}
                                             placeholder="Select location type(s)"
                                         />
@@ -817,19 +827,45 @@ const ProductionLocationInfo = ({
                                                 contributionForm.values
                                                     .locationType
                                             }
-                                            onChange={value =>
+                                            onChange={value => {
                                                 contributionForm.setFieldValue(
                                                     'locationType',
                                                     value,
-                                                )
-                                            }
+                                                );
+                                                contributionForm.setFieldTouched(
+                                                    'locationType',
+                                                    true,
+                                                    false,
+                                                );
+                                            }}
                                             placeholder="Enter location type(s)"
                                             aria-label="Location type"
-                                            styles={getSelectStyles()}
+                                            styles={getSelectStyles(
+                                                contributionForm.touched
+                                                    .locationType &&
+                                                    !!contributionForm.errors
+                                                        .locationType,
+                                            )}
                                             className={classes.selectStyles}
                                             components={customSelectComponents}
                                         />
                                     )}
+                                    {contributionForm.touched.locationType &&
+                                        contributionForm.errors
+                                            .locationType && (
+                                            <div
+                                                className={
+                                                    classes.errorWrapStyles
+                                                }
+                                            >
+                                                <InputErrorText
+                                                    text={
+                                                        contributionForm.errors
+                                                            .locationType
+                                                    }
+                                                />
+                                            </div>
+                                        )}
                                 </div>
                                 <div
                                     className={`${classes.inputSectionWrapStyles} ${classes.wrapStyles}`}
@@ -864,13 +900,23 @@ const ProductionLocationInfo = ({
                                                 contributionForm.values
                                                     .processingType
                                             }
-                                            onChange={value =>
+                                            onChange={value => {
                                                 contributionForm.setFieldValue(
                                                     'processingType',
                                                     value,
-                                                )
-                                            }
-                                            styles={getSelectStyles()}
+                                                );
+                                                contributionForm.setFieldTouched(
+                                                    'processingType',
+                                                    true,
+                                                    false,
+                                                );
+                                            }}
+                                            styles={getSelectStyles(
+                                                contributionForm.touched
+                                                    .processingType &&
+                                                    !!contributionForm.errors
+                                                        .processingType,
+                                            )}
                                             className={classes.selectStyles}
                                             placeholder="Select processing type(s)"
                                         />
@@ -882,19 +928,45 @@ const ProductionLocationInfo = ({
                                                 contributionForm.values
                                                     .processingType
                                             }
-                                            onChange={value =>
+                                            onChange={value => {
                                                 contributionForm.setFieldValue(
                                                     'processingType',
                                                     value,
-                                                )
-                                            }
+                                                );
+                                                contributionForm.setFieldTouched(
+                                                    'processingType',
+                                                    true,
+                                                    false,
+                                                );
+                                            }}
                                             placeholder="Enter processing type(s)"
                                             aria-label="Processing Type"
-                                            styles={getSelectStyles()}
+                                            styles={getSelectStyles(
+                                                contributionForm.touched
+                                                    .processingType &&
+                                                    !!contributionForm.errors
+                                                        .processingType,
+                                            )}
                                             className={classes.selectStyles}
                                             components={customSelectComponents}
                                         />
                                     )}
+                                    {contributionForm.touched.processingType &&
+                                        contributionForm.errors
+                                            .processingType && (
+                                            <div
+                                                className={
+                                                    classes.errorWrapStyles
+                                                }
+                                            >
+                                                <InputErrorText
+                                                    text={
+                                                        contributionForm.errors
+                                                            .processingType
+                                                    }
+                                                />
+                                            </div>
+                                        )}
                                 </div>
                                 <div
                                     className={`${classes.inputSectionWrapStyles} ${classes.wrapStyles}`}

--- a/src/react/src/components/Contribute/ProductionLocationInfo.jsx
+++ b/src/react/src/components/Contribute/ProductionLocationInfo.jsx
@@ -52,6 +52,8 @@ import {
     mapFacilityTypeOptions,
     mapProcessingTypeOptions,
     getSelectStyles,
+    containsPOBox,
+    isShortAddress,
 } from '../../util/util';
 
 import FeatureFlag from '../FeatureFlag';
@@ -61,8 +63,30 @@ import RequireAuthNotice from '../RequireAuthNotice';
 import StyledTooltip from '../StyledTooltip';
 
 import InputErrorText from './InputErrorText';
+import ContributionWarningDialog from './ContributionWarningDialog';
 import ProductionLocationDialog from './ProductionLocationDialog';
 import PostContributionSubmitErrorNotification from './PostContributionSubmitErrorNotification/PostContributionSubmitErrorNotification';
+
+// Ordered list of soft-warning checks run before submission. Each entry
+// specifies which form field to inspect, a condition function (returns true
+// when the warning should fire), and the dialog copy to show the contributor.
+// To add a new warning, append an entry here — no other code needs to change.
+const SUBMISSION_WARNING_CHECKS = [
+    {
+        field: 'address',
+        condition: containsPOBox,
+        title: 'Address May Contain a PO Box',
+        message:
+            'The address field appears to contain a PO Box. Street addresses provide better geocoding, and will allow our matching systems to accurately locate the facility on our map. Submissions with a street address are more likely to be matched correctly and accepted.',
+    },
+    {
+        field: 'address',
+        condition: isShortAddress,
+        title: 'Address Appears Short',
+        message:
+            'The address field appears to be short. Please ensure your address contains: street number (or cross streets or neighborhood/industrial zone) if available, town/city, state/province, postal code (if applicable). Submissions with these details are more likely to be matched correctly and accepted.',
+    },
+];
 
 const ProductionLocationInfo = ({
     submitMethod,
@@ -109,6 +133,8 @@ const ProductionLocationInfo = ({
         showPostSubmitErrorNotification,
         setShowPostSubmitErrorNotification,
     ] = useState(false);
+
+    const [activeWarningIndex, setActiveWarningIndex] = useState(null);
 
     const [enabledTaxonomy, setEnabledTaxonomy] = useState(false);
 
@@ -388,11 +414,25 @@ const ProductionLocationInfo = ({
         contributionForm.validateField('country');
     }, [contributionForm.values.productType, contributionForm.values.country]);
 
+    const runWarningChecks = (startIndex = 0) => {
+        const { values } = contributionForm;
+        for (let i = startIndex; i < SUBMISSION_WARNING_CHECKS.length; i += 1) {
+            const { field, condition } = SUBMISSION_WARNING_CHECKS[i];
+            if (condition(values[field])) {
+                setActiveWarningIndex(i);
+                return;
+            }
+        }
+        contributionForm.handleSubmit();
+    };
+
+    const handleSubmitClick = () => runWarningChecks(0);
+
     const activeSubmitButton = (
         <Button
             color="secondary"
             variant="contained"
-            onClick={contributionForm.handleSubmit}
+            onClick={handleSubmitClick}
             className={classes.submitButtonStyles}
             disabled={
                 !contributionForm.isValid || pendingModerationEventFetching
@@ -1146,6 +1186,25 @@ const ProductionLocationInfo = ({
                     </div>
                 </Paper>
             </div>
+            <ContributionWarningDialog
+                open={activeWarningIndex !== null}
+                onClose={() => setActiveWarningIndex(null)}
+                onSubmitAnyway={() => {
+                    const next = activeWarningIndex + 1;
+                    setActiveWarningIndex(null);
+                    runWarningChecks(next);
+                }}
+                title={
+                    activeWarningIndex !== null
+                        ? SUBMISSION_WARNING_CHECKS[activeWarningIndex].title
+                        : ''
+                }
+                message={
+                    activeWarningIndex !== null
+                        ? SUBMISSION_WARNING_CHECKS[activeWarningIndex].message
+                        : ''
+                }
+            />
             {showProductionLocationDialog &&
             (pendingModerationEventData?.cleaned_data ||
                 localStorage.getItem(moderationID) ||

--- a/src/react/src/components/Contribute/ProductionLocationInfo.jsx
+++ b/src/react/src/components/Contribute/ProductionLocationInfo.jsx
@@ -398,7 +398,7 @@ const ProductionLocationInfo = ({
 
     /*
     The Formik library, which is used for the SLC form, doesn’t
-    automatically re-run validation when the value of the product
+    automatically re-run validation when the value of the product, location, and processing
     type and country field changes - unless the field is actively touched or
     blurred. This issue happens only when clicking the "x"
     (remove) button on a value inside the React Select
@@ -412,7 +412,14 @@ const ProductionLocationInfo = ({
     useEffect(() => {
         contributionForm.validateField('productType');
         contributionForm.validateField('country');
-    }, [contributionForm.values.productType, contributionForm.values.country]);
+        contributionForm.validateField('locationType');
+        contributionForm.validateField('processingType');
+    }, [
+        contributionForm.values.productType,
+        contributionForm.values.country,
+        contributionForm.values.locationType,
+        contributionForm.values.processingType,
+    ]);
 
     const runWarningChecks = (startIndex = 0) => {
         const { values } = contributionForm;

--- a/src/react/src/util/constants.jsx
+++ b/src/react/src/util/constants.jsx
@@ -1632,6 +1632,7 @@ export const MAX_LOCATIONS_TO_SHOW = 100;
 export const SLC_FORM_CONSTRAINTS = Object.freeze({
     MAX_PRODUCT_TYPE_COUNT: 50,
     MAX_STRING_LENGTH: 200,
+    MIN_ADDRESS_LENGTH: 25,
 });
 
 export const HEADER_HEIGHT = 116;

--- a/src/react/src/util/styles.js
+++ b/src/react/src/util/styles.js
@@ -1225,6 +1225,54 @@ export const makeConfirmNotFoundLocationDialogStyles = theme =>
         }),
     });
 
+export const makeContributionWarningDialogStyles = theme =>
+    Object.freeze({
+        dialogPaperStyles: Object.freeze({
+            borderRadius: 0,
+            padding: '24px 80px 42px',
+        }),
+        closeButtonStyles: {
+            position: 'absolute',
+            right: '16px',
+            top: '16px',
+            color: '#000',
+        },
+        dialogTitleStyles: Object.freeze({
+            fontSize: '32px',
+            lineHeight: '32px',
+            fontWeight: theme.typography.fontWeightSemiBoldPlus,
+            textAlign: 'center',
+            padding: 0,
+        }),
+        dialogBodyStyles: Object.freeze({
+            textAlign: 'center',
+            padding: '16px 0 0',
+        }),
+        dialogActionsStyles: Object.freeze({
+            display: 'flex',
+            justifyContent: 'center',
+            gap: '16px',
+            paddingTop: '24px',
+        }),
+        buttonBaseStyles: Object.freeze({
+            textTransform: 'none',
+            border: 'none',
+            height: '48px',
+            width: '309px',
+        }),
+        buttonLabelStyles: Object.freeze({
+            fontSize: '18px',
+            lineHeight: '22px',
+            fontWeight: theme.typography.fontWeightExtraBold,
+        }),
+        submitAnywayButtonStyles: Object.freeze({
+            backgroundColor: theme.palette.action.main,
+            '&:hover': {
+                backgroundColor: theme.palette.action.dark,
+            },
+        }),
+    });
+
 export const makeProductionLocationDetailsStyles = theme => ({
     locationNameStyles: Object.freeze({
         fontSize: '36px',

--- a/src/react/src/util/util.js
+++ b/src/react/src/util/util.js
@@ -1739,6 +1739,17 @@ const isCleanValueMeaningful = value => {
     return cleaned.length > 0;
 };
 
+// Allows Latin Unicode blocks: Basic Latin through Latin Extended-B
+// (U+0000-U+024F) and Latin Extended Additional (U+1E00-U+1EFF).
+// Covers accented characters like é, ü, ñ, ø, etc.
+const containsOnlyLatinCharacters = value => {
+    if (typeof value !== 'string') return true;
+    return Array.from(value).every(char => {
+        const code = char.codePointAt(0);
+        return code <= 0x024f || (code >= 0x1e00 && code <= 0x1eff);
+    });
+};
+
 const slcTextFieldValidation = stringYup()
     .test(
         'is-trimmed',
@@ -1760,6 +1771,12 @@ const slcTextFieldValidation = stringYup()
         ({ label }) => `${label} cannot contain only spaces or symbols.`,
         value => value == null || isCleanValueMeaningful(value),
     )
+    .test(
+        'latin-characters-only',
+        ({ label }) =>
+            `${label} must contain only Latin characters. Remove any non-Latin characters (e.g. Chinese, Arabic, Cyrillic).`,
+        value => value == null || containsOnlyLatinCharacters(value),
+    )
     .max(
         SLC_FORM_CONSTRAINTS.MAX_STRING_LENGTH,
         ({ label }) =>
@@ -1772,15 +1789,42 @@ export const slcValidationSchema = objectYup({
         .required('Address is required.')
         .label('Address'),
     country: objectYup().nullable().required('Country is required.'),
-    productType: arrayYup().max(
-        SLC_FORM_CONSTRAINTS.MAX_PRODUCT_TYPE_COUNT,
-        `Maximum of ${SLC_FORM_CONSTRAINTS.MAX_PRODUCT_TYPE_COUNT} product types allowed.`,
+    productType: arrayYup()
+        .max(
+            SLC_FORM_CONSTRAINTS.MAX_PRODUCT_TYPE_COUNT,
+            `Maximum of ${SLC_FORM_CONSTRAINTS.MAX_PRODUCT_TYPE_COUNT} product types allowed.`,
+        )
+        .test(
+            'latin-characters-only',
+            'Product type(s) must contain only Latin characters. Remove any non-Latin characters (e.g. Chinese, Arabic, Cyrillic).',
+            value =>
+                !value ||
+                value.every(item => containsOnlyLatinCharacters(item?.label)),
+        ),
+    locationType: arrayYup().test(
+        'latin-characters-only',
+        'Location type(s) must contain only Latin characters. Remove any non-Latin characters (e.g. Chinese, Arabic, Cyrillic).',
+        value =>
+            !value ||
+            value.every(item => containsOnlyLatinCharacters(item?.label)),
+    ),
+    processingType: arrayYup().test(
+        'latin-characters-only',
+        'Processing type(s) must contain only Latin characters. Remove any non-Latin characters (e.g. Chinese, Arabic, Cyrillic).',
+        value =>
+            !value ||
+            value.every(item => containsOnlyLatinCharacters(item?.label)),
     ),
     numberOfWorkers: stringYup()
         .test(
             'is-trimmed',
             'Remove spaces at start and end of entry.',
             value => value == null || value === value.trim(),
+        )
+        .test(
+            'latin-characters-only',
+            'Only Latin characters are accepted. Use standard digits (e.g., 5 or 3-10).',
+            value => value == null || containsOnlyLatinCharacters(value),
         )
         .test(
             'valid-format-and-range',

--- a/src/react/src/util/util.js
+++ b/src/react/src/util/util.js
@@ -1778,7 +1778,7 @@ const validNumWorkersFormat = value => {
 
 export const containsPOBox = value => {
     if (typeof value !== 'string') return false;
-    return /\b(post\s+office|p\.?\s*o\.?\s+box)\b/i.test(value);
+    return /\b(post\s+office|p\.?\s*o\.?\s*box)\b/i.test(value);
 };
 
 export const isShortAddress = value => {

--- a/src/react/src/util/util.js
+++ b/src/react/src/util/util.js
@@ -1744,10 +1744,8 @@ const isCleanValueMeaningful = value => {
 // Covers accented characters like é, ü, ñ, ø, etc.
 const containsOnlyLatinCharacters = value => {
     if (typeof value !== 'string') return true;
-    return Array.from(value).every(char => {
-        const code = char.codePointAt(0);
-        return code <= 0x024f || (code >= 0x1e00 && code <= 0x1eff);
-    });
+    const normalized = value.normalize('NFC');
+    return !/[\u0250-\u1FFF\u2070-\u2E7F\u2E80-\uFFFF]/g.test(normalized);
 };
 
 const slcTextFieldValidation = stringYup()
@@ -1783,48 +1781,32 @@ const slcTextFieldValidation = stringYup()
             `${label} cannot exceed ${SLC_FORM_CONSTRAINTS.MAX_STRING_LENGTH} characters.`,
     );
 
+const latinOnlyArrayTest = fieldName =>
+    arrayYup().test(
+        'latin-characters-only',
+        `${fieldName} must contain only Latin characters. Remove any non-Latin characters (e.g. Chinese, Arabic, Cyrillic).`,
+        value =>
+            !value ||
+            value.every(item => containsOnlyLatinCharacters(item?.label)),
+    );
+
 export const slcValidationSchema = objectYup({
     name: slcTextFieldValidation.required('Name is required.').label('Name'),
     address: slcTextFieldValidation
         .required('Address is required.')
         .label('Address'),
     country: objectYup().nullable().required('Country is required.'),
-    productType: arrayYup()
-        .max(
-            SLC_FORM_CONSTRAINTS.MAX_PRODUCT_TYPE_COUNT,
-            `Maximum of ${SLC_FORM_CONSTRAINTS.MAX_PRODUCT_TYPE_COUNT} product types allowed.`,
-        )
-        .test(
-            'latin-characters-only',
-            'Product type(s) must contain only Latin characters. Remove any non-Latin characters (e.g. Chinese, Arabic, Cyrillic).',
-            value =>
-                !value ||
-                value.every(item => containsOnlyLatinCharacters(item?.label)),
-        ),
-    locationType: arrayYup().test(
-        'latin-characters-only',
-        'Location type(s) must contain only Latin characters. Remove any non-Latin characters (e.g. Chinese, Arabic, Cyrillic).',
-        value =>
-            !value ||
-            value.every(item => containsOnlyLatinCharacters(item?.label)),
+    productType: latinOnlyArrayTest('Product type(s)').max(
+        SLC_FORM_CONSTRAINTS.MAX_PRODUCT_TYPE_COUNT,
+        `Maximum of ${SLC_FORM_CONSTRAINTS.MAX_PRODUCT_TYPE_COUNT} product types allowed.`,
     ),
-    processingType: arrayYup().test(
-        'latin-characters-only',
-        'Processing type(s) must contain only Latin characters. Remove any non-Latin characters (e.g. Chinese, Arabic, Cyrillic).',
-        value =>
-            !value ||
-            value.every(item => containsOnlyLatinCharacters(item?.label)),
-    ),
+    locationType: latinOnlyArrayTest('Location type(s)'),
+    processingType: latinOnlyArrayTest('Processing type(s)'),
     numberOfWorkers: stringYup()
         .test(
             'is-trimmed',
             'Remove spaces at start and end of entry.',
             value => value == null || value === value.trim(),
-        )
-        .test(
-            'latin-characters-only',
-            'Only Latin characters are accepted. Use standard digits (e.g., 5 or 3-10).',
-            value => value == null || containsOnlyLatinCharacters(value),
         )
         .test(
             'valid-format-and-range',
@@ -1855,7 +1837,8 @@ export const slcValidationSchema = objectYup({
 
                 return false;
             },
-        ),
+        )
+        .label('Number of workers'),
     parentCompany: slcTextFieldValidation.label('Parent company'),
 });
 

--- a/src/react/src/util/util.js
+++ b/src/react/src/util/util.js
@@ -1807,7 +1807,7 @@ const SLC_TEXT_FIELD_TESTS = Object.freeze({
     'meaningful-characters': Object.freeze({
         message: ({ label }) =>
             `${label} cannot contain only spaces or symbols.`,
-        test: value => value == null || isCleanValueMeaningful(value),
+        test: value => isEmpty(value) || isCleanValueMeaningful(value),
     }),
     'latin-characters-only': Object.freeze({
         message: ({ label }) =>
@@ -1826,7 +1826,7 @@ const SLC_TEXT_FIELD_TESTS = Object.freeze({
             'Enter a single positive number (e.g., 5) or a valid range ' +
             '(e.g., 3–10). In a range, the minimum value must be less ' +
             'than or equal to the maximum, and both must be at least 1.',
-        test: value => value == null || validNumWorkersFormat(value),
+        test: value => isEmpty(value) || validNumWorkersFormat(value),
     }),
 });
 

--- a/src/react/src/util/util.js
+++ b/src/react/src/util/util.js
@@ -1749,8 +1749,7 @@ const notANumber = value => {
 
 const containsOnlyLatinCharacters = value => {
     if (typeof value !== 'string') return true;
-    const normalized = value.normalize('NFC');
-    return !/[\u0250-\u1FFF\u2070-\u2E7F\u2E80-\uFFFF]/g.test(normalized);
+    return /^[\p{Script=Latin}\p{M}\p{N}\p{P}\s]*$/u.test(value);
 };
 
 const validNumWorkersFormat = value => {

--- a/src/react/src/util/util.js
+++ b/src/react/src/util/util.js
@@ -1724,7 +1724,6 @@ export const getSelectStyles = (isErrorState = false, extendedStyles = {}) => ({
 export const snakeToTitleCase = str => startCase(toLower(str));
 
 // SLC form validation schema.
-
 const isCleanValueMeaningful = value => {
     if (typeof value !== 'string') return false;
 
@@ -1739,107 +1738,201 @@ const isCleanValueMeaningful = value => {
     return cleaned.length > 0;
 };
 
-// Allows Latin Unicode blocks: Basic Latin through Latin Extended-B
-// (U+0000-U+024F) and Latin Extended Additional (U+1E00-U+1EFF).
-// Covers accented characters like é, ü, ñ, ø, etc.
+const notANumber = value => {
+    const numberPattern = /^-?(0|[1-9]\d*)(\.\d+)?$/;
+    return !numberPattern.test(value);
+};
+
 const containsOnlyLatinCharacters = value => {
     if (typeof value !== 'string') return true;
     const normalized = value.normalize('NFC');
     return !/[\u0250-\u1FFF\u2070-\u2E7F\u2E80-\uFFFF]/g.test(normalized);
 };
 
-const slcTextFieldValidation = stringYup()
-    .test(
-        'is-trimmed',
-        'Remove spaces at start and end of text.',
-        value => value == null || value === value.trim(),
-    )
-    .test(
-        'not-a-number',
-        ({ label }) => `${label} cannot be a number.`,
-        value => {
-            if (value == null) return true;
+const validNumWorkersFormat = value => {
+    const singleNumberPattern = /^\d+$/;
+    const rangePattern = /^(\d+)-(\d+)$/;
 
-            const numberPattern = /^-?(0|[1-9]\d*)(\.\d+)?$/;
-            return !numberPattern.test(value);
-        },
-    )
-    .test(
-        'meaningful-characters',
-        ({ label }) => `${label} cannot contain only spaces or symbols.`,
-        value => value == null || isCleanValueMeaningful(value),
-    )
-    .test(
-        'latin-characters-only',
-        ({ label }) =>
-            `${label} must contain only Latin characters. Remove any non-Latin characters (e.g. Chinese, Arabic, Cyrillic).`,
-        value => value == null || containsOnlyLatinCharacters(value),
-    )
-    .max(
-        SLC_FORM_CONSTRAINTS.MAX_STRING_LENGTH,
-        ({ label }) =>
+    if (singleNumberPattern.test(value)) {
+        return !/^0/.test(value) && parseInt(value, 10) >= 1;
+    }
+
+    const match = value.match(rangePattern);
+    if (match) {
+        const [minStr, maxStr] = match.slice(1, 3);
+
+        const min = parseInt(minStr, 10);
+        const max = parseInt(maxStr, 10);
+
+        if (/^0/.test(minStr) || /^0/.test(maxStr)) return false;
+
+        return min >= 1 && max >= 1 && min <= max;
+    }
+
+    return false;
+};
+
+export const containsPOBox = value => {
+    if (typeof value !== 'string') return false;
+    return /\b(post\s+office|p\.?\s*o\.?\s+box)\b/i.test(value);
+};
+
+export const isShortAddress = value => {
+    if (typeof value !== 'string') return false;
+    return value.trim().length < SLC_FORM_CONSTRAINTS.MIN_ADDRESS_LENGTH;
+};
+
+// ─── SLC Validation Test Registry ──────────────────────────────────────────
+//
+// To add a new check: add an entry to SLC_TEXT_FIELD_TESTS or
+// SLC_ARRAY_FIELD_TESTS, then list the key in SLC_FIELD_VALIDATION_CONFIG for
+// whichever fields should run it.
+//
+// Text-field tests receive the raw string value (possibly null/undefined).
+// Array-field tests receive the full array of { label, value } objects.
+// Message functions receive Yup params — `label` is set via .label() below.
+
+const SLC_TEXT_FIELD_TESTS = Object.freeze({
+    'is-trimmed': Object.freeze({
+        message: 'Remove spaces at start and end of text.',
+        test: value => value == null || value === value.trim(),
+    }),
+    'not-a-number': Object.freeze({
+        message: ({ label }) => `${label} cannot be a number.`,
+        test: value => value == null || notANumber(value),
+    }),
+    'meaningful-characters': Object.freeze({
+        message: ({ label }) =>
+            `${label} cannot contain only spaces or symbols.`,
+        test: value => value == null || isCleanValueMeaningful(value),
+    }),
+    'latin-characters-only': Object.freeze({
+        message: ({ label }) =>
+            `${label} must contain only Latin characters. Please translate any non-Latin characters (e.g. Chinese, Arabic, Cyrillic).`,
+        test: value => value == null || containsOnlyLatinCharacters(value),
+    }),
+    'max-char-count': Object.freeze({
+        message: ({ label }) =>
             `${label} cannot exceed ${SLC_FORM_CONSTRAINTS.MAX_STRING_LENGTH} characters.`,
-    );
+        test: value =>
+            value == null ||
+            value.length <= SLC_FORM_CONSTRAINTS.MAX_STRING_LENGTH,
+    }),
+    'valid-format-and-range': Object.freeze({
+        message:
+            'Enter a single positive number (e.g., 5) or a valid range ' +
+            '(e.g., 3–10). In a range, the minimum value must be less ' +
+            'than or equal to the maximum, and both must be at least 1.',
+        test: value => value == null || validNumWorkersFormat(value),
+    }),
+});
 
-const latinOnlyArrayTest = fieldName =>
-    arrayYup().test(
-        'latin-characters-only',
-        `${fieldName} must contain only Latin characters. Remove any non-Latin characters (e.g. Chinese, Arabic, Cyrillic).`,
-        value =>
+const SLC_ARRAY_FIELD_TESTS = Object.freeze({
+    'latin-characters-only': Object.freeze({
+        message: ({ label }) =>
+            `${label} must contain only Latin characters. Remove any non-Latin characters (e.g. Chinese, Arabic, Cyrillic).`,
+        test: value =>
             !value ||
             value.every(item => containsOnlyLatinCharacters(item?.label)),
+    }),
+    'max-product-type-count': Object.freeze({
+        message: `Maximum of ${SLC_FORM_CONSTRAINTS.MAX_PRODUCT_TYPE_COUNT} product types allowed.`,
+        test: value =>
+            !value ||
+            value.length <= SLC_FORM_CONSTRAINTS.MAX_PRODUCT_TYPE_COUNT,
+    }),
+});
+
+// ─── Per-field validation config ───────────────────────────────────────────
+//
+// Lists which named tests each field runs, in order. Fields of type 'text'
+// draw from SLC_TEXT_FIELD_TESTS; 'array' fields draw from SLC_ARRAY_FIELD_TESTS.
+// To add a test to a field, append its name to the tests array below.
+
+const SLC_FIELD_VALIDATION_CONFIG = Object.freeze({
+    name: Object.freeze({
+        type: 'text',
+        tests: [
+            'is-trimmed',
+            'not-a-number',
+            'meaningful-characters',
+            'latin-characters-only',
+        ],
+    }),
+    address: Object.freeze({
+        type: 'text',
+        tests: [
+            'is-trimmed',
+            'not-a-number',
+            'meaningful-characters',
+            'latin-characters-only',
+            'max-char-count',
+        ],
+    }),
+    parentCompany: Object.freeze({
+        type: 'text',
+        tests: [
+            'is-trimmed',
+            'not-a-number',
+            'meaningful-characters',
+            'latin-characters-only',
+        ],
+    }),
+    productType: Object.freeze({
+        type: 'array',
+        tests: ['latin-characters-only', 'max-product-type-count'],
+    }),
+    locationType: Object.freeze({
+        type: 'array',
+        tests: ['latin-characters-only'],
+    }),
+    processingType: Object.freeze({
+        type: 'array',
+        tests: ['latin-characters-only'],
+    }),
+    numberOfWorkers: Object.freeze({
+        type: 'text',
+        tests: ['is-trimmed', 'valid-format-and-range'],
+    }),
+});
+
+const buildFieldValidation = ({ type, tests }) => {
+    const isArrayField = type === 'array';
+    const registry = isArrayField
+        ? SLC_ARRAY_FIELD_TESTS
+        : SLC_TEXT_FIELD_TESTS;
+    return tests.reduce(
+        (schema, testName) => {
+            const { message, test } = registry[testName];
+            return schema.test(testName, message, test);
+        },
+        isArrayField ? arrayYup() : stringYup(),
     );
+};
 
 export const slcValidationSchema = objectYup({
-    name: slcTextFieldValidation.required('Name is required.').label('Name'),
-    address: slcTextFieldValidation
+    name: buildFieldValidation(SLC_FIELD_VALIDATION_CONFIG.name)
+        .required('Name is required.')
+        .label('Name'),
+    address: buildFieldValidation(SLC_FIELD_VALIDATION_CONFIG.address)
         .required('Address is required.')
         .label('Address'),
     country: objectYup().nullable().required('Country is required.'),
-    productType: latinOnlyArrayTest('Product type(s)').max(
-        SLC_FORM_CONSTRAINTS.MAX_PRODUCT_TYPE_COUNT,
-        `Maximum of ${SLC_FORM_CONSTRAINTS.MAX_PRODUCT_TYPE_COUNT} product types allowed.`,
-    ),
-    locationType: latinOnlyArrayTest('Location type(s)'),
-    processingType: latinOnlyArrayTest('Processing type(s)'),
-    numberOfWorkers: stringYup()
-        .test(
-            'is-trimmed',
-            'Remove spaces at start and end of entry.',
-            value => value == null || value === value.trim(),
-        )
-        .test(
-            'valid-format-and-range',
-            'Enter a single positive number (e.g., 5) or a valid range ' +
-                '(e.g., 3–10). In a range, the minimum value must be less ' +
-                'than or equal to the maximum, and both must be at least 1.',
-            value => {
-                if (value == null) return true;
-
-                const singleNumberPattern = /^\d+$/;
-                const rangePattern = /^(\d+)-(\d+)$/;
-
-                if (singleNumberPattern.test(value)) {
-                    return !/^0/.test(value) && parseInt(value, 10) >= 1;
-                }
-
-                const match = value.match(rangePattern);
-                if (match) {
-                    const [minStr, maxStr] = match.slice(1, 3);
-
-                    const min = parseInt(minStr, 10);
-                    const max = parseInt(maxStr, 10);
-
-                    if (/^0/.test(minStr) || /^0/.test(maxStr)) return false;
-
-                    return min >= 1 && max >= 1 && min <= max;
-                }
-
-                return false;
-            },
-        )
-        .label('Number of workers'),
-    parentCompany: slcTextFieldValidation.label('Parent company'),
+    productType: buildFieldValidation(
+        SLC_FIELD_VALIDATION_CONFIG.productType,
+    ).label('Product type(s)'),
+    locationType: buildFieldValidation(
+        SLC_FIELD_VALIDATION_CONFIG.locationType,
+    ).label('Location type(s)'),
+    processingType: buildFieldValidation(
+        SLC_FIELD_VALIDATION_CONFIG.processingType,
+    ).label('Processing type(s)'),
+    numberOfWorkers: buildFieldValidation(
+        SLC_FIELD_VALIDATION_CONFIG.numberOfWorkers,
+    ).label('Number of workers'),
+    parentCompany: buildFieldValidation(
+        SLC_FIELD_VALIDATION_CONFIG.parentCompany,
+    ).label('Parent company'),
 });
 
 /* eslint-disable camelcase */

--- a/src/react/src/util/util.js
+++ b/src/react/src/util/util.js
@@ -1797,7 +1797,7 @@ const SLC_TEXT_FIELD_TESTS = Object.freeze({
         message: 'Remove spaces at start and end of text.',
         test: value => value == null || value === value.trim(),
     }),
-    'not-a-number': Object.freeze({
+    'valid-non-number': Object.freeze({
         message: ({ label }) => `${label} cannot be a number.`,
         test: value => value == null || notANumber(value),
     }),
@@ -1854,16 +1854,17 @@ const SLC_FIELD_VALIDATION_CONFIG = Object.freeze({
         type: 'text',
         tests: [
             'is-trimmed',
-            'not-a-number',
+            'valid-non-number',
             'meaningful-characters',
             'latin-characters-only',
+            'max-char-count',
         ],
     }),
     address: Object.freeze({
         type: 'text',
         tests: [
             'is-trimmed',
-            'not-a-number',
+            'valid-non-number',
             'meaningful-characters',
             'latin-characters-only',
             'max-char-count',
@@ -1873,9 +1874,10 @@ const SLC_FIELD_VALIDATION_CONFIG = Object.freeze({
         type: 'text',
         tests: [
             'is-trimmed',
-            'not-a-number',
+            'valid-non-number',
             'meaningful-characters',
             'latin-characters-only',
+            'max-char-count',
         ],
     }),
     productType: Object.freeze({


### PR DESCRIPTION
Refactor field requirements for the SLC submission form in `src/react/src/util/util.js` to more easily add new tests in the future. Add requirements for non-Latin characters and for values to fall under a maximum length (currently 200 characters).

Add warning dialogue in `src/react/src/components/Contribute/ProductionLocationInfo.jsx` to display a bypass-able pop-up when users click submit if certain tests are not met. Add warning dialogues for PO Boxes and for values under a minimum length (currently 25 characters) in the address field.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes SLC form validation rules (Latin-only/max length) and alters the submit flow to gate submission behind new warning dialogs, which could block or change user submissions if edge cases are missed.
> 
> **Overview**
> Adds a configurable validation registry for the SLC submission schema, introducing **Latin-character-only** and **max-length (200)** checks across key text fields and Latin-only validation for select-list array fields, while keeping number-of-workers format/range validation.
> 
> Updates the production location contribution form to show a bypassable **pre-submit warning dialog** (new `ContributionWarningDialog`) for suspicious addresses (PO Box or too short, via new `containsPOBox`/`isShortAddress` helpers and `MIN_ADDRESS_LENGTH` constraint), and improves Formik select UX by marking `locationType`/`processingType` as touched and rendering their validation errors consistently.
> 
> Extends test coverage with a dedicated `slcValidationSchema` test suite and updates an existing test assertion for the trimmed-text error message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 312ac5c4eaf015f7c5a8a55218d8f877df5c0713. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->