### PR TITLE
[OSDEV-2805] Fix dedupe-hub startup crash: time.clock removed in Python 3.8+

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   * **E2E tests** — `src/e2e/package.json` bumps `@playwright/test` from `^1.48.1` to `^1.55.1` (resolves to 1.60.0) to patch CVE-2025-59288; `src/e2e/package-lock.json` regenerated to match so `npm ci` succeeds in the e2e Dockerfile build.
 
 ### Bugfix
+* [OSDEV-2805](https://opensupplyhub.atlassian.net/browse/OSDEV-2805) - Fixed dedupe-hub service crashing on startup with `Initial Gazetteer Build Error: module 'time' has no attribute 'clock'`. `dedupe==1.9.4` calls `time.clock()` internally, which was removed in Python 3.8. Added a compatibility shim in `src/dedupe-hub/api/app/main.py` that assigns `time.perf_counter` as a drop-in replacement before any dedupe imports run.
 * [OSDEV-555](https://opensupplyhub.atlassian.net/browse/OSDEV-555) - Fixed several bugs in the list replacement workflow:
   * The Admin Dashboard Pending filter no longer shows lists that are in a REPLACED state (have an active replacement link) or are inactive (`is_active=False`).
   * The Admin Dashboard Approved filter no longer shows lists that have been replaced; a replaced list must only appear in the Replaced filter.

--- a/src/dedupe-hub/api/app/main.py
+++ b/src/dedupe-hub/api/app/main.py
@@ -1,6 +1,11 @@
 import asyncio
 import json
 import logging
+import time
+
+# dedupe 1.9.4 uses time.clock() which was removed in Python 3.8
+if not hasattr(time, 'clock'):
+    time.clock = time.perf_counter
 
 from random import randint
 from typing import Set, Any


### PR DESCRIPTION
Fix dedupe-hub service crashing on startup due to `time.clock` removal in Python 3.8+.

## Problem

The dedupe-hub service was failing to start, logging:

```
Initial Gazetteer Build Error: module 'time' has no attribute 'clock'
```

`dedupe==1.9.4` calls `time.clock()` internally. That function was deprecated in Python 3.3 and **removed entirely in Python 3.8**. The `Dockerfile` was recently bumped from `python:3.7` to `python:3.10` (OSDEV-2726), which exposed the incompatibility — the service ran fine on 3.7 but broke on 3.10.

## Fix

Added a one-line compatibility shim at the top of `main.py`, before any dedupe-touching imports run:

```python
if not hasattr(time, 'clock'):
    time.clock = time.perf_counter
```

`time.perf_counter` is the correct semantic replacement — it returns elapsed wall-clock time as a float, which is what `time.clock` returned on non-Windows platforms.

The guard (`hasattr` check) makes it a no-op on Python < 3.8 where `time.clock` still exists.

## Long-term note

The proper long-term fix is upgrading to `dedupe` 2.x, which has native Python 3.8+ support. That requires a non-trivial API migration (`sample()` → `prepare_training()`, `readTraining()` → `read_training()`, etc.) and is tracked separately in [OSDEV-2805](https://opensupplyhub.atlassian.net/browse/OSDEV-2805).

## Changes

- `src/dedupe-hub/api/app/main.py` — compatibility shim for `time.clock`
- `doc/release/RELEASE-NOTES.md` — bugfix entry for release 2.25.0

Made with [Cursor](https://cursor.com)

[OSDEV-2805]: https://opensupplyhub.atlassian.net/browse/OSDEV-2805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ