### PR TITLE
Improve release notes process and agent guidance

### DIFF
--- a/.agent/skills/release-notes/SKILL.md
+++ b/.agent/skills/release-notes/SKILL.md
@@ -26,7 +26,7 @@ New entries go at the **top** of the file, directly after the header block (line
 
 ## Steps
 
-1. **Read the current release notes** to find the latest version number.
+1. **Read the current release notes** (`doc/release/RELEASE-NOTES.md`) to find the latest version number and the structure of existing entries before writing anything.
 2. **Determine the new version** using semver:
     - Major feature release → bump minor (e.g. `2.19.0` → `2.20.0`)
     - Hotfix → bump patch (e.g. `2.18.0` → `2.18.1`)
@@ -82,7 +82,8 @@ New entries go at the **top** of the file, directly after the header block (line
 - Ensure that the following commands are included in the `post_deployment` command:
     - `migrate`
     - `reindex_database`
-```
+
+---
 
 ## Writing Rules
 
@@ -95,4 +96,4 @@ New entries go at the **top** of the file, directly after the header block (line
 5. **Be detailed.** Each bullet should explain _what_ changed and _why_, including endpoint paths, model names, field names, and behavioral effects.
 6. **Release instructions** always include at minimum `migrate` and `reindex_database`. Add other commands (e.g. `reindex_locations_with_approved_claim`) only when the release requires them.
 7. **Release date** — use the actual date if known, otherwise leave as `*Provide release date*`.
-8. **Separate releases** with two blank lines between entries.
+8. **Separate releases** with a `---` divider followed by two blank lines between entries.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,3 +43,7 @@ docker compose exec django python manage.py test
 
 - To write the description for each PR, use the [pr-description](.agent/skills/pr-description/SKILL.md) skill.
 - To update the release notes, use the [release-notes](.agent/skills/release-notes/SKILL.md) skill.
+
+IMPORTANT: Before creating a PR, always check whether `doc/release/RELEASE-NOTES.md` has been updated on the current branch. If it has not been updated, prompt the user to update it before opening the PR.
+
+IMPORTANT: When the user asks to add, update, or write a release notes entry, always use the [release-notes](.agent/skills/release-notes/SKILL.md) skill.


### PR DESCRIPTION
Improves the process around keeping release notes up to date.

## Changes

**`AGENTS.md`** — Instructs the agent to check whether `RELEASE-NOTES.md` has been updated before opening a PR, and to prompt the user if it hasn't.

**`.agent/skills/release-notes/SKILL.md`** — Two fixes:
- Explicitly instructs the agent to read the current release notes file before writing anything
- Adds the `---` separator to the entry format and writing rules, matching the actual file convention