### PR TITLE
[Hotfix-v.2.23.1][OSDEV-2717] Removed cache_page from FacilitiesViewSet.list to fix pylibmc.TooBig 500 error

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -3,6 +3,19 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). The format is based on the `RELEASE-NOTES-TEMPLATE.md` file.
 
+## Release 2.23.1
+
+## Introduction
+* Product name: Open Supply Hub
+* Release date: May 15, 2026
+
+### Bugfix
+* [OSDEV-2717](https://opensupplyhub.atlassian.net/browse/OSDEV-2717) - Fixed HTTP 500 (`pylibmc.TooBig`) on `GET /api/facilities/` by removing the `cache_page` decorator from `FacilitiesViewSet.list`. When `detail=true` is passed, the response includes four additional fields per facility (`contributors`, `extended_fields`, `contributor_fields`, `sector`), causing the serialized page to exceed Memcached's 1 MB item size limit. Removing caching from this endpoint resolves the crash for all requests to the facilities list.
+
+### Release instructions
+* Ensure that no commands are included in the `post_deployment` command.
+
+
 ## Release 2.23.0
 
 ## Introduction

--- a/src/django/api/management/commands/post_deployment.py
+++ b/src/django/api/management/commands/post_deployment.py
@@ -1,5 +1,4 @@
 from django.core.management.base import BaseCommand
-from django.core.management import call_command
 
 
 class Command(BaseCommand):
@@ -8,6 +7,4 @@ class Command(BaseCommand):
             'post-deployment tasks.')
 
     def handle(self, *args, **options):
-        call_command('migrate')
-        call_command('reindex_database')
-        call_command('backfill_moderation_event_os_id')
+        pass

--- a/src/django/api/views/facility/facilities_view_set.py
+++ b/src/django/api/views/facility/facilities_view_set.py
@@ -125,12 +125,6 @@ class FacilitiesViewSet(ListModelMixin,
         return super().get_throttles()
 
     @swagger_auto_schema(manual_parameters=facilities_list_parameters)
-    @method_decorator(
-        cache_page(
-            settings.MEMCACHED_VIEW_CACHE_TIMEOUT_SECONDS,
-            cache="view_cache",
-        ),
-    )
     def list(self, request):
         """
         Returns a list of facilities in GeoJSON format for a given query.


### PR DESCRIPTION
### What changed
- Removed the `@method_decorator(cache_page(...))` decorator from `FacilitiesViewSet.list` in `src/django/api/views/facility/facilities_view_set.py`.
- Reset `src/django/api/management/commands/post_deployment.py` to a no-op — no migrations are required for this hotfix.
- Added Release 2.23.1 section to `doc/release/RELEASE-NOTES.md`.

### Why
`GET /api/facilities/?detail=true` was returning HTTP 500 in production with `pylibmc.TooBig`. The `cache_page` decorator introduced in 2.23.0 wraps the list view with `UpdateCacheMiddleware`, which tries to store the full serialized response in Memcached. Memcached enforces a hard 1 MB per-item limit. When `detail=true`, the response includes four additional fields per facility (`contributors`, `extended_fields`, `contributor_fields`, `sector`); with up to 50 facilities per page this routinely exceeds 1 MB and crashes. Removing the decorator restores the pre-2.23.0 behaviour. The endpoint remains cached at the CDN layer (CloudFront, 120s TTL) for unauthenticated requests, so the performance impact is minimal.

### How to test
1. Pull the branch and start Docker: `docker compose up -d`
2. Call the endpoint with `detail=true`: