### PR TITLE
Increase RDS work_mem from 20 MB to 64 MB to eliminate disk spilling during PostGIS queries

### DIFF
--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -291,7 +291,7 @@ variable "rds_cpu_credit_balance_threshold" {
 }
 
 variable "rds_work_mem" {
-  default = "20000"
+  default = "65536"
 }
 
 variable "rds_deletion_protection" {

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -14,6 +14,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-2121](https://opensupplyhub.atlassian.net/browse/OSDEV-2121) - Updated the data download limits lead-in copy to not display when a user performs an unfiltered search without any search criteria or filters selected.
 * [OSDEV-2547](https://opensupplyhub.atlassian.net/browse/OSDEV-2547) - Refactored field tests and added warning pop-ups for the SLC submission form.
 
+### Architecture/Environment changes
+* Increased the RDS `work_mem` parameter from 20000 KB to 65536 KB (64 MB) in Terraform configuration to improve query performance for memory-intensive operations.
+
 ### Release instructions
 * Ensure that the following commands are included in the `post_deployment` command:
     * `migrate`


### PR DESCRIPTION
Increase the PostgreSQL work_mem parameter from 20000 (≈19.5 MB) to 65536 (64 MB) in the RDS parameter group to resolve performance degradation caused by excessive temporary file I/O during PostGIS spatial operations.

During traffic spikes, the database was writing temporary files (8.5–11.7 MB each) to disk for spatial aggregation operations like ST_AsMVT (vector tile generation). Although these files appear smaller than the 19.5 MB limit, in-memory data structures (hash tables, sorting trees) consume 2–3x more space than their serialized on-disk representation. This caused PostgreSQL to spill to disk repeatedly, and when many concurrent queries hit simultaneously, disk I/O was overwhelmed.