### PR TITLE
[OSDEV-2782] [SOC 2] S3 Block Public Access feature enabled (AWS)

### DIFF
--- a/deployment/terraform/cdn.tf
+++ b/deployment/terraform/cdn.tf
@@ -81,6 +81,15 @@ resource "aws_s3_bucket_ownership_controls" "react" {
   }
 }
 
+resource "aws_s3_bucket_public_access_block" "react" {
+  bucket = aws_s3_bucket.react.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 data "aws_iam_policy_document" "react" {
   statement {
     sid    = "denyInsecureTransport"

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -3,6 +3,27 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). The format is based on the `RELEASE-NOTES-TEMPLATE.md` file.
 
+## Release 2.25.0
+
+## Introduction
+* Product name: Open Supply Hub
+* Release date: TBD
+
+### Code/API changes
+
+### Architecture/Environment changes
+* [OSDEV-2782](https://opensupplyhub.atlassian.net/browse/OSDEV-2782) Added an `aws_s3_bucket_public_access_block` resource for the React frontend S3 bucket in `deployment/terraform/cdn.tf` to enable all four Block Public Access flags (`BlockPublicAcls`, `IgnorePublicAcls`, `BlockPublicPolicy`, `RestrictPublicBuckets`). No functional impact: the bucket is fronted by CloudFront via an Origin Access Identity, so BPA does not affect the read path.
+
+### Bugfix
+
+### What's new
+
+
+### Release instructions
+* Ensure that the following commands are included in the `post_deployment` command:
+    * `migrate`
+    * `reindex_database`
+
 ## Release 2.24.0
 
 ## Introduction


### PR DESCRIPTION
## Jira Ticket
<!--
  Link the Jira ticket this PR addresses. This gives reviewers the full
  business context, acceptance criteria, and any prior discussion.
  Format: [PROJECT-123](https://your-domain.atlassian.net/browse/PROJECT-123)
-->
 *[S3 Block Public Access feature enabled (AWS)](https://opensupplyhub.atlassian.net/browse/OSDEV-2782)*

---
## Summary of Changes
<!--
  Briefly explain WHAT changed and WHY. Focus on intent, not a file-by-file
  diff (reviewers can see the diff). Mention the root cause you found in
  the codebase and the approach you took to fix it.
-->
Adds an `aws_s3_bucket_public_access_block` resource for the `react` frontend bucket in `deployment/terraform/cdn.tf`, closing the only remaining Vanta "Block Public Access" finding among the buckets we manage in Terraform.

Context: while auditing every S3 bucket in the account for the Vanta task, I found that `aws_s3_bucket.logs` and `aws_s3_bucket.files` already have BPA fully enabled in `storage.tf`, but `aws_s3_bucket.react` was missing the equivalent resource. The bucket is fronted by CloudFront via an Origin Access Identity (see existing `aws_cloudfront_origin_access_identity.react` and bucket policy in `cdn.tf:84-128`), so enabling all four BPA flags has no functional impact — CloudFront authenticates as the OAI rather than relying on anonymous reads.


---
## Type of Change
<!--
  Check all that apply. This helps reviewers focus on the right risks
  (e.g., a UI change needs visual review, an architectural change needs
  design review).
-->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [] Backend change (API, database, business logic)
- [ ] UI / frontend change
- [x] Architectural change (affects structure, contracts, or shared modules)
- [ ] Refactor (no functional change)
- [ ] Breaking change (existing functionality may not work as before)
- [] Documentation / tooling only

---
## Testing
<!--
  Describe HOW you verified the fix. Include the scenarios you covered
  (happy path, edge cases, regressions). For UI changes, attach
  screenshots or a short screen recording. For backend changes, note
  the requests/queries you ran. For architectural changes, describe
  the manual or integration tests performed.
-->
**Static checks**
- `terraform fmt deployment/terraform/cdn.tf` — no diff
- `terraform validate` — passes

**Plan output** (against staging tfvars) — exactly one additive change, no destroys, no modifications to other resources:

```
+ resource "aws_s3_bucket_public_access_block" "react" {
    + block_public_acls       = true
    + block_public_policy     = true
    + bucket                  = (known after apply)
    + ignore_public_acls      = true
    + restrict_public_buckets = true
}
Plan: 1 to add, 0 to change, 0 to destroy.
```

**Post-apply verification (planned per environment)**
1. Confirm BPA reports all four flags enabled:
   `aws s3api get-public-access-block --bucket <react-bucket-name>`
2. Load the React frontend through CloudFront and verify it serves normally (index page + at least one deep route, since CloudFront → OAI → S3 is the read path that BPA does not affect).
3. Re-run `scripts/audit_s3_public_access.sh` and confirm the `react` bucket now reports `OK - BPA already enforced`.

Rollout order: staging → preprod → production, verifying step (2) on each before moving on.

---
## Known TODO Items
<!--
  List anything intentionally left out of this PR: follow-up tickets,
  known limitations, technical debt introduced, or items deferred to
  a future iteration. Write "None" if everything is included.
-->
Out of scope for this PR (tracked in `doc/s3-public-access-audit.md`, follow-up tickets to be opened after team review):

- **Delete 5 stale + 2 empty legacy buckets** (old `openapparelregistry-*` tilecache & logs, unused Elastic Beanstalk / CloudFormation-templates / Athena-query-results buckets). Not in Terraform; deletion will happen via CLI after team sign-off.
- **Investigate `opensupplyhub-backup-site`** — only bucket in the account currently serving public traffic (CloudFront `E3GSM48U92QXQX` + S3 website endpoint, pre-OAC pattern). Two paths documented in the audit doc: delete the bucket + distribution (preferred — last write 2023-12-07) or migrate to OAC.
- **Apply BPA outside Terraform to any keep-candidate** as defense-in-depth, even before deletion lands.

---
## Checklist
<!--
  Check the items that apply. Uncheck (or remove) any item that is not
  applicable to this PR and briefly explain why in the Summary if needed.
-->
### Implementation
- [x] My code follows the project's style guidelines and naming conventions.
- [x] I have removed debug logs, commented-out code, and unused imports.
- [x] Any AI-assisted code (e.g., Claude) has been reviewed, understood, and adapted to fit our codebase.
- [x] I have considered backward compatibility and migrations where applicable.

### Testing & Validation
- [x] I have manually tested the change in a local/dev environment.
- [ ] I have added or updated unit tests for the new/changed behavior. *(N/A — Terraform infra change; validated via `terraform plan`.)*
- [x] All existing tests pass locally.
- [ ] For UI changes: I have included screenshots or a recording, and verified responsive/cross-browser behavior. *(N/A — no UI change.)*
- [x] For backend changes: I have validated API contracts, error handling, and edge cases. *(Verified the existing CloudFront → OAI → S3 path is unaffected by BPA.)*
- [ ] For architectural changes: I have documented the design decision and notified affected teams. *(N/A — additive security control, no structural change.)*

### Documentation & Communication
- [x] I have updated relevant documentation (README, ADRs, inline comments, API docs).
- [ ] I have updated the Jira ticket status and added any relevant notes. *(N/A — Vanta-driven, no Jira ticket.)*

### Final Review
- [x] I have performed a self-review on my PR and I am presenting my best work for my peers to review.