### PR TITLE
[Quickfix-v.2.24][OSDEV-2542] Fix Data Partners dropdown behavior in sidebar search

### DIFF
--- a/src/react/src/components/Filters/DataPartnersFilter/DataPartnersFilter.jsx
+++ b/src/react/src/components/Filters/DataPartnersFilter/DataPartnersFilter.jsx
@@ -15,6 +15,7 @@ const DataPartnersFilter = ({
     selectedContributors,
     onContributorChange,
     loadGroupsIfNeeded,
+    isSideBarSearch,
 }) => {
     useEffect(() => {
         if (selectedContributors?.length) {
@@ -35,7 +36,7 @@ const DataPartnersFilter = ({
                     fetching ? 'Loading...' : 'No options'
                 }
                 disabled={fetching}
-                isSideBarSearch
+                isSideBarSearch={isSideBarSearch}
             />
         </div>
     );
@@ -52,6 +53,11 @@ DataPartnersFilter.propTypes = {
     selectedContributors: arrayOf(contributorOptionPropType).isRequired,
     onContributorChange: func.isRequired,
     loadGroupsIfNeeded: func.isRequired,
+    isSideBarSearch: bool,
+};
+
+DataPartnersFilter.defaultProps = {
+    isSideBarSearch: false,
 };
 
 const mapStateToProps = state => ({

--- a/src/react/src/components/HomepageSidebarSearch.jsx
+++ b/src/react/src/components/HomepageSidebarSearch.jsx
@@ -308,7 +308,11 @@ function FilterSidebarSearchTab({
                 <ShowOnly when={!embed}>
                     <FeatureFlag
                         flag={PRIVATE_INSTANCE}
-                        alternative={<DataPartnersFilter />}
+                        alternative={
+                            <DataPartnersFilter
+                                isSideBarSearch={isSideBarSearch}
+                            />
+                        }
                     >
                         <></>
                     </FeatureFlag>


### PR DESCRIPTION
## Summary
- Make `DataPartnersFilter` accept `isSideBarSearch` as a prop and default it to `false`.
- Keep homepage sidebar behavior by explicitly passing `isSideBarSearch={true}` from `HomepageSidebarSearch`.
- Preserve non-sidebar behavior in other contexts so dropdown positioning uses the expected mode.

Fixes [OSDEV-2542](https://opensupplyhub.atlassian.net/browse/OSDEV-2542)

[OSDEV-2542]: https://opensupplyhub.atlassian.net/browse/OSDEV-2542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ