### PR TITLE
[OSDEV-2779] Preserve contributors in embed detail URLs

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -3,6 +3,20 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). The format is based on the `RELEASE-NOTES-TEMPLATE.md` file.
 
+## Release 2.25.0
+
+## Introduction
+* Product name: Open Supply Hub
+* Release date: May 29, 2026
+
+### Bugfix
+* [OSDEV-2779](https://opensupplyhub.atlassian.net/browse/OSDEV-2779) - Fixed embedded map location profiles showing only Name and Sector after opening a facility from the map. `getFilteredSearchForEmbed()` (introduced in OSDEV-2352) preserved only the `contributor` query parameter when building embed detail URLs, but embed list URLs use `contributors`. Clicking a facility dropped the contributor ID from the URL, so embed config was not loaded and the facility API was not called with embed contributor context. The helper now preserves `contributors` so configured embed fields render on the profile again.
+
+### Release instructions
+* Ensure that the following commands are included in the `post_deployment` command:
+    * `migrate`
+    * `reindex_database`
+
 ## Release 2.24.0
 
 ## Introduction

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Introduction
 * Product name: Open Supply Hub
-* Release date: May 29, 2026
+* Release date: June 12, 2026
 
 ### Bugfix
 * [OSDEV-2779](https://opensupplyhub.atlassian.net/browse/OSDEV-2779) - Fixed embedded map location profiles showing only Name and Sector after opening a facility from the map. `getFilteredSearchForEmbed()` (introduced in OSDEV-2352) preserved only the `contributor` query parameter when building embed detail URLs, but embed list URLs use `contributors`. Clicking a facility dropped the contributor ID from the URL, so embed config was not loaded and the facility API was not called with embed contributor context. The helper now preserves `contributors` so configured embed fields render on the profile again.

--- a/doc/release/RELEASE-PROTOCOL.md
+++ b/doc/release/RELEASE-PROTOCOL.md
@@ -84,6 +84,8 @@ This document outlines the SDLC pillars of the opensupplyhub monorepo, as well a
 | v2.21.0 | March 31, 2026 | April 4, 2026 | @Vadim Kovalenko |
 | v2.22.0 | April 21, 2026 | April 25, 2026 | @Vlad Shapik |
 | v2.23.0 | May 12, 2026 | May 15, 2026 | @Vlad Shapik |
+| v2.24.0 | May 26, 2026 | May 29, 2026 | @Vadim Kovalenko |
+| v2.25.0 | June 09, 2026 | June 12, 2026 | @Vadim Kovalenko |
 
 ## General Information
 

--- a/src/react/src/__tests__/embedModeNavigation.test.js
+++ b/src/react/src/__tests__/embedModeNavigation.test.js
@@ -71,29 +71,31 @@ const minimalAuthState = {
     },
 };
 
-const createTestStore = (overrides = {}) =>
-    setupStore({
-        facilities: minimalFacilitiesState,
+const createTestStore = (overrides = {}) => {
+    const { facilities: facilitiesOverride, ...restOverrides } = overrides;
+
+    return setupStore({
         filterOptions: {
             contributors: { data: null, fetching: false, error: null },
             parentCompanies: { data: null, fetching: false, error: null },
             lists: { data: null, fetching: false, error: null },
         },
         partnerGroupContributors: { data: null, fetching: false, error: null },
-        ...overrides,
+        ...restOverrides,
         facilities: {
             ...minimalFacilitiesState,
-            ...(overrides.facilities || {}),
+            ...(facilitiesOverride || {}),
             facilities: {
                 ...minimalFacilitiesState.facilities,
-                ...(overrides.facilities?.facilities || {}),
+                ...(facilitiesOverride?.facilities || {}),
             },
             singleFacility: {
                 ...minimalFacilitiesState.singleFacility,
-                ...(overrides.facilities?.singleFacility || {}),
+                ...(facilitiesOverride?.singleFacility || {}),
             },
         },
     });
+};
 
 describe('embed mode navigation integration', () => {
     beforeEach(() => {

--- a/src/react/src/__tests__/embedModeNavigation.test.js
+++ b/src/react/src/__tests__/embedModeNavigation.test.js
@@ -1,0 +1,236 @@
+import React from 'react';
+import { Route } from 'react-router-dom';
+import { waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { setupStore } from '../configureStore';
+import { setFiltersFromQueryString } from '../actions/filters';
+import { fetchSingleFacility } from '../actions/facilities';
+import FacilityDetailsContent from '../components/FacilityDetailsContent';
+import apiRequest from '../util/apiRequest';
+import { getFilteredSearchForEmbed } from '../util/util';
+import renderWithProviders from '../util/testUtils/renderWithProviders';
+
+jest.mock('../util/apiRequest', () => ({
+    __esModule: true,
+    default: {
+        get: jest.fn(() =>
+            Promise.resolve({
+                data: {
+                    id: 'CN20200165JMYV0',
+                    type: 'Feature',
+                    properties: {
+                        name: 'Test Facility',
+                        os_id: 'CN20200165JMYV0',
+                        sector: [],
+                        extended_fields: {},
+                    },
+                },
+            }),
+        ),
+    },
+}));
+
+jest.mock('../components/FacilityDetailsClaimFlag', () => () => null);
+jest.mock('../components/FacilityDetailsClosureStatus', () => () => null);
+jest.mock('../components/FacilityDetailsCoreFields', () => () => null);
+jest.mock('../components/FacilityDetailsInteractiveMap', () => () => null);
+jest.mock('../components/FacilityDetailsLocationFields', () => () => null);
+jest.mock('../components/FacilityDetailsGeneralFields', () => () => null);
+jest.mock('../components/PartnerFields/PartnerFieldsSection/PartnerFieldsSection', () => () => null);
+jest.mock('../components/FacilityDetailsContributors', () => () => null);
+
+const EMBED_LIST_SEARCH = '?contributors=2340&lists=9193&sort_by=name_asc&embed=1';
+const OS_ID = 'CN20200165JMYV0';
+const CONTRIBUTOR_ID = 2340;
+
+const contributorFilterOption = {
+    value: CONTRIBUTOR_ID,
+    label: String(CONTRIBUTOR_ID),
+};
+
+const minimalFacilitiesState = {
+    facilities: {
+        data: null,
+        fetching: false,
+        error: null,
+        nextPageURL: null,
+        isInfiniteLoading: false,
+        hasAppliedFilters: false,
+    },
+    singleFacility: {
+        data: null,
+        fetching: false,
+        error: null,
+    },
+};
+
+const minimalAuthState = {
+    user: {
+        claimed_facility_ids: { approved: [], pending: [] },
+    },
+};
+
+const createTestStore = (overrides = {}) =>
+    setupStore({
+        facilities: minimalFacilitiesState,
+        filterOptions: {
+            contributors: { data: null, fetching: false, error: null },
+            parentCompanies: { data: null, fetching: false, error: null },
+            lists: { data: null, fetching: false, error: null },
+        },
+        partnerGroupContributors: { data: null, fetching: false, error: null },
+        ...overrides,
+        facilities: {
+            ...minimalFacilitiesState,
+            ...(overrides.facilities || {}),
+            facilities: {
+                ...minimalFacilitiesState.facilities,
+                ...(overrides.facilities?.facilities || {}),
+            },
+            singleFacility: {
+                ...minimalFacilitiesState.singleFacility,
+                ...(overrides.facilities?.singleFacility || {}),
+            },
+        },
+    });
+
+describe('embed mode navigation integration', () => {
+    beforeEach(() => {
+        apiRequest.get.mockReset();
+        apiRequest.get.mockImplementation(() =>
+            Promise.resolve({
+                data: {
+                    id: OS_ID,
+                    type: 'Feature',
+                    properties: {
+                        name: 'Test Facility',
+                        os_id: OS_ID,
+                        sector: [],
+                        extended_fields: {},
+                    },
+                },
+            }),
+        );
+    });
+
+    describe('setFiltersFromQueryString (URL → Redux)', () => {
+        it('hydrates contributors and embed from embed list URL', async () => {
+            const store = createTestStore();
+
+            await store.dispatch(setFiltersFromQueryString(EMBED_LIST_SEARCH));
+
+            const { filters, embeddedMap } = store.getState();
+            expect(embeddedMap.embed).toBe('1');
+            expect(filters.contributors).toEqual([contributorFilterOption]);
+        });
+
+        it('clears contributors when detail URL has embed only (refresh regression)', async () => {
+            const store = createTestStore({
+                filters: {
+                    contributors: [contributorFilterOption],
+                },
+                embeddedMap: { embed: '1' },
+            });
+
+            await store.dispatch(setFiltersFromQueryString('?embed=1'));
+
+            expect(store.getState().filters.contributors).toEqual([]);
+        });
+
+        it('hydrates contributors from embed detail URL produced by getFilteredSearchForEmbed', async () => {
+            const store = createTestStore();
+            const detailSearch = getFilteredSearchForEmbed(EMBED_LIST_SEARCH);
+
+            expect(detailSearch).toBe('?embed=1&contributors=2340');
+
+            await store.dispatch(setFiltersFromQueryString(detailSearch));
+
+            expect(store.getState().filters.contributors).toEqual([
+                contributorFilterOption,
+            ]);
+        });
+    });
+
+    describe('fetchSingleFacility (Redux → API)', () => {
+        it('calls API with embed=1 and contributor when Redux has a contributor', async () => {
+            const store = createTestStore();
+
+            await store.dispatch(
+                fetchSingleFacility(
+                    OS_ID,
+                    1,
+                    [contributorFilterOption],
+                    true,
+                ),
+            );
+
+            expect(apiRequest.get).toHaveBeenCalledTimes(1);
+            const url = apiRequest.get.mock.calls[0][0];
+            expect(url).toContain(`facilities/${OS_ID}/`);
+            expect(url).toContain('embed=1');
+            expect(url).toContain(`contributor=${CONTRIBUTOR_ID}`);
+        });
+
+        it('uses non-embed API URL when embed flag is off (no contributor in Redux)', async () => {
+            const store = createTestStore();
+
+            await store.dispatch(fetchSingleFacility(OS_ID, 0, null, true));
+
+            const url = apiRequest.get.mock.calls[0][0];
+            expect(url).not.toContain('contributor=');
+            expect(url).not.toContain('embed=1');
+        });
+    });
+
+    describe('FacilityDetailsContent (hydrate + mount → fetch)', () => {
+        const renderDetailPage = async (search, preHydrateSearch) => {
+            const store = createTestStore({
+                auth: minimalAuthState,
+                embeddedMap: { embed: '', config: {}, loading: false, error: null },
+                featureFlags: { flags: {}, fetching: false },
+            });
+
+            if (preHydrateSearch) {
+                await store.dispatch(setFiltersFromQueryString(preHydrateSearch));
+            }
+
+            renderWithProviders(
+                <MemoryRouter
+                    initialEntries={[`/facilities/${OS_ID}${search}`]}
+                >
+                    <Route
+                        path="/facilities/:osID"
+                        component={FacilityDetailsContent}
+                    />
+                </MemoryRouter>,
+                { reduxStore: store },
+            );
+
+            return store;
+        };
+
+        it('fetches facility with embed contributor after list URL hydration', async () => {
+            await renderDetailPage(
+                '?embed=1&contributors=2340',
+                EMBED_LIST_SEARCH,
+            );
+
+            await waitFor(() => expect(apiRequest.get).toHaveBeenCalled());
+
+            const url = apiRequest.get.mock.calls[0][0];
+            expect(url).toContain('embed=1');
+            expect(url).toContain(`contributor=${CONTRIBUTOR_ID}`);
+        });
+
+        it('fetches without embed contributor when only embed=1 is hydrated (stripped detail URL)', async () => {
+            await renderDetailPage('?embed=1', '?embed=1');
+
+            await waitFor(() => expect(apiRequest.get).toHaveBeenCalled());
+
+            const url = apiRequest.get.mock.calls[0][0];
+            expect(url).not.toContain(`contributor=${CONTRIBUTOR_ID}`);
+            expect(url).not.toContain('embed=1');
+        });
+    });
+});

--- a/src/react/src/__tests__/embedModeNavigation.test.jsx
+++ b/src/react/src/__tests__/embedModeNavigation.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { Route } from 'react-router-dom';
+import { MemoryRouter, Route } from 'react-router-dom';
 import { waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
 
 import { setupStore } from '../configureStore';
 import { setFiltersFromQueryString } from '../actions/filters';

--- a/src/react/src/__tests__/utils.tests.js
+++ b/src/react/src/__tests__/utils.tests.js
@@ -3007,9 +3007,17 @@ describe('shouldUseProductionLocationPage', () => {
 });
 
 describe('getFilteredSearchForEmbed', () => {
-    it('keeps only embed and contributor params', () => {
-        const search = '?embed=1&contributor=abc&sort_by=contributors_desc';
-        expect(getFilteredSearchForEmbed(search)).toBe('?embed=1&contributor=abc');
+    it('keeps embed and contributors params', () => {
+        const search = '?embed=1&contributors=abc&sort_by=contributors_desc';
+        expect(getFilteredSearchForEmbed(search)).toBe('?embed=1&contributors=abc');
+    });
+
+    it('preserves contributors from embed list URLs', () => {
+        const search =
+            '?contributors=10672&lists=9193&sort_by=name_asc&embed=1';
+        expect(getFilteredSearchForEmbed(search)).toBe(
+            '?embed=1&contributors=10672',
+        );
     });
 
     it('returns empty string when embed is absent or search is empty', () => {
@@ -3027,9 +3035,9 @@ describe('makeFacilityDetailLinkOnRedirect', () => {
     it('builds production location link with embed params only', () => {
         const url = makeFacilityDetailLinkOnRedirect(
             'CN2026030PXM73F',
-            '?embed=1&contributor=abc&sort_by=contributors_desc',
+            '?embed=1&contributors=abc&sort_by=contributors_desc',
             true,
         );
-        expect(url).toBe('/production-locations/CN2026030PXM73F?embed=1&contributor=abc');
+        expect(url).toBe('/production-locations/CN2026030PXM73F?embed=1&contributors=abc');
     });
 });

--- a/src/react/src/util/util.js
+++ b/src/react/src/util/util.js
@@ -262,7 +262,7 @@ export const getFilteredSearchForEmbed = search => {
     if (!params.has('embed')) return '';
 
     const filtered = new URLSearchParams();
-    ['embed', 'contributor'].forEach(key => {
+    ['embed', 'contributors'].forEach(key => {
         const value = params.get(key);
         if (value !== null) {
             filtered.set(key, value);


### PR DESCRIPTION
Fix [OSDEV-2779](https://opensupplyhub.atlassian.net/browse/OSDEV-2779)

Fix `getFilteredSearchForEmbed` to keep `contributors` on facility navigation so embed profiles load contributor-scoped fields.

[OSDEV-2779]: https://opensupplyhub.atlassian.net/browse/OSDEV-2779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ