### PR TITLE
[OSDEV-555] Fix Admin Dashboard PENDING/APPROVED filters returning wrong-status lists

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   * The Admin Dashboard Pending filter no longer shows lists that are in a REPLACED state (have an active replacement link) or are inactive (`is_active=False`).
   * The Admin Dashboard Approved filter no longer shows lists that have been replaced; a replaced list must only appear in the Replaced filter.
   * The "Select a list to replace" dropdown on the Upload screen now only shows eligible lists (status `PENDING`, or `APPROVED` with an active source). Replaced, Rejected, and inactive lists are hidden. A matching backend guard was added to enforce this via the API.
+  * The Admin Dashboard Pending and Approved filters now correctly isolate lists by their actual status; previously, active non-replaced lists of any status could appear in either filter.
 * [OSDEV-2779](https://opensupplyhub.atlassian.net/browse/OSDEV-2779) - Fixed embedded map location profiles showing only Name and Sector after opening a facility from the map. `getFilteredSearchForEmbed()` (introduced in OSDEV-2352) preserved only the `contributor` query parameter when building embed detail URLs, but embed list URLs use `contributors`. Clicking a facility dropped the contributor ID from the URL, so embed config was not loaded and the facility API was not called with embed contributor context. The helper now preserves `contributors` so configured embed fields render on the profile again.
 
 ### Release instructions

--- a/src/django/api/tests/test_dashboard_list.py
+++ b/src/django/api/tests/test_dashboard_list.py
@@ -135,6 +135,43 @@ class DashboardListTest(BaseFacilityListTest):
             "must not appear in the Pending filter.",
         )
 
+    def test_pending_filter_excludes_approved_lists(self):
+        self.list.status = FacilityList.APPROVED
+        self.list.save()
+
+        self.client.login(
+            email=self.superuser_email, password=self.superuser_password
+        )
+        response = self.client.get(
+            "/api/admin-facility-lists/?status={}".format(FacilityList.PENDING)
+        )
+
+        self.assertEqual(200, response.status_code)
+        names = [d["name"] for d in response.json()["results"]]
+        self.assertNotIn(
+            "First List",
+            names,
+            "An APPROVED list must not appear in the Pending filter.",
+        )
+
+    def test_approved_filter_excludes_pending_lists(self):
+        self.client.login(
+            email=self.superuser_email, password=self.superuser_password
+        )
+        response = self.client.get(
+            "/api/admin-facility-lists/?status={}".format(
+                FacilityList.APPROVED
+            )
+        )
+
+        self.assertEqual(200, response.status_code)
+        names = [d["name"] for d in response.json()["results"]]
+        self.assertNotIn(
+            "First List",
+            names,
+            "A PENDING list must not appear in the Approved filter.",
+        )
+
     def test_pending_filter_includes_non_replaced_pending_lists(self):
         self.client.login(
             email=self.superuser_email, password=self.superuser_password

--- a/src/django/api/views/admin_facility_list_view.py
+++ b/src/django/api/views/admin_facility_list_view.py
@@ -60,6 +60,7 @@ class AdminFacilityListView(ListAPIView):
             facility_lists = facility_lists.filter(replaced_by__isnull=False)
         elif status in (FacilityList.PENDING, FacilityList.APPROVED):
             facility_lists = facility_lists.filter(
+                status=status,
                 replaced_by__isnull=True,
                 source__is_active=True,
             )


### PR DESCRIPTION
## Problem

After PR #1028 (OSDEV-555), the `PENDING` and `APPROVED` Admin Dashboard filters could return lists of the wrong status. The new `elif status in (FacilityList.PENDING, FacilityList.APPROVED)` branch applied `replaced_by__isnull=True` and `source__is_active=True` guards but omitted `status=status`, so any active non-replaced list — regardless of its actual status — could appear in either filter.

Concretely: an `APPROVED` list with an active source and no replacement link (e.g. list 9303) was showing up in the `?status=PENDING` filter.

## Changes

`admin_facility_list_view.py`
- Added `status=status` to the `PENDING`/`APPROVED` filter branch so each filter is correctly isolated to its own status value.

`test_dashboard_list.py`
- Added `test_pending_filter_excludes_approved_lists`: asserts an APPROVED list does not appear in `?status=PENDING`.
- Added `test_approved_filter_excludes_pending_lists`: asserts a PENDING list does not appear in `?status=APPROVED`.

## Related

Jira: [OSDEV-555](https://opensupplyhub.atlassian.net/browse/OSDEV-555)
Follow-up to PR #1028.

Made with [Cursor](https://cursor.com)

[OSDEV-555]: https://opensupplyhub.atlassian.net/browse/OSDEV-555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ