### PR TITLE
[OSDEV-2724] Fix facility list table header displaying row number instead of blank

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -9,17 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * Product name: Open Supply Hub
 * Release date: May 29, 2026
 
-### Database changes
-
-#### Migrations
-
-#### Schema changes
-
-### Code/API changes
-
-### Architecture/Environment changes
-
 ### Bugfix
+
+* Fixed facility list table header displaying "1" as a row number instead of being blank. Data rows are now numbered sequentially starting from 1. The total row count was always correct and remains unaffected.
 
 ### What's new
 * [OSDEV-2695](https://opensupplyhub.atlassian.net/browse/OSDEV-2695) - Updated in-platform links previously pointing to `info.opensupplyhub.org/data-integrations` to point to `info.opensupplyhub.org/spotlight`, reflecting the superseded info site page.

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -21,7 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Bugfix
 
-* Fixed facility list table header displaying "1" as a row number instead of being blank. Data rows are now numbered sequentially starting from 1. The total row count was always correct and remains unaffected.
+* [OSDEV-2724](https://opensupplyhub.atlassian.net/browse/OSDEV-2724) - Fixed facility list table header displaying "1" as a row number instead of being blank. Data rows are now numbered sequentially starting from 1. The total row count was always correct and remains unaffected.
 
 ### What's new
 * [OSDEV-2695](https://opensupplyhub.atlassian.net/browse/OSDEV-2695) - Updated in-platform links previously pointing to `info.opensupplyhub.org/data-integrations` to point to `info.opensupplyhub.org/spotlight`, reflecting the superseded info site page.

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -9,6 +9,16 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * Product name: Open Supply Hub
 * Release date: May 29, 2026
 
+### Database changes
+
+#### Migrations
+
+#### Schema changes
+
+### Code/API changes
+
+### Architecture/Environment changes
+
 ### Bugfix
 
 * Fixed facility list table header displaying "1" as a row number instead of being blank. Data rows are now numbered sequentially starting from 1. The total row count was always correct and remains unaffected.

--- a/src/react/src/components/FacilityListItemsTable.jsx
+++ b/src/react/src/components/FacilityListItemsTable.jsx
@@ -625,7 +625,7 @@ class FacilityListItemsTable extends Component {
                     <Table style={{ tableLayout: 'fixed', minWidth: '1200px' }}>
                         <TableHead>
                             <FacilityListItemsTableRow
-                                rowIndex="1"
+                                rowIndex=""
                                 countryName="Country Name"
                                 name="Name"
                                 address="Address"

--- a/src/react/src/util/constants.jsx
+++ b/src/react/src/util/constants.jsx
@@ -1378,7 +1378,7 @@ export const optionsForSortingResults = [
 ];
 
 // This offset is necessary to match row indices in the uploaded files.
-export const uploadedFileRowIndexOffset = 2;
+export const uploadedFileRowIndexOffset = 1;
 
 export const USER_DEFAULT_STATE = Object.freeze({
     isAnon: true,


### PR DESCRIPTION
## Summary

The header row was assigned `rowIndex="1"`, causing it to display a row number. Data rows were consequently numbered starting from 2. The header should show no row number and data rows should start at 1. The total row count displayed on the page was always correct and is unaffected by this change.

## Before

<img width="1403" height="750" alt="Screenshot 2026-05-15 at 9 09 36 PM" src="https://github.com/user-attachments/assets/fe4e4a6e-255b-4b31-bc94-b969b1568997" />

## After

<img width="1407" height="766" alt="Screenshot 2026-05-15 at 9 08 05 PM" src="https://github.com/user-attachments/assets/b0ac5fc9-9ff6-46f3-b7bd-5b9b0459e19a" />



## Test plan

- [x] Navigate to `/dashboard/lists` and open a facility list
- [x] Confirm the header row has a blank first column (no row number)
- [x] Confirm data rows are numbered starting from 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)