### PR TITLE
[OSDEV-2657] Right-size partner data file upload Batch job resources

### DIFF
--- a/deployment/terraform/job-definitions/partner_data_file_upload.json
+++ b/deployment/terraform/job-definitions/partner_data_file_upload.json
@@ -1,7 +1,7 @@
 {
   "image": "${image_url}",
-  "vcpus": 2,
-  "memory": 4096,
+  "vcpus": 1,
+  "memory": 512,
   "command": [
     "python",
     "manage.py",

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -540,17 +540,15 @@ variable "batch_partner_data_file_upload_ce_desired_vcpus" {
 
 variable "batch_partner_data_file_upload_ce_max_vcpus" {
   type    = number
-  default = 8
+  default = 1
 }
 
 variable "batch_partner_data_file_upload_ce_instance_types" {
   type = list(string)
 
   default = [
-    "c5",
-    "m5",
-    "m4",
-    "c4",
+    "t3",
+    "t3a",
   ]
 }
 

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -3,6 +3,21 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). The format is based on the `RELEASE-NOTES-TEMPLATE.md` file.
 
+## Release 2.26.0
+
+## Introduction
+* Product name: Open Supply Hub
+* Release date: June 26, 2026
+
+### Architecture/Environment changes
+* [Follow-up][OSDEV-2657](https://opensupplyhub.atlassian.net/browse/OSDEV-2657) - Right-sized AWS Batch resources for partner Google Sheet uploads after monitoring showed the original 2 vCPU / 4096 MB allocation was excessive for workloads up to 10k rows per sheet (~0.1 CPU and ~400 MB observed). Reduced the partner data file upload job definition to 1 vCPU and 512 MB memory, switched the compute environment instance families from `c5`/`m5`/`m4`/`c4` to `t3`/`t3a`, and set `batch_partner_data_file_upload_ce_max_vcpus` to 1 so only one upload job runs at a time in the dedicated queue.
+
+### Release instructions
+* Ensure that the following commands are included in the `post_deployment` command:
+    * `migrate`
+    * `reindex_database`
+
+
 ## Release 2.25.0
 
 ## Introduction

--- a/doc/release/RELEASE-PROTOCOL.md
+++ b/doc/release/RELEASE-PROTOCOL.md
@@ -86,6 +86,7 @@ This document outlines the SDLC pillars of the opensupplyhub monorepo, as well a
 | v2.23.0 | May 12, 2026 | May 15, 2026 | @Vlad Shapik |
 | v2.24.0 | May 26, 2026 | May 29, 2026 | @Vadim Kovalenko |
 | v2.25.0 | June 09, 2026 | June 12, 2026 | @Vadim Kovalenko |
+| v2.26.0 | June 23, 2026 | June 26, 2026 | @Vlad Shapik |
 
 ## General Information
 


### PR DESCRIPTION
## Summary

Follow-up to the partner Google Sheet upload Batch infrastructure shipped in 2.25.0. Monitoring showed the original 2 vCPU / 4096 MB job definition was far above actual usage (~0.1 CPU and ~400 MB for up to 10k rows per sheet). This PR reduces the job to 1 vCPU / 512 MB and switches the compute environment to smaller `t3`/`t3a` instance families.

Processing was tested with **10k rows**, which looks like the practical upper range based on [Francesca's comment on OSDEV-2657](https://opensupplyhub.atlassian.net/browse/OSDEV-2657?focusedCommentId=30843).

Parallel jobs are intentionally blocked (`max_vcpus = 1`) because all upload jobs share the same Google Service Account. A single job already runs close to the Sheets write quota (60 requests/min per user); running jobs in parallel would almost certainly exceed that limit and cause write failures.

Implements [OSDEV-2657](https://opensupplyhub.atlassian.net/browse/OSDEV-2657)

## Changes

- `partner_data_file_upload.json`: 2 vCPU / 4096 MB → 1 vCPU / 512 MB
- `variables.tf`: instance families `c5`/`m5`/`m4`/`c4` → `t3`/`t3a`; `max_vcpus` 8 → 1
- `RELEASE-NOTES.md`: new 2.26.0 section with `[Follow-up]` entry
- `RELEASE-PROTOCOL.md`: add v2.26.0 schedule (responsible: @Vlad Shapik)

## Test plan

- [ ] `terraform plan` shows updated job definition and compute environment settings for the partner upload Batch queue
- [ ] Submit a partner data file upload from Django admin on Development and confirm the Batch job starts and completes
- [ ] Verify a second submitted job stays queued until the first finishes (`max_vcpus = 1`)

[OSDEV-2657]: https://opensupplyhub.atlassian.net/browse/OSDEV-2657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ