### PR TITLE
Add reusable agent skills and quick-start guidance.

### DIFF
--- a/.agents/skills/pr-description/SKILL.md
+++ b/.agents/skills/pr-description/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: pr-description
+description: Write high-quality pull request descriptions based on Google's CL description best practices. Use when creating a pull request, writing a PR description, or when the user asks to describe changes for a PR or merge request.
+---
+
+# Writing Good PR Descriptions
+
+Based on [Google's CL description guidelines](https://google.github.io/eng-practices/review/developer/cl-descriptions.html).
+
+A PR description is a public record of change. It must communicate:
+
+1. **What** change is being made — summarize so readers understand without reading the entire diff.
+2. **Why** these changes are being made — what context did the author have? What decisions aren't reflected in the code?
+
+The description becomes a permanent part of version control history. Future developers will search for the PR based on its description. If all the important information is in the code and not the description, it will be much harder to locate. And even after finding it, they need to understand _why_ the change was made — code reveals what the software does, but not why it exists.
+
+IMPORTANT: THE DESCRIPTION SHOULD BE EASY TO READ AND CONCISE!!!
+
+## Gathering Context
+
+Before writing the description, run these commands in parallel to understand the full scope of changes:
+
+- `git log --oneline <base-branch>..HEAD`
+- `git diff <base-branch>..HEAD --stat`
+- `git diff <base-branch>..HEAD`
+- `git log <base-branch>..HEAD --format="%B---"`
+
+Get the ticket id from the current branch name. For example, if the branch name is `OSDEV-1234-add-new-feature`, the ticket id is `OSDEV-1234`. Use the following command to get the ticket id:
+
+```bash
+git branch --show-current | grep -oE 'OSDEV-[0-9]+'
+```
+
+And then fetch the ticket details from JIRA using the ticket id to get additional context.
+
+## First Line
+
+- Short summary of specifically **what** is being done.
+- Complete sentence, written as though it were an order (imperative mood).
+- Followed by an empty line.
+
+The first line appears in version control history summaries, so it must be informative enough that future code searchers don't have to read the full description to understand what the PR did. It should stand alone, allowing readers to skim history quickly.
+
+Keep it short, focused, and to the point. Clarity and utility to the reader is the top concern.
+
+Say "**Delete** the FizzBuzz RPC and **replace** it with the new system." instead of "**Deleting** the FizzBuzz RPC and **replacing** it with the new system."
+
+The rest of the description does not need to be imperative.
+
+## Body is Informative
+
+The rest of the description should fill in the details and include any supplemental information a reader needs to understand the changelist holistically:
+
+- A brief description of the problem being solved
+- Why this is the best approach
+- Any shortcomings to the approach
+- Background information: bug/ticket numbers, benchmark results, links to design documents
+
+If you include links to external resources, consider that they may not be visible to future readers due to access restrictions or retention policies. Where possible, include enough context for reviewers and future readers to understand the PR without following the links.
+
+Even small PRs deserve attention to detail. Put the PR in context.
+
+## Bad PR Descriptions
+
+"Fix bug" is an inadequate description. What bug? What did you do to fix it? Other bad examples:
+
+- "Fix build."
+- "Add patch."
+- "Moving code from A to B."
+- "Phase 1."
+- "Add convenience functions."
+- "kill weird URLs."
+
+These do not provide enough useful information.
+
+## Good PR Descriptions
+
+### Functionality change
+
+> RPC: Remove size limit on RPC server message freelist.
+>
+> Servers like FizzBuzz have very large messages and would benefit from reuse. Make the freelist larger, and add a goroutine that frees the freelist entries slowly over time, so that idle servers eventually release all freelist entries.
+
+The first few words describe what the PR does. The rest talks about the problem being solved, why this is a good solution, and the specific implementation.
+
+### Refactoring
+
+> Construct a Task with a TimeKeeper to use its TimeStr and Now methods.
+>
+> Add a Now method to Task, so the borglet() getter method can be removed (which was only used by OOMCandidate to call borglet's Now method). This replaces the methods on Borglet that delegate to a TimeKeeper.
+>
+> Allowing Tasks to supply Now is a step toward eliminating the dependency on Borglet. Eventually, collaborators that depend on getting Now from the Task should be changed to use a TimeKeeper directly, but this has been an accommodation to refactoring in small steps.
+>
+> Continuing the long-range goal of refactoring the Borglet Hierarchy.
+
+The first line describes what the PR does and how this is a change from the past. The rest describes the specific implementation, the context, that the solution isn't ideal, and possible future direction. It explains _why_ the change is being made.
+
+### Small PR that needs some context
+
+> Create a Python3 build rule for status.py.
+>
+> This allows consumers who are already using this as in Python3 to depend on a rule that is next to the original status build rule instead of somewhere in their own tree. It encourages new consumers to use Python3 if they can, instead of Python2, and significantly simplifies some automated build file refactoring tools being worked on currently.
+
+The first sentence describes what's being done. The rest explains _why_ and gives the reviewer context.
+
+## Using Tags
+
+Tags are manually entered labels that categorize PRs (e.g. `[tag]`, `#tag`, `tag:`). They are optional.
+
+If using tags, consider whether they belong in the body or the first line. Limit tag usage in the first line so it doesn't obscure the content.
+
+Good:
+
+- `[banana] Peel the banana before eating.`
+- `#banana #apple: Assemble a fruit basket.`
+
+Bad:
+
+- `[banana peeler factory factory][apple picking service] Assemble a fruit basket.` — too many/long tags overwhelm the first line.
+
+## Review Before Submitting
+
+PRs can undergo significant change during review. Review the description before submitting to ensure it still reflects what the PR does.

--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: release-notes
+description: >-
+    Update release notes entries in doc/release/RELEASE-NOTES.md.
+    Use when the user asks to write, draft, add, or update release notes,
+    or when preparing a new release entry.
+---
+
+# Writing Release Notes
+
+## Gathering Context
+
+Before writing the note, run these commands in parallel to understand the full scope of changes:
+
+- `git log --oneline <base-branch>..HEAD`
+- `git diff <base-branch>..HEAD --stat`
+- `git diff <base-branch>..HEAD`
+- `git log <base-branch>..HEAD --format="%B---"`
+
+## File Location
+
+- Release notes: `doc/release/RELEASE-NOTES.md`
+- Template: `doc/release/RELEASE-NOTES-TEMPLATE.md`
+
+New entries go at the **top** of the file, directly after the header block (lines 1–4).
+
+## Steps
+
+1. **Read the current release notes** to find the latest version number.
+2. **Determine the new version** using semver:
+    - Major feature release → bump minor (e.g. `2.19.0` → `2.20.0`)
+    - Hotfix → bump patch (e.g. `2.18.0` → `2.18.1`)
+3. **Gather changes** — ask the user for, or derive from git log / PR history:
+    - New migrations and schema changes
+    - Code/API changes
+    - Architecture/environment changes
+    - Bug fixes
+    - New user-facing features
+    - Required post-deployment commands
+4. **Write the entry** following the format below.
+5. **Make them concise** - each bullet should include only the most important information, avoiding unnecessary details.
+6. **Update** the [RELEASE-NOTES.md](/doc/release/RELEASE-NOTES.md) file with the new entry.
+
+## Entry Format
+
+```markdown
+## Release X.Y.Z
+
+## Introduction
+
+- Product name: Open Supply Hub
+- Release date: _Provide release date_
+
+### Database changes
+
+#### Migrations
+
+- <filename>.py - <What the migration does>.
+
+#### Schema changes
+
+- [OSDEV-XXXX](https://opensupplyhub.atlassian.net/browse/OSDEV-XXXX) - <Describe model/table changes>.
+
+### Code/API changes
+
+- [OSDEV-XXXX](https://opensupplyhub.atlassian.net/browse/OSDEV-XXXX) - <Describe code or API changes>.
+
+### Architecture/Environment changes
+
+- [OSDEV-XXXX](https://opensupplyhub.atlassian.net/browse/OSDEV-XXXX) - <Describe infra/devops changes>.
+
+### Bugfix
+
+- [OSDEV-XXXX](https://opensupplyhub.atlassian.net/browse/OSDEV-XXXX) - <Describe the fix>.
+
+### What's new
+
+- [OSDEV-XXXX](https://opensupplyhub.atlassian.net/browse/OSDEV-XXXX) - <Describe user-facing feature or change>.
+
+### Release instructions
+
+- Ensure that the following commands are included in the `post_deployment` command:
+    - `migrate`
+    - `reindex_database`
+```
+
+## Writing Rules
+
+1. **Omit empty sections.** Only include sections that have content. Hotfix releases often only have `Bugfix` and `Release instructions`.
+2. **Link Jira tickets** using `[OSDEV-XXXX](https://opensupplyhub.atlassian.net/browse/OSDEV-XXXX)` format.
+3. **Prefix tags** when applicable:
+    - `[Hotfix][OSDEV-XXXX]` — for hotfix-specific items.
+    - `[Follow-up][OSDEV-XXXX]` — for follow-up work from a previous release.
+4. **Migration entries** use the format: `* <filename>.py - <description>.`
+5. **Be detailed.** Each bullet should explain _what_ changed and _why_, including endpoint paths, model names, field names, and behavioral effects.
+6. **Release instructions** always include at minimum `migrate` and `reindex_database`. Add other commands (e.g. `reindex_locations_with_approved_claim`) only when the release requires them.
+7. **Release date** — use the actual date if known, otherwise leave as `*Provide release date*`.
+8. **Separate releases** with two blank lines between entries.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,11 +39,12 @@ docker compose exec react yarn test --watchAll=false
 docker compose exec django python manage.py test
 ```
 
-## Release notes & PR descriptions
+## Agents & skills
 
-- To write the description for each PR, use the [pr-description](.agent/skills/pr-description/SKILL.md) skill.
-- To update the release notes, use the [release-notes](.agent/skills/release-notes/SKILL.md) skill.
-
-IMPORTANT: Before creating a PR, always check whether `doc/release/RELEASE-NOTES.md` has been updated on the current branch. If it has not been updated, prompt the user to update it before opening the PR.
-
-IMPORTANT: When the user asks to add, update, or write a release notes entry, always use the [release-notes](.agent/skills/release-notes/SKILL.md) skill.
+| Task | Tool |
+|---|---|
+| Implement a Jira ticket end-to-end (code + tests + PR description) | [implementer](.cursor/agents/implementer.md) subagent |
+| Plan a Jira ticket before implementation | [ticket-planner](.cursor/agents/ticket-planner.md) subagent |
+| Scan all codebase layers for a ticket's impact | [codebase-explorer](.cursor/agents/codebase-explorer.md) subagent |
+| Write a PR description | [pr-description](.agents/skills/pr-description/SKILL.md) skill |
+| Update release notes | [release-notes](.agents/skills/release-notes/SKILL.md) skill |


### PR DESCRIPTION
Split agent workflow docs into standalone project guidance so implementation PRs stay focused while contributors still get consistent instructions for PR descriptions and release notes.