### PR TITLE
[OSDEV-2788] Create data moderation pause banner on the "Add Data" and “Claim a Production Location” pages

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -53,7 +53,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### What's new
 * [OSDEV-2657](https://opensupplyhub.atlassian.net/browse/OSDEV-2657) - Moderators can submit partner Google Sheets through Django admin (**Partner Data File Uploads**) to apply partner-field production location updates without using the API. Each row with a valid `os_id` creates a pending moderation event; row-level outcomes appear in `error` and `moderation_id` columns added to the sheet.
-* [OSDEV-2788](https://opensupplyhub.atlassian.net/browse/OSDEV-2788) - A banner has been added to the "Add data" and "Claim a Production Location" notifying contributors about the upcoming data moderation pause, hidden behind the enable_moderation_pause_info waffle switch.
+* [OSDEV-2788](https://opensupplyhub.atlassian.net/browse/OSDEV-2788) - A banner has been added to the "Add data" and "Claim a Production Location" pages notifying contributors about the upcoming data moderation pause, hidden behind the enable_moderation_pause_info waffle switch.
 
 ### Release instructions
 * Ensure that the following commands are included in the `post_deployment` command:

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -53,6 +53,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### What's new
 * [OSDEV-2657](https://opensupplyhub.atlassian.net/browse/OSDEV-2657) - Moderators can submit partner Google Sheets through Django admin (**Partner Data File Uploads**) to apply partner-field production location updates without using the API. Each row with a valid `os_id` creates a pending moderation event; row-level outcomes appear in `error` and `moderation_id` columns added to the sheet.
+* [OSDEV-2788](https://opensupplyhub.atlassian.net/browse/OSDEV-2788) - A banner has been added to the "Add data" and "Claim a Production Location" notifying contributors about the upcoming data moderation pause, hidden behind the enable_moderation_pause_info waffle switch.
 
 ### Release instructions
 * Ensure that the following commands are included in the `post_deployment` command:

--- a/src/django/api/migrations/0212_add_moderation_pause_info_switch.py
+++ b/src/django/api/migrations/0212_add_moderation_pause_info_switch.py
@@ -1,0 +1,31 @@
+from django.db import migrations
+
+
+SWITCH_NAME = 'enable_moderation_pause_info'
+
+
+def create_switch(apps, schema_editor):
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.get_or_create(
+        name=SWITCH_NAME,
+        defaults={'active': False},
+    )
+
+
+def delete_switch(apps, schema_editor):
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.filter(name=SWITCH_NAME).delete()
+
+
+class Migration(migrations.Migration):
+    """
+    Migration to introduce a switch for the moderation pause info banner.
+    """
+
+    dependencies = [
+        ('api', '0211_create_partner_data_file_upload'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_switch, delete_switch),
+    ]

--- a/src/react/src/__tests__/components/MaintenanceBanner.test.js
+++ b/src/react/src/__tests__/components/MaintenanceBanner.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import renderWithProviders from '../../util/testUtils/renderWithProviders';
-import MaintenanceBanner from '../../components/Navbar/MaintenanceBanner/MaintenanceBanner';
+import MaintenanceBanner from '../../components/Navbar/MaintenanceBanner';
 
 const HEADLINE_TEXT =
     'Open Supply Hub is currently undergoing planned maintenance.';

--- a/src/react/src/components/AddLocationData.jsx
+++ b/src/react/src/components/AddLocationData.jsx
@@ -10,6 +10,7 @@ import Grid from '@material-ui/core/Grid';
 import CircularProgress from '@material-ui/core/CircularProgress';
 
 import AppGrid from './AppGrid';
+import ModerationPauseBanner from './ModerationPauseBanner';
 import RequireAuthNotice from './RequireAuthNotice';
 
 import { openInNewTab } from '../util/util';
@@ -49,6 +50,7 @@ function AddLocationData({ classes, userHasSignedIn, fetchingSessionSignIn }) {
 
     return (
         <div className={classes.container}>
+            <ModerationPauseBanner />
             <Typography variant="display3" className={classes.title}>
                 Add production location data to OS Hub
             </Typography>

--- a/src/react/src/components/InitialClaimFlow/ClaimIntro/ClaimIntro.jsx
+++ b/src/react/src/components/InitialClaimFlow/ClaimIntro/ClaimIntro.jsx
@@ -8,6 +8,7 @@ import Typography from '@material-ui/core/Typography';
 
 import ClaimInfoSection from './ClaimInfoSection';
 import AppOverflow from '../../AppOverflow';
+import ModerationPauseBanner from '../../ModerationPauseBanner';
 import RequireAuthNotice from '../../RequireAuthNotice';
 import { claimIntroStyles } from './styles';
 import withScrollReset from '../HOCs/withScrollReset';
@@ -51,6 +52,7 @@ const ClaimIntro = ({
 
     return (
         <div className={`${classes.root} notranslate`} translate="no">
+            <ModerationPauseBanner />
             <AppOverflow>
                 <div className={classes.container}>
                     <div className={classes.heroSection}>

--- a/src/react/src/components/ModerationPauseBanner.jsx
+++ b/src/react/src/components/ModerationPauseBanner.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { bool, object } from 'prop-types';
+import { connect } from 'react-redux';
+import Typography from '@material-ui/core/Typography';
+import { withStyles } from '@material-ui/core/styles';
+
+import { ENABLE_MODERATION_PAUSE_INFO } from '../util/constants';
+import moderationPauseBannerStyles from '../util/bannerStyles';
+
+const ModerationPauseBanner = ({ isActive, classes }) => {
+    if (!isActive) {
+        return null;
+    }
+
+    return (
+        <div className={classes.banner}>
+            <Typography
+                component="p"
+                variant="headline"
+                className={classes.headline}
+            >
+                Planning to upload data soon? From Monday, June 29th to Friday,
+                August 7th 2026, we are running an Automation Sprint and
+                processing times will be extended.
+            </Typography>
+            <Typography component="p" variant="body1" className={classes.body}>
+                List uploads, adding a single production location (OS ID), and
+                claims submitted during this window will take at least 6
+                additional weeks beyond our{' '}
+                <a
+                    href="https://info.opensupplyhub.org/resources/data-processing-timelines"
+                    target="_blank"
+                    rel="noreferrer"
+                >
+                    standard timelines
+                </a>{' '}
+                to go live.
+            </Typography>
+            <Typography component="p" variant="body1" className={classes.body}>
+                If timing matters, we recommend submitting before June 29th.{' '}
+                <a
+                    href="https://info.opensupplyhub.org/resources/automation-sprint-2026"
+                    target="_blank"
+                    rel="noreferrer"
+                >
+                    Learn more.
+                </a>
+            </Typography>
+        </div>
+    );
+};
+
+ModerationPauseBanner.propTypes = {
+    isActive: bool.isRequired,
+    classes: object.isRequired,
+};
+
+const mapStateToProps = ({ featureFlags: { flags } }) => ({
+    isActive: !!flags[ENABLE_MODERATION_PAUSE_INFO],
+});
+
+export default connect(mapStateToProps)(
+    withStyles(moderationPauseBannerStyles)(ModerationPauseBanner),
+);

--- a/src/react/src/components/Navbar/MaintenanceBanner.jsx
+++ b/src/react/src/components/Navbar/MaintenanceBanner.jsx
@@ -4,8 +4,8 @@ import { connect } from 'react-redux';
 import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core/styles';
 
-import { DISABLE_LIST_UPLOADING } from '../../../util/constants';
-import maintenanceBannerStyles from './styles';
+import { DISABLE_LIST_UPLOADING } from '../../util/constants';
+import maintenanceBannerStyles from '../../util/bannerStyles';
 
 const MaintenanceBanner = ({ isActive, classes }) => {
     if (!isActive) {

--- a/src/react/src/components/Navbar/Navbar.jsx
+++ b/src/react/src/components/Navbar/Navbar.jsx
@@ -6,7 +6,7 @@ import { MobileNavbarItems, NavbarItems } from '../../util/constants';
 import Logo from './Logo';
 import BurgerButton from './BurgerButton';
 import NavbarQ42022Banner from './NavbarQ42022Banner';
-import MaintenanceBanner from './MaintenanceBanner/MaintenanceBanner';
+import MaintenanceBanner from './MaintenanceBanner';
 import MenuClickHandlerContext from './MenuClickHandlerContext';
 
 const breakpoint = '(max-width: 75rem)';

--- a/src/react/src/util/bannerStyles.js
+++ b/src/react/src/util/bannerStyles.js
@@ -1,5 +1,5 @@
-import COLOURS from '../../../util/COLOURS';
-import getTypographyStyles from '../../../util/typographyStyles';
+import COLOURS from './COLOURS';
+import getTypographyStyles from './typographyStyles';
 
 export default theme => {
     const typography = getTypographyStyles(theme);

--- a/src/react/src/util/constants.jsx
+++ b/src/react/src/util/constants.jsx
@@ -590,6 +590,7 @@ export const ENABLE_DROMO_UPLOADING = 'enable_dromo_uploading';
 export const ENABLE_V1_CLAIMS_FLOW = 'enable_v1_claims_flow';
 export const ENABLE_PRODUCTION_LOCATION_PAGE =
     'enable_production_location_page';
+export const ENABLE_MODERATION_PAUSE_INFO = 'enable_moderation_pause_info';
 
 export const DEFAULT_COUNTRY_CODE = 'IE';
 

--- a/src/react/src/util/propTypes.js
+++ b/src/react/src/util/propTypes.js
@@ -34,6 +34,7 @@ import {
     ENABLE_DROMO_UPLOADING,
     ENABLE_V1_CLAIMS_FLOW,
     ENABLE_PRODUCTION_LOCATION_PAGE,
+    ENABLE_MODERATION_PAUSE_INFO,
 } from './constants';
 
 export const registrationFormValuesPropType = shape({
@@ -373,6 +374,7 @@ export const featureFlagPropType = oneOf([
     ENABLE_DROMO_UPLOADING,
     ENABLE_V1_CLAIMS_FLOW,
     ENABLE_PRODUCTION_LOCATION_PAGE,
+    ENABLE_MODERATION_PAUSE_INFO,
 ]);
 
 export const facilityClaimsListPropType = arrayOf(


### PR DESCRIPTION
1. Added in moderation pause banners containing the provided [copy](https://docs.google.com/document/d/1PPcgOspxLzJ9mOf_8zTVM2TXR7JjzKcCz0xPz6CupNc/edit?usp=sharing) to the "Add data" and "Claim a Production Location" pages, hidden behind new waffle switch `enable_moderation_pause_info`
2. Refactored `ModerationPauseBanner.jsx` to use a new common `bannerStyles.js`