### PR TITLE
[OSDEV-2659] Apply download limits to API users in session-based auth

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -7,11 +7,14 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Introduction
 * Product name: Open Supply Hub
-* Release date: May 9, 2026
+* Release date: May 15, 2026
 
 ### What's new
 * [OSDEV-1227](https://opensupplyhub.atlassian.net/browse/OSDEV-1227) - Replaced "Rejected" with "Feedback Phase" on user-facing list status pages (My Lists table, list detail page, and status summary message) to use more welcoming language.
 * [OSDEV-2121](https://opensupplyhub.atlassian.net/browse/OSDEV-2121) - Updated the data download limits lead-in copy to not display when a user performs an unfiltered search without any search criteria or filters selected.
+
+### Code/API changes
+* [OSDEV-2659](https://opensupplyhub.atlassian.net/browse/OSDEV-2659) - Enforce download limits for all non-anonymous session-authenticated users, bypass limits only for token-authenticated API requests, and use `get_or_create_user_download_limit` in the Stripe webhook to handle users without a pre-existing limit record.
 
 ### Release instructions
 * Ensure that the following commands are included in the `post_deployment` command:

--- a/src/django/api/models/facility_download_limit.py
+++ b/src/django/api/models/facility_download_limit.py
@@ -14,9 +14,9 @@ from api.models.facility_download_limit_manager import (
 class FacilityDownloadLimit(models.Model):
     """
     Stores the number of facility records allowed for free download per
-    calendar year, the number of paid facility records for non-API
-    users, the date of last update of free facilities records, and the
-    date when paid facility records were purchased.
+    calendar year, the number of paid facility records, the date of last
+    update of free facilities records, and the date when paid facility
+    records were purchased.
     """
     uuid = models.UUIDField(
         default=uuid.uuid4,
@@ -89,9 +89,7 @@ class FacilityDownloadLimit(models.Model):
         user,
         custom_date=None
     ) -> Optional[FacilityDownloadLimit]:
-        is_api_user = not user.is_anonymous and user.has_groups
-        # If user is an API user we don't want to impose limits.
-        if is_api_user or user.is_anonymous:
+        if user.is_anonymous:
             return None
 
         defaults = {'updated_at': custom_date} if custom_date else {}

--- a/src/django/api/services/facilities_download_service.py
+++ b/src/django/api/services/facilities_download_service.py
@@ -96,6 +96,9 @@ class FacilitiesDownloadService:
 
     @staticmethod
     def get_download_limit(request):
+        if request.auth is not None:
+            return None
+
         initial_release_date = make_aware(datetime(2025, 7, 12))
 
         return FacilityDownloadLimit.get_or_create_user_download_limit(

--- a/src/django/api/tests/test_download_locations_checkout_webhook_view.py
+++ b/src/django/api/tests/test_download_locations_checkout_webhook_view.py
@@ -2,10 +2,12 @@ import stripe
 
 from unittest.mock import patch, MagicMock
 
+from django.contrib.auth.models import Group
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 
+from api.constants import FeatureGroups, SINGLE_PAID_DOWNLOAD_RECORDS
 from api.models import (
     DownloadLocationPayment,
     FacilityDownloadLimit,
@@ -146,3 +148,46 @@ class DownloadLocationsCheckoutWebhookViewTest(TestCase):
         )
         self.assertEqual(response.status_code, 500)
         self.assertIn("Unexpected error", response.content.decode())
+
+    @patch("stripe.checkout.Session.retrieve")
+    @patch("stripe.Webhook.construct_event")
+    def test_api_user_payment_credits_download_limit(
+        self,
+        mock_construct,
+        mock_retrieve
+    ):
+        group = Group.objects.get(name=FeatureGroups.CAN_SUBMIT_FACILITY)
+        self.user.groups.add(group)
+
+        session = {
+            "metadata": {"user_id": self.user.id},
+            "id": "session_api_user",
+            "payment_intent": "pi_api",
+            "amount_subtotal": 20000,
+            "amount_total": 20000,
+            "discounts": [],
+        }
+        mock_construct.return_value = {
+            "type": "checkout.session.completed",
+            "data": {"object": session},
+        }
+
+        mock_line_item = MagicMock()
+        mock_line_item.quantity = 3
+        mock_line_items = MagicMock()
+        mock_line_items.data = [mock_line_item]
+        mock_session = MagicMock()
+        mock_session.line_items = mock_line_items
+        mock_retrieve.return_value = mock_session
+
+        response = self.client.post(
+            self.url, data={}, content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 200)
+
+        self.download_limit.refresh_from_db()
+        expected_paid = 3 * SINGLE_PAID_DOWNLOAD_RECORDS
+        self.assertEqual(
+            self.download_limit.paid_download_records, expected_paid
+        )
+        self.assertIsNotNone(self.download_limit.purchase_date)

--- a/src/django/api/tests/test_facilities_download_viewset.py
+++ b/src/django/api/tests/test_facilities_download_viewset.py
@@ -1,4 +1,5 @@
 from rest_framework import status
+from rest_framework.authtoken.models import Token
 from rest_framework.test import APITestCase
 from django.urls import reverse
 from django.contrib.auth.models import Group
@@ -1345,24 +1346,70 @@ class FacilitiesDownloadViewSetTest(APITestCase):
         'FREE_FACILITIES_DOWNLOAD_LIMIT',
         FREE_FACILITIES_DOWNLOAD_LIMIT,
     )
-    def test_api_user_can_download_over_limit(self):
+    def test_api_user_subject_to_download_limit(self):
         user = self.create_user(is_api_user=True)
         self.login_user(user)
+        FacilityDownloadLimit.objects.create(
+            user=user,
+            free_download_records=FREE_FACILITIES_DOWNLOAD_LIMIT,
+            paid_download_records=0,
+        )
 
         response = self.get_facility_downloads()
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_api_user_download_decrements_quota(self):
+        user = self.create_user(is_api_user=True)
+        self.login_user(user)
+        limit = FacilityDownloadLimit.objects.create(
+            user=user,
+            free_download_records=20,
+            paid_download_records=0,
+        )
+
+        with patch(
+            'api.services.facilities_download_service.'
+            'FacilitiesDownloadService.send_email_if_needed',
+            return_value=None
+        ):
+            response = self.get_facility_downloads()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        total_count = response.data.get("count")
+
+        limit.refresh_from_db()
+        self.assertEqual(
+            limit.free_download_records,
+            max(20 - total_count, 0)
+        )
+
+    @patch(
+        'api.constants.FacilitiesDownloadSettings.'
+        'FREE_FACILITIES_DOWNLOAD_LIMIT',
+        FREE_FACILITIES_DOWNLOAD_LIMIT,
+    )
+    def test_api_user_token_auth_unlimited_downloads(self):
+        user = self.create_user(is_api_user=True)
+        Contributor.objects.create(
+            admin=user,
+            name="API Contributor",
+            contrib_type="Brand / Retailer",
+        )
+        token = Token.objects.create(user=user)
+        FacilityDownloadLimit.objects.create(
+            user=user,
+            free_download_records=FREE_FACILITIES_DOWNLOAD_LIMIT,
+            paid_download_records=0,
+        )
+
+        response = self.client.get(
+            self.download_url,
+            HTTP_AUTHORIZATION="Token {0}".format(token),
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertGreater(
             len(response.data.get("results", {}).get("rows", [])),
-            FREE_FACILITIES_DOWNLOAD_LIMIT
+            FREE_FACILITIES_DOWNLOAD_LIMIT,
         )
-
-    def test_api_user_not_limited_by_download_count(self):
-        user = self.create_user(is_api_user=True)
-        self.login_user(user)
-
-        for _ in range(5):
-            response = self.get_facility_downloads()
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_is_same_contributor_true_when_all_facilities_belong_to_user(self):
         user = self.create_user()

--- a/src/django/api/tests/test_user_serializer.py
+++ b/src/django/api/tests/test_user_serializer.py
@@ -1,6 +1,8 @@
-from api.models import User
+from django.contrib.auth.models import Group
 from rest_framework.test import APITestCase
-from api.constants import FacilitiesDownloadSettings
+
+from api.constants import FacilitiesDownloadSettings, FeatureGroups
+from api.models import User
 from api.models.facility_download_limit import FacilityDownloadLimit
 
 
@@ -40,4 +42,19 @@ class UserSerializerTest(APITestCase):
         self.assertEqual(
             number_from_db,
             FacilitiesDownloadSettings.FREE_FACILITIES_DOWNLOAD_LIMIT
+        )
+
+    def test_api_user_gets_default_allowed_records_number(self):
+        group = Group.objects.get(name=FeatureGroups.CAN_SUBMIT_FACILITY)
+        self.user.groups.add(group)
+
+        response = self.client.post(
+            "/user-login/",
+            {'email': self.email, 'password': self.test_pass},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json()["allowed_records_number"],
+            FacilitiesDownloadSettings.FREE_FACILITIES_DOWNLOAD_LIMIT,
         )

--- a/src/django/api/views/stripe/download_locations_checkout_webhook_view.py
+++ b/src/django/api/views/stripe/download_locations_checkout_webhook_view.py
@@ -5,7 +5,7 @@ from django.http import HttpResponse, HttpResponseBadRequest
 from django.views import View
 from django.utils import timezone
 
-from api.models import DownloadLocationPayment, FacilityDownloadLimit
+from api.models import DownloadLocationPayment, FacilityDownloadLimit, User
 from api.constants import SINGLE_PAID_DOWNLOAD_RECORDS
 
 
@@ -58,8 +58,10 @@ class DownloadLocationsCheckoutWebhookView(View):
                 )
                 payment.save()
 
-                download_limit = FacilityDownloadLimit.objects.get(
-                    user_id=user_id
+                user = User.objects.get(id=user_id)
+                download_limit = (
+                    FacilityDownloadLimit
+                    .get_or_create_user_download_limit(user)
                 )
 
                 full_session = stripe.checkout.Session.retrieve(

--- a/src/django/api/views/stripe/download_locations_checkout_webhook_view.py
+++ b/src/django/api/views/stripe/download_locations_checkout_webhook_view.py
@@ -5,7 +5,7 @@ from django.http import HttpResponse, HttpResponseBadRequest
 from django.views import View
 from django.utils import timezone
 
-from api.models import DownloadLocationPayment, FacilityDownloadLimit, User
+from api.models import DownloadLocationPayment, FacilityDownloadLimit
 from api.constants import SINGLE_PAID_DOWNLOAD_RECORDS
 
 
@@ -58,10 +58,10 @@ class DownloadLocationsCheckoutWebhookView(View):
                 )
                 payment.save()
 
-                user = User.objects.get(id=user_id)
-                download_limit = (
-                    FacilityDownloadLimit
-                    .get_or_create_user_download_limit(user)
+                download_limit, _ = (
+                    FacilityDownloadLimit.objects.get_or_create(
+                        user_id=user_id,
+                    )
                 )
 
                 full_session = stripe.checkout.Session.retrieve(
@@ -76,8 +76,8 @@ class DownloadLocationsCheckoutWebhookView(View):
                 download_limit.save(
                     update_fields=[
                         "paid_download_records",
-                        "purchase_date"
-                    ]
+                        "purchase_date",
+                    ],
                 )
 
             except KeyError as e:


### PR DESCRIPTION
Apply facility download limits to API users when they access the web UI via session-based authentication, while keeping programmatic token-based API access unlimited.

Previously, all users belonging to an API group (`has_groups`) were fully exempt from download limits regardless of how they authenticated. This meant API users browsing the web UI could bypass download quotas that regular users were subject to — an unintended loophole.
