### PR TITLE
[OSDEV-2694] Remove sustainability copy from platform footer

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -3,6 +3,34 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). The format is based on the `RELEASE-NOTES-TEMPLATE.md` file.
 
+## Release 2.24.0
+
+## Introduction
+* Product name: Open Supply Hub
+* Release date: May 29, 2026
+
+### Database changes
+
+#### Migrations
+
+#### Schema changes
+
+### Code/API changes
+
+### Architecture/Environment changes
+
+### Bugfix
+
+### What's new
+* [OSDEV-2694](https://opensupplyhub.atlassian.net/browse/OSDEV-2694) - Removed the sentence "This site was designed for low energy usage and is hosted on data centers using 100% renewable energy." from the platform footer. This copy applies to the info site only and was inadvertently included in the product footer.
+
+### Release instructions
+* Ensure that the following commands are included in the `post_deployment` command:
+    * `migrate`
+    * `reindex_database`
+
+---
+
 ## Release 2.23.0
 
 ## Introduction

--- a/src/react/src/components/Footer/FooterText.jsx
+++ b/src/react/src/components/Footer/FooterText.jsx
@@ -7,10 +7,6 @@ export default function FooterText() {
                 Open Supply Hub is established as a 501(c)(3) nonprofit
                 organization, registered in the USA.
             </p>
-            <p>
-                This site was designed for low energy usage and is hosted on
-                data centers using 100% renewable energy.
-            </p>
             <br />
             <p>
                 Open Supply Hub (OS Hub)&reg; is a registered trademark of Open


### PR DESCRIPTION
Remove the sentence "This site was designed for low energy usage and is hosted on data centers using 100% renewable energy." from the platform footer.

## Background

This sustainability statement is accurate for the info site (info.opensupplyhub.org) only, where it was originally written. It was inadvertently included in the product/platform footer, where it does not apply. The info site footer is unaffected by this change.

## Changes

**`FooterText.jsx`** — Removed the sustainability paragraph. The `<br />` spacer between the nonprofit registration line and the trademark line is preserved.

## Testing

Verify on http://localhost:6543 that:
- The sustainability sentence no longer appears in the footer
- The footer layout renders cleanly on desktop and mobile

Ticket: OSDEV-2694