### PR TITLE
OSDEV-2416: [Embedded Map] Percentage formatting issue

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Architecture/Environment changes
 
 ### Bugfix
+* [OSDEV-2416](https://opensupplyhub.atlassian.net/browse/OSDEV-2416) - Fixed percent-formatted columns in XLSX uploads being stored as raw decimals (e.g. `0.5`) when the column's second row was blank. The parser now checks the percent format on every cell individually, so values like `0.5` and `0.75` are correctly saved as `50%` and `75%`, and blank cells stay empty.
 
 ### What's new
 * [OSDEV-2695](https://opensupplyhub.atlassian.net/browse/OSDEV-2695) - Updated in-platform links previously pointing to `info.opensupplyhub.org/data-integrations` to point to `info.opensupplyhub.org/spotlight`, reflecting the superseded info site page.

--- a/src/django/contricleaner/lib/parsers/source_parser_xlsx.py
+++ b/src/django/contricleaner/lib/parsers/source_parser_xlsx.py
@@ -1,7 +1,6 @@
 from typing import List, Union
 
 from openpyxl import load_workbook
-from openpyxl.utils import get_column_letter
 from openpyxl.worksheet.worksheet import Worksheet
 from django.core.files.base import File
 
@@ -18,19 +17,6 @@ class SourceParserXLSX(SourceParser, FileParser):
     def _parse(file: File) -> List[dict]:
         try:
             worksheet = SourceParserXLSX.__get_xlsx_sheet(file)
-
-            # openpyxl package is 1-indexed
-            percent_col = [get_column_letter(cell.column)
-                           for cell in worksheet[2]
-                           if '%' in cell.number_format]
-
-            if percent_col:
-                for col in percent_col:
-                    for cell in worksheet[col]:
-                        if cell.row != 1:
-                            cell.value = SourceParserXLSX.__format_percent(
-                                cell.value
-                            )
 
             worksheet_rows = worksheet.rows
             # Using `next` extracts the header row, causing the iteration of
@@ -57,8 +43,14 @@ class SourceParserXLSX(SourceParser, FileParser):
         formatted_row = []
 
         for cell in row:
-            formatted_cell_value = \
-                SourceParserXLSX.__format_cell_value(cell.value)
+            if '%' in cell.number_format:
+                formatted_cell_value = SourceParserXLSX.__format_percent(
+                    cell.value
+                )
+            else:
+                formatted_cell_value = SourceParserXLSX.__format_cell_value(
+                    cell.value
+                )
             formatted_row.append(formatted_cell_value)
 
         return formatted_row
@@ -82,7 +74,9 @@ class SourceParserXLSX(SourceParser, FileParser):
 
     @staticmethod
     def __format_percent(value: Union[float, int, str, None]) -> str:
-        if value is None or isinstance(value, str):
+        if value is None:
+            return ''
+        if isinstance(value, str):
             return value
         if value <= 1.0:
             str_value = str(value * 100)

--- a/src/django/contricleaner/tests/test_source_parser_xlsx.py
+++ b/src/django/contricleaner/tests/test_source_parser_xlsx.py
@@ -232,6 +232,67 @@ class SourceParserXLSXTest(TestCase):
 
         os.remove('test.xlsx')
 
+    def test_percent_formatting_detected_per_cell_not_only_from_row_2(self):
+        """Regression test: percent cells must be detected per cell.
+
+        Previously the parser only examined row 2 to decide which columns were
+        percent-formatted.  If row 2 had a blank/None value in a percent column
+        (e.g. the contributor left that cell empty), every other row in that
+        column would be stored as a raw decimal (0.5) instead of a percentage
+        (50%).  The fix checks cell.number_format on every cell individually.
+        """
+        # Row 2 has an empty percent cell; rows 3-4 have real decimal values
+        # that must be converted to percent strings.
+        sheet_rows = (
+            ('country', 'name', 'address', 'percentage_of_male_workers'),
+            ('United States', 'Factory A', '1 Main St', None),   # row 2: blank
+            ('Canada', 'Factory B', '2 Side Ave', 0.5),          # row 3: 50%
+            ('Italy', 'Factory C', '3 Via Roma', 0.75),          # row 4: 75%
+        )
+
+        workbook = Workbook()
+        sheet = workbook.active
+        for row in sheet_rows:
+            sheet.append(row)
+
+        percentage_style = NamedStyle(
+            name='percentage',
+            number_format='0.00%'
+        )
+        # Apply percent style to ALL data cells in column 4 (including the
+        # blank row-2 cell) — this is the realistic scenario where the
+        # spreadsheet template marks the column as percent-formatted.
+        for row in sheet.iter_rows(min_row=1, max_row=len(sheet_rows),
+                                   min_col=4, max_col=4):
+            for cell in row:
+                cell.style = percentage_style
+
+        workbook.save('test_per_cell.xlsx')
+
+        with open('test_per_cell.xlsx', 'rb') as xlsx_file:
+            uploaded_file = SimpleUploadedFile(
+                'test_per_cell.xlsx', xlsx_file.read()
+            )
+
+        contri_cleaner = ContriCleaner(
+            uploaded_file,
+            SectorCacheMock(),
+            OSIDLookupMock()
+        )
+        processed_list = contri_cleaner.process_data()
+
+        percent_values = [
+            row.raw_json.get('percentage_of_male_workers')
+            for row in processed_list.rows
+        ]
+
+        # Row 2 (blank) should remain empty; rows 3-4 must be percent strings.
+        self.assertEqual(percent_values[0], '')      # blank → empty string
+        self.assertEqual(percent_values[1], '50%')   # 0.5  → '50%'
+        self.assertEqual(percent_values[2], '75%')   # 0.75 → '75%'
+
+        os.remove('test_per_cell.xlsx')
+
     @patch('contricleaner.lib.parsers.source_parser_xlsx.load_workbook')
     def test_entities_forbidden_exception(self, mock_load_workbook):
         mock_load_workbook.side_effect = EntitiesForbidden(


### PR DESCRIPTION
## Summary of Changes
OSDEV-2416 — [Embedded Map] Percentage formatting issue

- Bug: Percent-formatted columns were detected by inspecting only row 2. If row 2's cell was blank, the entire column was treated as non-percent and stored as raw decimals (e.g. 0.5 instead of 50%).
- Fix: Removed the row-2 column scan and get_column_letter import. __format_row now checks cell.number_format per cell, applying __format_percent only when % is present.
- Null handling: __format_percent now returns '' for None (previously coerced through the string branch).

### Testing
- Tests: Added test_percent_formatting_detected_per_cell_not_only_from_row_2 — blank row-2 cell stays '', while 0.5 → '50%' and 0.75 → '75%' in subsequent rows.

- As you can see, executing this query in postgres console:
`select name,address,raw_json from api_facilitylistitem order by created_at desc limit 1;`
it returns this data, meaning that the data was processed correctly:

<img width="1206" height="336" alt="image" src="https://github.com/user-attachments/assets/2d02c93d-ceb1-4667-ac7d-9a10cccca506" />

Facility that was uploaded:
<img width="926" height="515" alt="image" src="https://github.com/user-attachments/assets/d429d01d-31a5-4ce4-bebe-ae8cd127a576" />

<img width="710" height="547" alt="image" src="https://github.com/user-attachments/assets/9c9737ff-91e3-43ac-ae88-ed1a004bd7b2" />


### Known TODO Items
N/A

### Checklist
- [x] I have performed a self-review on my PR and am presenting my best work for my peers to review.
