### PR TITLE
[Quickfix][OSDEV-2704] Fix django.utils.timezone.utc removal in check_api_limits command

### DIFF
--- a/src/django/api/management/commands/check_api_limits.py
+++ b/src/django/api/management/commands/check_api_limits.py
@@ -1,5 +1,4 @@
 import datetime
-from django.utils import timezone
 
 from django.core.management.base import BaseCommand
 
@@ -10,4 +9,4 @@ class Command(BaseCommand):
     help = 'Manages Api Limits for Contributors.'
 
     def handle(self, *args, **options):
-        check_api_limits(datetime.datetime.now(tz=timezone.utc))
+        check_api_limits(datetime.datetime.now(tz=datetime.timezone.utc))

--- a/src/django/api/tests/test_api_limit.py
+++ b/src/django/api/tests/test_api_limit.py
@@ -19,6 +19,7 @@ from api.limitation.date.date_limitation_utils import (
 from dateutil.relativedelta import relativedelta
 from datetime import datetime, time
 
+from django.core.management import call_command
 from django.test import TestCase
 from django.utils import timezone
 
@@ -434,6 +435,9 @@ class ApiLimitTest(TestCase):
                 contributor=self.contrib_three_free
             ).first().active, False
         )
+
+    def test_check_api_limits_command_runs(self):
+        call_command('check_api_limits')
 
     def test_prepare_start_date(self):
         date_one = datetime(day=30, month=10, year=2024)


### PR DESCRIPTION
## What

Replace `django.utils.timezone.utc` with `datetime.timezone.utc` in the `check_api_limits` management command, and add a regression test that invokes the command through its entry point.

## Why

`django.utils.timezone.utc` was deprecated in Django 4.0 and removed in Django 5.0. The ECS task running this command was failing with:

```
AttributeError: module 'django.utils.timezone' has no attribute 'utc'
  File ".../check_api_limits.py", line 13, in handle
    check_api_limits(datetime.datetime.now(tz=timezone.utc))
```

The fix uses the stdlib equivalent `datetime.timezone.utc`, which has been available since Python 3.2 and is the recommended replacement.

The existing test suite (`test_api_limit.py`) did not catch this because all tests call `check_api_limits()` (the function in `api/limits.py`) directly with a pre-built datetime, bypassing the `Command.handle()` entry point entirely. The new test exercises the full command invocation via `call_command('check_api_limits')`.

Made with [Cursor](https://cursor.com)