### PR TITLE
[OSDEV-2360] Backfill os_id into OpenSearch for historical moderation events

### DIFF
--- a/src/django/api/management/commands/backfill_moderation_event_os_id.py
+++ b/src/django/api/management/commands/backfill_moderation_event_os_id.py
@@ -5,6 +5,9 @@ from api.models.moderation_event import ModerationEvent
 from api.services.opensearch.opensearch import OpenSearchServiceConnection
 from api.views.v1.index_names import OpenSearchIndexNames
 
+BATCH_SIZE = 100
+SCROLL_TIMEOUT = '2m'
+
 
 class Command(BaseCommand):
     help = (
@@ -22,23 +25,66 @@ class Command(BaseCommand):
             )
         )
 
+    def __get_uuids_missing_os_id(self, opensearch):
+        """Scroll through OpenSearch to find approved events missing os_id."""
+        query = {
+            'size': BATCH_SIZE,
+            '_source': ['moderation_id'],
+            'query': {
+                'bool': {
+                    'must': [
+                        {'term': {'status': 'APPROVED'}},
+                    ],
+                    'must_not': [
+                        {'exists': {'field': 'os_id'}},
+                    ],
+                }
+            },
+        }
+
+        response = opensearch.client.search(
+            index=OpenSearchIndexNames.MODERATION_EVENTS_INDEX,
+            body=query,
+            scroll=SCROLL_TIMEOUT,
+        )
+
+        uuids = []
+        scroll_id = response['_scroll_id']
+
+        while True:
+            hits = response['hits']['hits']
+            if not hits:
+                break
+            uuids.extend(
+                hit['_source']['moderation_id'] for hit in hits
+            )
+            response = opensearch.client.scroll(
+                scroll_id=scroll_id,
+                scroll=SCROLL_TIMEOUT,
+            )
+            scroll_id = response['_scroll_id']
+
+        opensearch.client.clear_scroll(scroll_id=scroll_id)
+        return uuids
+
     def handle(self, *args, **options):
         dry_run = options.get('dry_run', False)
 
-        events = ModerationEvent.objects.filter(
-            status=ModerationEvent.Status.APPROVED,
-            os_id__isnull=False,
-        ).values('uuid', 'os_id')
+        opensearch = OpenSearchServiceConnection()
 
-        count = events.count()
+        self.stdout.write(
+            'Scanning OpenSearch for approved events missing os_id...'
+        )
+        uuids = self.__get_uuids_missing_os_id(opensearch)
+        count = len(uuids)
 
         if count == 0:
             self.stdout.write(
-                self.style.WARNING('No approved events with os_id found.')
+                self.style.SUCCESS('No events missing os_id in OpenSearch.')
             )
             return
 
-        self.stdout.write(f'Found {count} events to update.')
+        self.stdout.write(f'Found {count} events missing os_id.')
 
         if dry_run:
             self.stdout.write(
@@ -49,25 +95,35 @@ class Command(BaseCommand):
             )
             return
 
-        opensearch = OpenSearchServiceConnection()
         updated = 0
         skipped = 0
 
-        for event in events.iterator(chunk_size=1000):
-            try:
-                opensearch.client.update(
-                    index=OpenSearchIndexNames.MODERATION_EVENTS_INDEX,
-                    id=str(event['uuid']),
-                    body={'doc': {'os_id': event['os_id']}},
-                )
-                updated += 1
-            except NotFoundError:
-                skipped += 1
-            except ConnectionError as e:
-                self.stderr.write(
-                    self.style.ERROR(f'Connection error: {e}')
-                )
-                raise
+        for i in range(0, count, BATCH_SIZE):
+            batch_uuids = uuids[i:i + BATCH_SIZE]
+            events = ModerationEvent.objects.filter(
+                uuid__in=batch_uuids,
+                os_id__isnull=False,
+            ).values('uuid', 'os_id')
+
+            for event in events:
+                try:
+                    opensearch.client.update(
+                        index=OpenSearchIndexNames.MODERATION_EVENTS_INDEX,
+                        id=str(event['uuid']),
+                        body={'doc': {'os_id': event['os_id']}},
+                    )
+                    updated += 1
+                except NotFoundError:
+                    skipped += 1
+                except ConnectionError as e:
+                    self.stderr.write(
+                        self.style.ERROR(f'Connection error: {e}')
+                    )
+                    raise
+
+            self.stdout.write(
+                f'Progress: {min(i + BATCH_SIZE, count)}/{count}'
+            )
 
         self.stdout.write(
             self.style.SUCCESS(


### PR DESCRIPTION
Add a management command to repair historical approved moderation events that are missing `os_id` in OpenSearch.

## Background

The post-save signal for `ModerationEvent` was previously writing the field to OpenSearch as `"os"` instead of `"os_id"` (fixed in #986). Logstash normally masked the bug by doing full document replacements on its schedule — but when Logstash fell out of sync (pipeline restarts, index rebuilds), events approved in that window ended up permanently missing `os_id` in OpenSearch. Since Logstash's watermark-based sync only catches records updated after the last run, those historical events were never corrected.

## Changes

**`api/management/commands/backfill_moderation_event_os_id.py`** — New management command that scrolls OpenSearch to find approved events missing `os_id`, fetches the correct `os_id` from PostgreSQL, and patches only those documents. A previous iteration of this command updated all approved events unconditionally, which timed out in staging due to nearly 300k records. This version uses the OpenSearch Scroll API to target only the affected subset, then batches the PostgreSQL lookups and OpenSearch updates in groups of 100. Events where `os_id` is also absent in the DB are skipped. Supports `--dry-run` to preview the count before writing.

**`api/management/commands/post_deployment.py`** — Wires the backfill into the post-deployment step so it runs automatically on each deploy until all affected records are resolved (it exits quickly once there is nothing left to fix).

## Testing

Tested locally:
- Created a test `ModerationEvent` in the DB with `os_id` set, indexed it in OpenSearch without `os_id` to reproduce the bug
- `--dry-run` correctly identified it as needing backfill
- Live run updated the OpenSearch document; confirmed `os_id` appeared in the document afterward
- Events with no `os_id` in the DB were correctly skipped

Ticket: OSDEV-2360