### PR TITLE
[OSDEV-2659] Fix download limit handling for API users and harden Stripe webhook

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -25,7 +25,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * Ensure that the following commands are included in the `post_deployment` command:
     * `migrate`
     * `reindex_database`
-    * `reindex_locations_with_approved_claim`
     * `backfill_moderation_event_os_id`
 
 

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Introduction
 * Product name: Open Supply Hub
-* Release date: May 9, 2026
+* Release date: May 15 2026
 
 ### What's new
 * [OSDEV-1227](https://opensupplyhub.atlassian.net/browse/OSDEV-1227) - Replaced "Rejected" with "Feedback Phase" on user-facing list status pages (My Lists table, list detail page, and status summary message) to use more welcoming language.
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-2547](https://opensupplyhub.atlassian.net/browse/OSDEV-2547) - Refactored field tests and added warning pop-ups for the SLC submission form.
 * [OSDEV-2360](https://opensupplyhub.atlassian.net/browse/OSDEV-2360) - Updated how we write os_id for moderation events so we are not dependent on Logstash to write the os_id.
 
+### Code/API changes
+* [OSDEV-2659](https://opensupplyhub.atlassian.net/browse/OSDEV-2659) - Updated download limits logic: exempt API-token requests from data download limits, add idempotent duplicate webhook handling, and use `get_or_create` for `FacilityDownloadLimit` in the checkout webhook.
 
 ### Architecture/Environment changes
 * Increased the RDS `work_mem` parameter from 20000 KB to 65536 KB (64 MB) in Terraform configuration to improve query performance for memory-intensive operations.
@@ -35,9 +37,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Bugfix
 * [OSDEV-2563](https://opensupplyhub.atlassian.net/browse/OSDEV-2563) - Fix partner fields in facility download to use unfiltered extended fields, and add 10-minute cache to the all_contributors endpoint.
-
-### Code/API changes
-* [OSDEV-2659](https://opensupplyhub.atlassian.net/browse/OSDEV-2659) - Updated download limits logic: exempt API-token requests from data download limits, add idempotent duplicate webhook handling, and use `get_or_create` for `FacilityDownloadLimit` in the checkout webhook.
 
 ### What's new
 * [OSDEV-2557](https://opensupplyhub.atlassian.net/browse/OSDEV-2557) - Hyphenate Spotlight Partners description text in the **Understanding Data Sources** section.

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -29,6 +29,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Bugfix
 * [OSDEV-2563](https://opensupplyhub.atlassian.net/browse/OSDEV-2563) - Fix partner fields in facility download to use unfiltered extended fields, and add 10-minute cache to the all_contributors endpoint.
 
+### Code/API changes
+* [OSDEV-2659](https://opensupplyhub.atlassian.net/browse/OSDEV-2659) - Updated download limits logic: exempt API-token requests from data download limits, add idempotent duplicate webhook handling, and use `get_or_create` for `FacilityDownloadLimit` in the checkout webhook.
+
 ### What's new
 * [OSDEV-2557](https://opensupplyhub.atlassian.net/browse/OSDEV-2557) - Hyphenate Spotlight Partners description text in the **Understanding Data Sources** section.
 * [OSDEV-2564](https://opensupplyhub.atlassian.net/browse/OSDEV-2564) - Renamed navbar labels ('Premium Features' → 'Featured Solutions', 'Data Cleaning Service' → 'Embedded Map', 'Pricing' → 'Solutions') and updated corresponding InfoPaths to align with new feature naming.

--- a/src/django/api/management/commands/post_deployment.py
+++ b/src/django/api/management/commands/post_deployment.py
@@ -10,5 +10,4 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         call_command('migrate')
         call_command('reindex_database')
-        call_command('reindex_locations_with_approved_claim')
         call_command('backfill_moderation_event_os_id')

--- a/src/django/api/models/facility_download_limit.py
+++ b/src/django/api/models/facility_download_limit.py
@@ -89,9 +89,7 @@ class FacilityDownloadLimit(models.Model):
         user,
         custom_date=None
     ) -> Optional[FacilityDownloadLimit]:
-        is_api_user = not user.is_anonymous and user.has_groups
-        # If user is an API user we don't want to impose limits.
-        if is_api_user or user.is_anonymous:
+        if user.is_anonymous:
             return None
 
         defaults = {'updated_at': custom_date} if custom_date else {}

--- a/src/django/api/services/facilities_download_service.py
+++ b/src/django/api/services/facilities_download_service.py
@@ -104,7 +104,6 @@ class FacilitiesDownloadService:
         if has_api_token:
             return None
 
-
         initial_release_date = make_aware(datetime(2025, 7, 12))
 
         return FacilityDownloadLimit.get_or_create_user_download_limit(

--- a/src/django/api/services/facilities_download_service.py
+++ b/src/django/api/services/facilities_download_service.py
@@ -96,6 +96,15 @@ class FacilitiesDownloadService:
 
     @staticmethod
     def get_download_limit(request):
+        has_api_token = request.auth is not None
+
+        # This is needed to figure out if the user is an API user or not.
+        # The main reason is that API users should be counted against their
+        # API limit when using the API, not the data download limit.
+        if has_api_token:
+            return None
+
+
         initial_release_date = make_aware(datetime(2025, 7, 12))
 
         return FacilityDownloadLimit.get_or_create_user_download_limit(

--- a/src/django/api/tests/test_download_locations_checkout_webhook_view.py
+++ b/src/django/api/tests/test_download_locations_checkout_webhook_view.py
@@ -98,6 +98,47 @@ class DownloadLocationsCheckoutWebhookViewTest(TestCase):
             ],
         )
 
+    @patch("stripe.checkout.Session.retrieve")
+    @patch("stripe.Webhook.construct_event")
+    def test_successful_payment_updates_download_limit(
+        self,
+        mock_construct,
+        mock_retrieve
+    ):
+        quantity = 3
+        session = {
+            "metadata": {"user_id": self.user.id},
+            "id": "session_456",
+            "payment_intent": "pi_456",
+            "amount_subtotal": 15000,
+            "amount_total": 15000,
+            "discounts": [],
+        }
+        mock_construct.return_value = {
+            "type": "checkout.session.completed",
+            "data": {"object": session},
+        }
+
+        mock_line_item = MagicMock()
+        mock_line_item.quantity = quantity
+        mock_line_items = MagicMock()
+        mock_line_items.data = [mock_line_item]
+        mock_session = MagicMock()
+        mock_session.line_items = mock_line_items
+        mock_retrieve.return_value = mock_session
+
+        response = self.client.post(
+            self.url, data={}, content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 200)
+
+        self.download_limit.refresh_from_db()
+        self.assertEqual(
+            self.download_limit.paid_download_records,
+            quantity * 10000,
+        )
+        self.assertIsNotNone(self.download_limit.purchase_date)
+
     @patch("stripe.Webhook.construct_event")
     def test_missing_field_returns_400(self, mock_construct):
         session = {
@@ -194,3 +235,48 @@ class DownloadLocationsCheckoutWebhookViewTest(TestCase):
         )
         self.assertEqual(response.status_code, 500)
         self.assertIn("Unexpected error", response.content.decode())
+
+    @patch("stripe.checkout.Session.retrieve")
+    @patch("stripe.Webhook.construct_event")
+    def test_payment_creates_download_limit_when_not_exists(
+        self,
+        mock_construct,
+        mock_retrieve,
+    ):
+        self.download_limit.delete()
+        self.assertFalse(
+            FacilityDownloadLimit.objects.filter(user=self.user).exists()
+        )
+
+        quantity = 2
+        session = {
+            "metadata": {"user_id": self.user.id},
+            "id": "session_new_limit",
+            "payment_intent": "pi_new",
+            "amount_subtotal": 10000,
+            "amount_total": 10000,
+            "discounts": [],
+        }
+        mock_construct.return_value = {
+            "type": "checkout.session.completed",
+            "data": {"object": session},
+        }
+
+        mock_line_item = MagicMock()
+        mock_line_item.quantity = quantity
+        mock_line_items = MagicMock()
+        mock_line_items.data = [mock_line_item]
+        mock_session = MagicMock()
+        mock_session.line_items = mock_line_items
+        mock_retrieve.return_value = mock_session
+
+        response = self.client.post(
+            self.url, data={}, content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 200)
+
+        limit = FacilityDownloadLimit.objects.get(user=self.user)
+        self.assertEqual(
+            limit.paid_download_records,
+            quantity * 10000,
+        )

--- a/src/django/api/tests/test_download_locations_checkout_webhook_view.py
+++ b/src/django/api/tests/test_download_locations_checkout_webhook_view.py
@@ -6,11 +6,7 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 
-from api.models import (
-    DownloadLocationPayment,
-    FacilityDownloadLimit,
-    User
-)
+from api.models import DownloadLocationPayment, FacilityDownloadLimit, User
 
 
 class DownloadLocationsCheckoutWebhookViewTest(TestCase):
@@ -28,13 +24,13 @@ class DownloadLocationsCheckoutWebhookViewTest(TestCase):
             updated_at=timezone.now(),
         )
 
-        self.url = reverse('download-locations-checkout-webhook')
+        self.url = reverse("download-locations-checkout-webhook")
 
     @patch("stripe.Webhook.construct_event")
     def test_invalid_payload_returns_400(self, mock_construct):
         mock_construct.side_effect = ValueError("invalid payload")
         response = self.client.post(
-            self.url, data={}, content_type='application/json'
+            self.url, data={}, content_type="application/json"
         )
         self.assertEqual(response.status_code, 400)
         self.assertIn("Invalid payload", response.content.decode())
@@ -45,7 +41,7 @@ class DownloadLocationsCheckoutWebhookViewTest(TestCase):
             "invalid signature", "signature_header"
         )
         response = self.client.post(
-            self.url, data={}, content_type='application/json'
+            self.url, data={}, content_type="application/json"
         )
         self.assertEqual(response.status_code, 400)
         self.assertIn("Invalid signature", response.content.decode())
@@ -53,9 +49,7 @@ class DownloadLocationsCheckoutWebhookViewTest(TestCase):
     @patch("stripe.checkout.Session.retrieve")
     @patch("stripe.Webhook.construct_event")
     def test_successful_payment_creates_payment_record(
-        self,
-        mock_construct,
-        mock_retrieve
+        self, mock_construct, mock_retrieve
     ):
         session = {
             "metadata": {"user_id": self.user.id},
@@ -81,7 +75,7 @@ class DownloadLocationsCheckoutWebhookViewTest(TestCase):
         mock_retrieve.return_value = mock_session
 
         response = self.client.post(
-            self.url, data={}, content_type='application/json'
+            self.url, data={}, content_type="application/json"
         )
         self.assertEqual(response.status_code, 200)
 
@@ -101,9 +95,7 @@ class DownloadLocationsCheckoutWebhookViewTest(TestCase):
     @patch("stripe.checkout.Session.retrieve")
     @patch("stripe.Webhook.construct_event")
     def test_successful_payment_updates_download_limit(
-        self,
-        mock_construct,
-        mock_retrieve
+        self, mock_construct, mock_retrieve
     ):
         quantity = 3
         session = {
@@ -128,7 +120,7 @@ class DownloadLocationsCheckoutWebhookViewTest(TestCase):
         mock_retrieve.return_value = mock_session
 
         response = self.client.post(
-            self.url, data={}, content_type='application/json'
+            self.url, data={}, content_type="application/json"
         )
         self.assertEqual(response.status_code, 200)
 
@@ -139,8 +131,13 @@ class DownloadLocationsCheckoutWebhookViewTest(TestCase):
         )
         self.assertIsNotNone(self.download_limit.purchase_date)
 
+    @patch("stripe.checkout.Session.retrieve")
     @patch("stripe.Webhook.construct_event")
-    def test_missing_field_returns_400(self, mock_construct):
+    def test_missing_field_returns_400(
+        self,
+        mock_construct,
+        mock_retrieve,
+    ):
         session = {
             "metadata": {"user_id": self.user.id},
             "id": "session_123",
@@ -152,9 +149,10 @@ class DownloadLocationsCheckoutWebhookViewTest(TestCase):
             "type": "checkout.session.completed",
             "data": {"object": session},
         }
+        mock_retrieve.return_value = MagicMock()
 
         response = self.client.post(
-            self.url, data={}, content_type='application/json'
+            self.url, data={}, content_type="application/json"
         )
         self.assertEqual(response.status_code, 400)
         self.assertIn("Missing expected field", response.content.decode())
@@ -188,12 +186,12 @@ class DownloadLocationsCheckoutWebhookViewTest(TestCase):
         mock_retrieve.return_value = mock_session
 
         response1 = self.client.post(
-            self.url, data={}, content_type='application/json'
+            self.url, data={}, content_type="application/json"
         )
         self.assertEqual(response1.status_code, 200)
 
         response2 = self.client.post(
-            self.url, data={}, content_type='application/json'
+            self.url, data={}, content_type="application/json"
         )
         self.assertEqual(response2.status_code, 200)
 
@@ -231,7 +229,7 @@ class DownloadLocationsCheckoutWebhookViewTest(TestCase):
         mock_save.side_effect = Exception("db error")
 
         response = self.client.post(
-            self.url, data={}, content_type='application/json'
+            self.url, data={}, content_type="application/json"
         )
         self.assertEqual(response.status_code, 500)
         self.assertIn("Unexpected error", response.content.decode())
@@ -271,7 +269,7 @@ class DownloadLocationsCheckoutWebhookViewTest(TestCase):
         mock_retrieve.return_value = mock_session
 
         response = self.client.post(
-            self.url, data={}, content_type='application/json'
+            self.url, data={}, content_type="application/json"
         )
         self.assertEqual(response.status_code, 200)
 

--- a/src/django/api/tests/test_download_locations_checkout_webhook_view.py
+++ b/src/django/api/tests/test_download_locations_checkout_webhook_view.py
@@ -118,6 +118,54 @@ class DownloadLocationsCheckoutWebhookViewTest(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn("Missing expected field", response.content.decode())
 
+    @patch("stripe.checkout.Session.retrieve")
+    @patch("stripe.Webhook.construct_event")
+    def test_duplicate_webhook_returns_200_without_double_counting(
+        self,
+        mock_construct,
+        mock_retrieve,
+    ):
+        session = {
+            "metadata": {"user_id": self.user.id},
+            "id": "session_duplicate",
+            "payment_intent": "pi_dup",
+            "amount_subtotal": 5000,
+            "amount_total": 2500,
+            "discounts": [],
+        }
+        mock_construct.return_value = {
+            "type": "checkout.session.completed",
+            "data": {"object": session},
+        }
+
+        mock_line_item = MagicMock()
+        mock_line_item.quantity = 1
+        mock_line_items = MagicMock()
+        mock_line_items.data = [mock_line_item]
+        mock_session = MagicMock()
+        mock_session.line_items = mock_line_items
+        mock_retrieve.return_value = mock_session
+
+        response1 = self.client.post(
+            self.url, data={}, content_type='application/json'
+        )
+        self.assertEqual(response1.status_code, 200)
+
+        response2 = self.client.post(
+            self.url, data={}, content_type='application/json'
+        )
+        self.assertEqual(response2.status_code, 200)
+
+        self.assertEqual(
+            DownloadLocationPayment.objects.filter(
+                stripe_session_id="session_duplicate"
+            ).count(),
+            1,
+        )
+
+        self.download_limit.refresh_from_db()
+        self.assertEqual(self.download_limit.paid_download_records, 10000)
+
     @patch(
         "api.views.stripe.download_locations_checkout_webhook_view"
         ".DownloadLocationPayment.save"

--- a/src/django/api/tests/test_facilities_download_viewset.py
+++ b/src/django/api/tests/test_facilities_download_viewset.py
@@ -1,4 +1,5 @@
 from rest_framework import status
+from rest_framework.authtoken.models import Token
 from rest_framework.test import APITestCase
 from django.urls import reverse
 from django.contrib.auth.models import Group
@@ -1347,7 +1348,13 @@ class FacilitiesDownloadViewSetTest(APITestCase):
     )
     def test_api_user_can_download_over_limit(self):
         user = self.create_user(is_api_user=True)
-        self.login_user(user)
+        Contributor.objects.create(
+            admin=user,
+            name="API Contributor",
+            contrib_type="Brand / Retailer",
+        )
+        token = Token.objects.create(user=user)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
 
         response = self.get_facility_downloads()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -1358,7 +1365,13 @@ class FacilitiesDownloadViewSetTest(APITestCase):
 
     def test_api_user_not_limited_by_download_count(self):
         user = self.create_user(is_api_user=True)
-        self.login_user(user)
+        Contributor.objects.create(
+            admin=user,
+            name="API Contributor",
+            contrib_type="Brand / Retailer",
+        )
+        token = Token.objects.create(user=user)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
 
         for _ in range(5):
             response = self.get_facility_downloads()
@@ -1539,3 +1552,30 @@ class FacilitiesDownloadViewSetTest(APITestCase):
             limit.refresh_from_db()
             self.assertEqual(limit.free_download_records, 0)
             self.assertEqual(limit.paid_download_records, 0)
+
+    def test_get_download_limit_returns_none_for_token_auth(self):
+        from api.services.facilities_download_service import (
+            FacilitiesDownloadService
+        )
+
+        user = self.create_user(is_api_user=True)
+        request = MagicMock()
+        request.user = user
+        request.auth = Token.objects.create(user=user)
+
+        result = FacilitiesDownloadService.get_download_limit(request)
+        self.assertIsNone(result)
+
+    def test_get_download_limit_returns_limit_for_session_auth(self):
+        from api.services.facilities_download_service import (
+            FacilitiesDownloadService
+        )
+
+        user = self.create_user()
+        request = MagicMock()
+        request.user = user
+        request.auth = None
+
+        result = FacilitiesDownloadService.get_download_limit(request)
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, FacilityDownloadLimit)

--- a/src/django/api/views/stripe/download_locations_checkout_webhook_view.py
+++ b/src/django/api/views/stripe/download_locations_checkout_webhook_view.py
@@ -57,6 +57,9 @@ class DownloadLocationsCheckoutWebhookView(View):
                     )
                     return HttpResponse(status=200)
 
+                full_session = stripe.checkout.Session.retrieve(
+                    session["id"], expand=["line_items"]
+                )
                 payment_id = session["payment_intent"]
                 amount_subtotal = session["amount_subtotal"]
                 amount_total = session["amount_total"]
@@ -76,10 +79,6 @@ class DownloadLocationsCheckoutWebhookView(View):
                     FacilityDownloadLimit.objects.get_or_create(
                         user_id=user_id,
                     )
-                )
-
-                full_session = stripe.checkout.Session.retrieve(
-                    session["id"], expand=["line_items"]
                 )
                 line_item = full_session.line_items.data[0]
                 item_quantity = line_item.quantity

--- a/src/django/api/views/stripe/download_locations_checkout_webhook_view.py
+++ b/src/django/api/views/stripe/download_locations_checkout_webhook_view.py
@@ -1,3 +1,4 @@
+import logging
 import stripe
 
 from django.conf import settings
@@ -7,6 +8,8 @@ from django.utils import timezone
 
 from api.models import DownloadLocationPayment, FacilityDownloadLimit
 from api.constants import SINGLE_PAID_DOWNLOAD_RECORDS
+
+logger = logging.getLogger(__name__)
 
 
 class DownloadLocationsCheckoutWebhookView(View):
@@ -43,6 +46,17 @@ class DownloadLocationsCheckoutWebhookView(View):
 
             try:
                 stripe_session_id = session["id"]
+
+                payment_exists = DownloadLocationPayment.objects.filter(
+                    stripe_session_id=stripe_session_id
+                ).exists()
+
+                if payment_exists:
+                    logger.info(
+                        f"Payment exists for session: {stripe_session_id}",
+                    )
+                    return HttpResponse(status=200)
+
                 payment_id = session["payment_intent"]
                 amount_subtotal = session["amount_subtotal"]
                 amount_total = session["amount_total"]
@@ -69,14 +83,13 @@ class DownloadLocationsCheckoutWebhookView(View):
                 )
                 line_item = full_session.line_items.data[0]
                 item_quantity = line_item.quantity
-
                 paid_records = item_quantity * SINGLE_PAID_DOWNLOAD_RECORDS
                 download_limit.paid_download_records += paid_records
                 download_limit.purchase_date = timezone.now()
                 download_limit.save(
                     update_fields=[
                         "paid_download_records",
-                        "purchase_date"
+                        "purchase_date",
                     ]
                 )
 

--- a/src/django/api/views/stripe/download_locations_checkout_webhook_view.py
+++ b/src/django/api/views/stripe/download_locations_checkout_webhook_view.py
@@ -58,8 +58,10 @@ class DownloadLocationsCheckoutWebhookView(View):
                 )
                 payment.save()
 
-                download_limit = FacilityDownloadLimit.objects.get(
-                    user_id=user_id
+                download_limit, _ = (
+                    FacilityDownloadLimit.objects.get_or_create(
+                        user_id=user_id,
+                    )
                 )
 
                 full_session = stripe.checkout.Session.retrieve(


### PR DESCRIPTION
Resolve the discrepancy where API users who purchased additional data downloads via the UI checkout never received their credits, requiring manual admin intervention.

**Problem (from [OSDEV-2659](https://opensupplyhub.atlassian.net/browse/OSDEV-2659)):** The UI enforces a 5,000-record download limit for all authenticated users (including API users) and redirects them to Stripe checkout when they exceed it. However, the backend assumed API users have unlimited UI downloads and returned `None` for their download limit — which meant the Stripe webhook callback was ignored and purchased credits were never applied. A paying API user purchased $600 worth of downloads but was still capped at 5,000 records until support manually updated the limit via Django admin.

**Solution (Option 2 from the ticket):** Update the backend to match the UI behavior — API users are now subject to standard UI data download limits and can properly receive purchased credits through Stripe checkout.

Changes:

- **`FacilitiesDownloadService.get_download_limit`** — Return `None` early when the request carries an API token (`request.auth is not None`), so API-token requests bypass the data download limit (they're counted against their API quota instead). This moves the API-user check from the model to the service layer where the request context is available.
- **`FacilityDownloadLimit.get_or_create_user_download_limit`** — Simplified to only skip anonymous users. The previous `is_api_user` check here was causing the webhook to fail when trying to update the download limit after a successful purchase.
- **`DownloadLocationsCheckoutWebhookView`** — Two fixes:
  1. Use `get_or_create` instead of `get` for `FacilityDownloadLimit`, so the limit record is created automatically if it doesn't exist yet (which happens for API users making their first UI purchase).
  2. Check for existing `DownloadLocationPayment` before processing to handle duplicate webhook deliveries from Stripe — returns 200 without double-counting.
- **Tests** — Added test for duplicate webhook idempotency: verifies a second delivery returns 200, creates only one payment record, and doesn't inflate `paid_download_records`.

[OSDEV-2659]: https://opensupplyhub.atlassian.net/browse/OSDEV-2659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ