### PR TITLE
[OSDEV-2695] Update /data-integrations links to /spotlight

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -3,6 +3,34 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). The format is based on the `RELEASE-NOTES-TEMPLATE.md` file.
 
+## Release 2.24.0
+
+## Introduction
+* Product name: Open Supply Hub
+* Release date: May 29, 2026
+
+### Database changes
+
+#### Migrations
+
+#### Schema changes
+
+### Code/API changes
+
+### Architecture/Environment changes
+
+### Bugfix
+
+### What's new
+* [OSDEV-2695](https://opensupplyhub.atlassian.net/browse/OSDEV-2695) - Updated in-platform links previously pointing to `info.opensupplyhub.org/data-integrations` to point to `info.opensupplyhub.org/spotlight`, reflecting the superseded info site page.
+
+### Release instructions
+* Ensure that the following commands are included in the `post_deployment` command:
+    * `migrate`
+    * `reindex_database`
+
+---
+
 ## Release 2.23.0
 
 ## Introduction

--- a/src/react/src/components/ProductionLocation/Heading/DataSourcesInfo/constants.js
+++ b/src/react/src/components/ProductionLocation/Heading/DataSourcesInfo/constants.js
@@ -35,6 +35,6 @@ export const DATA_SOURCES_ITEMS = Object.freeze([
         title: 'Spotlight Partners',
         subsectionText:
             'Additional information about facility operations or context shared by third-party platforms',
-        learnMoreUrl: 'https://info.opensupplyhub.org/data-integrations',
+        learnMoreUrl: 'https://info.opensupplyhub.org/spotlight',
     }),
 ]);

--- a/src/react/src/components/ProductionLocation/PartnerSection/PartnerDataContainer/PartnerDataContainer.jsx
+++ b/src/react/src/components/ProductionLocation/PartnerSection/PartnerDataContainer/PartnerDataContainer.jsx
@@ -69,7 +69,7 @@ function PartnerDataContainer({
                                         data listed here? Looking to access this
                                         data for compliance reporting, risk
                                         analysis, or supplier monitoring?
-                                        <LearnMoreLink href="https://info.opensupplyhub.org/data-integrations" />
+                                        <LearnMoreLink href="https://info.opensupplyhub.org/spotlight" />
                                     </>
                                 }
                                 icon={InfoOutlined}
@@ -87,7 +87,7 @@ function PartnerDataContainer({
                             production location, its context, and/or its
                             operations.{' '}
                             <a
-                                href="https://info.opensupplyhub.org/data-integrations"
+                                href="https://info.opensupplyhub.org/spotlight"
                                 target="_blank"
                                 rel="noopener noreferrer"
                             >
@@ -108,7 +108,7 @@ function PartnerDataContainer({
                                 facility.
                             </b>{' '}
                             <a
-                                href="https://info.opensupplyhub.org/data-integrations"
+                                href="https://info.opensupplyhub.org/spotlight"
                                 target="_blank"
                                 rel="noopener noreferrer"
                             >

--- a/src/react/src/util/constants.jsx
+++ b/src/react/src/util/constants.jsx
@@ -382,7 +382,7 @@ export const productionLocationInfoRouteCreate =
     '/contribute/single-location/info/:moderationID?';
 export const productionLocationInfoRouteUpdate =
     '/contribute/single-location/:osID/info/:moderationID?';
-export const pilotIntegrationsDocsRoute = `${InfoLink}/data-integrations`;
+export const pilotIntegrationsDocsRoute = `${InfoLink}/spotlight`;
 
 export const contributeFieldsEnum = Object.freeze({
     name: 'name',


### PR DESCRIPTION
Update all in-platform links pointing to `https://info.opensupplyhub.org/data-integrations` to point to `https://info.opensupplyhub.org/spotlight` instead.

## Background

The info site page at `/data-integrations` has been superseded by `/spotlight`. In-platform references need to be updated so users aren't sent to outdated content.

## Changes

Four occurrences updated across three files:

- **`util/constants.jsx`** — `pilotIntegrationsDocsRoute` constant (referenced in the Understanding Data Sources section via `PartnerFieldsSection`)
- **`PartnerDataContainer.jsx`** — tooltip link, intro text link (has-data variant), intro text link (no-data variant)
- **`DataSourcesInfo/constants.js`** — Spotlight section `learnMoreUrl`

No additional occurrences of `data-integrations` were found beyond the four above.

## Testing

The Spotlight section requires `PartnerFieldGroup` records to render, which are not present in the local dev DB. Link changes can be verified on the test environment after merge, or by inspecting the source directly.

Ticket: OSDEV-2695