### PR TITLE
[OSDEV-2804] Remove unused zywillc/kafka Terraform provider to fix CI 504 failure

### DIFF
--- a/deployment/terraform/kafka.tf
+++ b/deployment/terraform/kafka.tf
@@ -60,27 +60,3 @@ resource "aws_security_group_rule" "msk_outbound" {
 
   security_group_id = aws_security_group.msk.id
 }
-
-# locals {
-#   broker_host_list = "${split(",", replace(element(concat(module.msk_cluster.bootstrap_brokers, list("")), 0), ":9092", ""))}"
-# }
-
-
-
-# locals {
-#   broker_host_list = split(",",module.msk_cluster.bootstrap_brokers[0])
-# }
-
-
-# provider "kafka" {
-#   # bootstrap_servers = ["${module.msk_cluster.bootstrap_brokers}"]
-#   # bootstrap_servers = module.msk_cluster.bootstrap_brokers
-#   bootstrap_servers = local.broker_host_list
-# }
-
-# resource "kafka_topic" "logs" {
-#   # bootstrap_servers = join(",", module.msk_cluster.bootstrap_brokers)
-#   name               = "${var.topic_dedup_basic_name}"
-#   replication_factor = 1
-#   partitions         = 1
-# }

--- a/deployment/terraform/versions.tf
+++ b/deployment/terraform/versions.tf
@@ -10,10 +10,6 @@ terraform {
       source  = "hashicorp/template"
       version = "~> 2.2.0"
     }
-    kafka = {
-      source = "zywillc/kafka"
-      version = "1.0.1"
-    }
     random = {
       source  = "hashicorp/random"
       version = "~> 3.7"

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   * **E2E tests** — `src/e2e/package.json` bumps `@playwright/test` from `^1.48.1` to `^1.55.1` (resolves to 1.60.0) to patch CVE-2025-59288; `src/e2e/package-lock.json` regenerated to match so `npm ci` succeeds in the e2e Dockerfile build.
 
 ### Bugfix
+* [OSDEV-2804](https://opensupplyhub.atlassian.net/browse/OSDEV-2804) - Fixed the Deploy to AWS pipeline failing during `terraform init` with a 504 Gateway Timeout from GitHub when installing the unused `zywillc/kafka` provider (v1.0.1). Removed the provider declaration from `deployment/terraform/versions.tf` — all `kafka_topic` resources and the `provider "kafka"` block in `kafka.tf` were already commented out, making the declaration dead code.
 * [OSDEV-555](https://opensupplyhub.atlassian.net/browse/OSDEV-555) - Fixed several bugs in the list replacement workflow:
   * The Admin Dashboard Pending filter no longer shows lists that are in a REPLACED state (have an active replacement link) or are inactive (`is_active=False`).
   * The Admin Dashboard Approved filter no longer shows lists that have been replaced; a replaced list must only appear in the Replaced filter.


### PR DESCRIPTION
Remove the `zywillc/kafka` provider declaration from `deployment/terraform/versions.tf`.

## Problem

The Deploy to AWS pipeline was failing during `terraform init` with:

```
Error: Failed to install provider

Error while installing zywillc/kafka v1.0.1: could not query provider
registry for registry.terraform.io/zywillc/kafka: failed to retrieve
authentication checksums for provider: the request failed after 2 attempts,
please try again later: 504 Gateway Timeout returned from github.com
```

The `zywillc/kafka` provider is distributed via GitHub Releases, and Terraform's registry fetches authentication checksums from GitHub at install time. When GitHub CDN returns a 504, the provider can't be installed and the entire pipeline fails. This is a recurring pattern in this project (see [OSDEV-2160](https://opensupplyhub.atlassian.net/browse/OSDEV-2160), [OSDEV-2381](https://opensupplyhub.atlassian.net/browse/OSDEV-2381)) where unreliable external dependencies break CI.

## Why removing the declaration is safe

The provider was never actually in use. In `kafka.tf`, both the `provider "kafka"` block and the `kafka_topic` resource are fully commented out — only AWS MSK resources remain active, which are managed by `hashicorp/aws`. The `kafka_topic_basic_name` references elsewhere in the Terraform config are plain string template variables (environment variables passed to containers), not Terraform resource references.

Kafka topics are managed separately by the `create_kafka_topic` workflow job via `./deployment/run_kafka_task`, not through Terraform.

Because the `infra` script runs `rm -rf .terraform` before every `terraform init`, the provider was being re-downloaded from scratch on every single pipeline run — turning a transient GitHub CDN outage into a guaranteed CI failure.

## Changes

- `deployment/terraform/versions.tf` — removed the `zywillc/kafka` provider block
- `doc/release/RELEASE-NOTES.md` — added bugfix entry under Release 2.25.0

Fixes [OSDEV-2804](https://opensupplyhub.atlassian.net/browse/OSDEV-2804).

Made with [Cursor](https://cursor.com)

[OSDEV-2160]: https://opensupplyhub.atlassian.net/browse/OSDEV-2160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OSDEV-2381]: https://opensupplyhub.atlassian.net/browse/OSDEV-2381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OSDEV-2804]: https://opensupplyhub.atlassian.net/browse/OSDEV-2804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ