### PR TITLE
[OSDEV-2334] Claims: JavaScript error during claim submission using Google Translate mode in the browser

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -20,7 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Architecture/Environment changes
 
 ### Bugfix
-* [OSDEV-2334](https://opensupplyhub.atlassian.net/browse/OSDEV-2334) - Fixed a `NotFoundError` on `insertBefore` that blocked facility claims when browser auto-translation (e.g. Google Translate) was active, by marking the root of the claim flow components (`ClaimFacility`, `ClaimIntro`, `ClaimForm`) with `translate="no"` / `notranslate` so the browser skips them.
+* [OSDEV-2334](https://opensupplyhub.atlassian.net/browse/OSDEV-2334) - Fixed a `NotFoundError` on `insertBefore` that blocked facility claims when browser auto-translation (e.g. Google Translate) was active, by marking the root of the claim flow components (`ClaimFacility`, `ClaimIntro`, `ClaimForm`) with `translate="no"` / `notranslate` so the browser skips them for auto-traslation.
 
 ### What's new
 * [OSDEV-2694](https://opensupplyhub.atlassian.net/browse/OSDEV-2694) - Removed the sentence "This site was designed for low energy usage and is hosted on data centers using 100% renewable energy." from the platform footer. This copy applies to the info site only and was inadvertently included in the product footer.

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Architecture/Environment changes
 
 ### Bugfix
+* [OSDEV-2334](https://opensupplyhub.atlassian.net/browse/OSDEV-2334) - Fixed a `NotFoundError` on `insertBefore` that blocked facility claims when browser auto-translation (e.g. Google Translate) was active, by marking the root of the claim flow components (`ClaimFacility`, `ClaimIntro`, `ClaimForm`) with `translate="no"` / `notranslate` so the browser skips them.
 
 ### What's new
 * [OSDEV-2694](https://opensupplyhub.atlassian.net/browse/OSDEV-2694) - Removed the sentence "This site was designed for low energy usage and is hosted on data centers using 100% renewable energy." from the platform footer. This copy applies to the info site only and was inadvertently included in the product footer.

--- a/src/react/src/components/ClaimFacility.jsx
+++ b/src/react/src/components/ClaimFacility.jsx
@@ -71,7 +71,11 @@ const ClaimFacility = ({
     }
 
     return (
-        <div style={appStyles.gridStyles}>
+        <div
+            style={appStyles.gridStyles}
+            translate="no"
+            className="notranslate"
+        >
             <AppOverflow>
                 <AppGrid title="">
                     <div style={claimFacilityContainerStyles.containerStyles}>

--- a/src/react/src/components/InitialClaimFlow/ClaimForm/ClaimForm.jsx
+++ b/src/react/src/components/InitialClaimFlow/ClaimForm/ClaimForm.jsx
@@ -261,7 +261,7 @@ const ClaimForm = ({
     };
 
     return (
-        <div className={classes.container}>
+        <div className={`${classes.container} notranslate`} translate="no">
             <Typography className={classes.title}>
                 Production Location Claims Process
             </Typography>

--- a/src/react/src/components/InitialClaimFlow/ClaimIntro/ClaimIntro.jsx
+++ b/src/react/src/components/InitialClaimFlow/ClaimIntro/ClaimIntro.jsx
@@ -50,7 +50,7 @@ const ClaimIntro = ({
     };
 
     return (
-        <div className={classes.root}>
+        <div className={`${classes.root} notranslate`} translate="no">
             <AppOverflow>
                 <div className={classes.container}>
                     <div className={classes.heroSection}>


### PR DESCRIPTION
## Summary of Changes
Approach. The "quick mitigation" from the ticket: tell the browser not to auto-translate the Claim flow, so Google Translate stops swapping text nodes and React's reconciler stops crashing with NotFoundError: insertBefore. No structural code changes — just translate="no" plus the notranslate className on the root of each Claim flow component, with a comment referencing OSDEV-2334.

The previously attempted div -> li change on line 121 of ClaimAttachmentsUploader.jsx is still in place; it's correct HTML semantics: https://github.com/opensupplyhub/open-supply-hub/pull/868

### Testing
Before:
https://github.com/user-attachments/assets/cbcb03f5-1a30-4a93-942d-17c764bf9c72

After:
https://github.com/user-attachments/assets/239f467d-976a-48d3-9608-ba71e53c03a5

### Known TODO Items
N/A

### Checklist
- [x] I have performed a self-review on my PR and am presenting my best work for my peers to review.