### PR TITLE
[Backmerge][OSDEV-2704] Fix django timezone issue for api limit command

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Bugfix
 * [OSDEV-463](https://opensupplyhub.atlassian.net/browse/OSDEV-463) - Fixed two bugs in replaced list handling: (1) approving a replacement list now sets `Source.is_active = False` on the original (replaced) list so it no longer appears active; (2) rejecting a replacement list now clears the `replaces` FK so the original list is no longer marked as replaced and can be replaced again.
+* [OSDEV-2704](https://opensupplyhub.atlassian.net/browse/OSDEV-2704) - Fixed `check_api_limits` management command crashing with `AttributeError: module 'django.utils.timezone' has no attribute 'utc'` since the Django 3.2→5.2 upgrade. Replaced the removed `django.utils.timezone.utc` with the stdlib `datetime.timezone.utc`. Added a regression test that invokes the command via `call_command()` to cover the entry point.
 
 ### Code/API changes
 * Added configurable view-level caching (`MEMCACHED_VIEW_CACHE_TIMEOUT_SECONDS`, defaults to 600s) to contributor and facility endpoints (`all_contributors`, `ContributorFacilityListSortedViewSet`, `ContributorFacilityListViewSet`, `FacilitiesViewSet.list`, `FacilitiesViewSet.retrieve`, `UserProfileFacilities`, `UserProfileFacilityLists`) to reduce database load.

--- a/src/django/api/management/commands/check_api_limits.py
+++ b/src/django/api/management/commands/check_api_limits.py
@@ -1,5 +1,4 @@
 import datetime
-from django.utils import timezone
 
 from django.core.management.base import BaseCommand
 
@@ -10,4 +9,4 @@ class Command(BaseCommand):
     help = 'Manages Api Limits for Contributors.'
 
     def handle(self, *args, **options):
-        check_api_limits(datetime.datetime.now(tz=timezone.utc))
+        check_api_limits(datetime.datetime.now(tz=datetime.timezone.utc))

--- a/src/django/api/tests/test_api_limit.py
+++ b/src/django/api/tests/test_api_limit.py
@@ -19,6 +19,7 @@ from api.limitation.date.date_limitation_utils import (
 from dateutil.relativedelta import relativedelta
 from datetime import datetime, time
 
+from django.core.management import call_command
 from django.test import TestCase
 from django.utils import timezone
 
@@ -434,6 +435,9 @@ class ApiLimitTest(TestCase):
                 contributor=self.contrib_three_free
             ).first().active, False
         )
+
+    def test_check_api_limits_command_runs(self):
+        call_command('check_api_limits')
 
     def test_prepare_start_date(self):
         date_one = datetime(day=30, month=10, year=2024)


### PR DESCRIPTION
Backmerge of https://github.com/opensupplyhub/open-supply-hub/pull/1000

## What

Replace `django.utils.timezone.utc` with `datetime.timezone.utc` in the `check_api_limits` management command, and add a regression test that invokes the command through its entry point.

## Why

`django.utils.timezone.utc` was deprecated in Django 4.0 and removed in Django 5.0. The ECS task running this command was failing with:

```
AttributeError: module 'django.utils.timezone' has no attribute 'utc'
  File ".../check_api_limits.py", line 13, in handle
    check_api_limits(datetime.datetime.now(tz=timezone.utc))
```

The fix uses the stdlib equivalent `datetime.timezone.utc`, which has been available since Python 3.2 and is the recommended replacement.

The existing test suite (`test_api_limit.py`) did not catch this because all tests call `check_api_limits()` (the function in `api/limits.py`) directly with a pre-built datetime, bypassing the `Command.handle()` entry point entirely. The new test exercises the full command invocation via `call_command('check_api_limits')`.

Fix [OSDEV-2704](https://opensupplyhub.atlassian.net/browse/OSDEV-2704)

[OSDEV-2704]: https://opensupplyhub.atlassian.net/browse/OSDEV-2704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ