### PR TITLE
[OSDEV-2360] Fix os_id field name in ModerationEvent OpenSearch signal

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -58,7 +58,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
     * `migrate`
     * `reindex_database`
     * `reindex_locations_with_approved_claim`
-    * `backfill_moderation_event_os_id`
 
 
 ## Release 2.22.0

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -37,6 +37,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
     * `migrate`
     * `reindex_database`
     * `reindex_locations_with_approved_claim`
+    * `backfill_moderation_event_os_id`
 
 
 ## Release 2.22.0

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### What's new
 * [OSDEV-1227](https://opensupplyhub.atlassian.net/browse/OSDEV-1227) - Replaced "Rejected" with "Feedback Phase" on user-facing list status pages (My Lists table, list detail page, and status summary message) to use more welcoming language.
+* [OSDEV-2360](https://opensupplyhub.atlassian.net/browse/OSDEV-2360) - Updated how we write os_id for moderation events so we are not dependent on Logstash to write the os_id.
 
 ### Release instructions
 * Ensure that the following commands are included in the `post_deployment` command:

--- a/src/django/api/management/commands/backfill_moderation_event_os_id.py
+++ b/src/django/api/management/commands/backfill_moderation_event_os_id.py
@@ -53,7 +53,7 @@ class Command(BaseCommand):
         updated = 0
         skipped = 0
 
-        for event in events:
+        for event in events.iterator(chunk_size=1000):
             try:
                 opensearch.client.update(
                     index=OpenSearchIndexNames.MODERATION_EVENTS_INDEX,

--- a/src/django/api/management/commands/backfill_moderation_event_os_id.py
+++ b/src/django/api/management/commands/backfill_moderation_event_os_id.py
@@ -1,0 +1,77 @@
+from django.core.management.base import BaseCommand
+from opensearchpy.exceptions import ConnectionError, NotFoundError
+
+from api.models.moderation_event import ModerationEvent
+from api.services.opensearch.opensearch import OpenSearchServiceConnection
+from api.views.v1.index_names import OpenSearchIndexNames
+
+
+class Command(BaseCommand):
+    help = (
+        'Backfills os_id into OpenSearch for approved moderation events '
+        'where it is missing due to the signal writing the wrong field name.'
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            help=(
+                'Show how many events would be updated without '
+                'actually writing to OpenSearch.'
+            )
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options.get('dry_run', False)
+
+        events = ModerationEvent.objects.filter(
+            status=ModerationEvent.Status.APPROVED,
+            os_id__isnull=False,
+        ).values('uuid', 'os_id')
+
+        count = events.count()
+
+        if count == 0:
+            self.stdout.write(
+                self.style.WARNING('No approved events with os_id found.')
+            )
+            return
+
+        self.stdout.write(f'Found {count} events to update.')
+
+        if dry_run:
+            self.stdout.write(
+                self.style.WARNING(
+                    f'DRY RUN: Would update {count} events. '
+                    'Run without --dry-run to write to OpenSearch.'
+                )
+            )
+            return
+
+        opensearch = OpenSearchServiceConnection()
+        updated = 0
+        skipped = 0
+
+        for event in events:
+            try:
+                opensearch.client.update(
+                    index=OpenSearchIndexNames.MODERATION_EVENTS_INDEX,
+                    id=str(event['uuid']),
+                    body={'doc': {'os_id': event['os_id']}},
+                )
+                updated += 1
+            except NotFoundError:
+                skipped += 1
+            except ConnectionError as e:
+                self.stderr.write(
+                    self.style.ERROR(f'Connection error: {e}')
+                )
+                raise
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f'Done. Updated: {updated}, '
+                f'not found in OpenSearch: {skipped}.'
+            )
+        )

--- a/src/django/api/management/commands/post_deployment.py
+++ b/src/django/api/management/commands/post_deployment.py
@@ -11,3 +11,4 @@ class Command(BaseCommand):
         call_command('migrate')
         call_command('reindex_database')
         call_command('reindex_locations_with_approved_claim')
+        call_command('backfill_moderation_event_os_id')

--- a/src/django/api/signals.py
+++ b/src/django/api/signals.py
@@ -74,7 +74,7 @@ def moderation_event_update_handler_for_opensearch(
                 "doc": {
                     "uuid": str(instance.uuid),
                     "status": str(instance.status),
-                    "os": instance.os.id if instance.os else None
+                    "os_id": instance.os.id if instance.os else None
                 }
             },
         )

--- a/src/django/api/signals.py
+++ b/src/django/api/signals.py
@@ -74,7 +74,7 @@ def moderation_event_update_handler_for_opensearch(
                 "doc": {
                     "uuid": str(instance.uuid),
                     "status": str(instance.status),
-                    "os_id": instance.os.id if instance.os else None
+                    "os_id": instance.os_id
                 }
             },
         )


### PR DESCRIPTION
## What

Rename the field written by the `ModerationEvent` post-save signal from `"os"` to `"os_id"` in `src/django/api/signals.py`.

Create a new Django command to backfill missing os_ids.

## Why

When a moderation event is approved, the post-save signal immediately updates the OpenSearch document with three fields: `uuid`, `status`, and the linked facility ID. The facility ID was being written under the key `"os"`, but the rest of the system (Logstash, the contribution record frontend) expects it under `"os_id"`.

Under normal conditions this bug is invisible: Logstash runs on a schedule, picks up the approved event via its `updated_at` tracking, and does a full document replacement in OpenSearch — including `os_id` pulled directly from the `api_moderationevent` table. That replacement overwrites what the signal wrote and drops the stray `"os"` field.

The bug surfaces when Logstash falls out of sync (e.g. after a pipeline restart resets its `last_run` tracking file). Events approved during the gap are stuck with whatever the signal wrote — `os_id` is absent from their OpenSearch documents and never appears on the contribution record page.

This was observed in production: approved `NEW_LOCATION` events from a months-long window were missing `os_id` on the moderation page. The gap closed after the OSDEV-2401 deployment restarted Logstash, but historical records were not backfilled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates OpenSearch documents during signals and post-deploy, so mistakes can affect search data consistency; the new backfill command also has a likely runtime bug referencing an undefined `errors` variable.
> 
> **Overview**
> Fixes the `ModerationEvent` post-save OpenSearch update to write the facility identifier under `os_id` (instead of the incorrect `os`).
> 
> Adds a new management command, `backfill_moderation_event_os_id`, and wires it into `post_deployment` to update existing approved moderation event documents in OpenSearch with their `os_id` (with a `--dry-run` mode and skipping missing docs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b481116f57bd48a5508706ffc4ed9a9324c47383. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->