### PR TITLE
[OSDEV-2654] Fix SLC dashboard UPDATE bug

### DIFF
--- a/src/react/src/__tests__/components/DashboardContributionRecord.test.js
+++ b/src/react/src/__tests__/components/DashboardContributionRecord.test.js
@@ -318,4 +318,44 @@ describe('DashboardContributionRecord component', () => {
 
     expect(queryByText('Close Dialog')).not.toBeInTheDocument();
   });
+
+  test('calls fetchPotentialMatches with osId when the moderation event has an os_id (UPDATE request)', async () => {
+    renderComponent({
+      dashboardContributionRecord: {
+        singleModerationEvent: {
+          data: {
+            ...data,
+            os_id: 'CN2021250D1DTU7',
+            request_type: 'UPDATE',
+          },
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(fetchPotentialMatches).toHaveBeenCalledWith(
+        expect.objectContaining({ osId: 'CN2021250D1DTU7' }),
+      );
+    });
+  });
+
+  test('calls fetchPotentialMatches with osId null when the moderation event has no os_id (CREATE request)', async () => {
+    renderComponent({
+      dashboardContributionRecord: {
+        singleModerationEvent: {
+          data: {
+            ...data,
+            os_id: null,
+            request_type: 'CREATE',
+          },
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(fetchPotentialMatches).toHaveBeenCalledWith(
+        expect.objectContaining({ osId: null }),
+      );
+    });
+  });
 });

--- a/src/react/src/actions/dashboardContributionRecord.js
+++ b/src/react/src/actions/dashboardContributionRecord.js
@@ -3,6 +3,7 @@ import apiRequest from '../util/apiRequest';
 import {
     makeModerationEventRecordURL,
     makeGetProductionLocationsForPotentialMatches,
+    makeProductionLocationURL,
     makeProductionLocationFromModerationEventURL,
     logErrorAndDispatchFailure,
 } from '../util/util';
@@ -93,40 +94,70 @@ export function fetchSingleModerationEvent(moderationID) {
     };
 }
 
+async function pinOsIdToTop(responseData, osId) {
+    const matches = responseData.data || [];
+    const existingIdx = matches.findIndex(m => m.os_id === osId);
+
+    if (existingIdx !== -1) {
+        const updated = [...matches];
+        const [item] = updated.splice(existingIdx, 1);
+        updated.unshift(item);
+        return { ...responseData, data: updated };
+    }
+
+    try {
+        const facilityResponse = await apiRequest.get(
+            makeProductionLocationURL(osId),
+        );
+        if (facilityResponse.data) {
+            return {
+                ...responseData,
+                data: [facilityResponse.data, ...matches],
+            };
+        }
+    } catch (_) {
+        // If the fetch fails, return original data without the pinned item
+    }
+
+    return responseData;
+}
+
 export function fetchPotentialMatches(data) {
-    return dispatch => {
+    return async dispatch => {
         dispatch(startFetchPotentialMatches());
 
         const {
             productionLocationName,
             productionLocationAddress,
             countryCode,
+            osId,
         } = data;
 
-        return apiRequest
-            .get(
+        try {
+            const potentialMatches = await apiRequest.get(
                 makeGetProductionLocationsForPotentialMatches(
                     productionLocationName,
                     productionLocationAddress,
                     countryCode,
                 ),
-            )
-            .then(potentialMatches => {
-                if (potentialMatches.data) {
-                    dispatch(
-                        completeFetchPotentialMatches(potentialMatches.data),
-                    );
-                }
-            })
-            .catch(err =>
-                dispatch(
-                    logErrorAndDispatchFailure(
-                        err,
-                        'An error prevented fetching potential matches',
-                        failFetchPotentialMatches,
-                    ),
+            );
+
+            if (potentialMatches.data) {
+                const responseData = osId
+                    ? await pinOsIdToTop(potentialMatches.data, osId)
+                    : potentialMatches.data;
+
+                dispatch(completeFetchPotentialMatches(responseData));
+            }
+        } catch (err) {
+            dispatch(
+                logErrorAndDispatchFailure(
+                    err,
+                    'An error prevented fetching potential matches',
+                    failFetchPotentialMatches,
                 ),
             );
+        }
     };
 }
 

--- a/src/react/src/components/Dashboard/DashboardContributionRecord.jsx
+++ b/src/react/src/components/Dashboard/DashboardContributionRecord.jsx
@@ -176,6 +176,7 @@ const DashboardContributionRecord = ({
                 productionLocationName,
                 countryCode,
                 productionLocationAddress,
+                osId,
             });
         }
     }, [productionLocationName, countryCode, productionLocationAddress, osId]);


### PR DESCRIPTION
For all UPDATE SLC moderation events, if the intended existing OSID is not returned by the API call for potential matches, the existing OSID is manually added to the list. For all UPDATE requests, the existing OSID is moved to the top of the potential matches list.