### PR TITLE
[OSDEV-2657] Fix partner upload Batch instance types

### DIFF
--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -547,8 +547,8 @@ variable "batch_partner_data_file_upload_ce_instance_types" {
   type = list(string)
 
   default = [
-    "t3",
-    "t3a",
+    "c4",
+    "m4",
   ]
 }
 

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * Release date: June 26, 2026
 
 ### Architecture/Environment changes
-* [Follow-up][OSDEV-2657](https://opensupplyhub.atlassian.net/browse/OSDEV-2657) - Right-sized AWS Batch resources for partner Google Sheet uploads after monitoring showed the original 2 vCPU / 4096 MB allocation was excessive for workloads up to 10k rows per sheet (~0.1 CPU and ~400 MB observed). Reduced the partner data file upload job definition to 1 vCPU and 512 MB memory, switched the compute environment instance families from `c5`/`m5`/`m4`/`c4` to `t3`/`t3a`, and set `batch_partner_data_file_upload_ce_max_vcpus` to 1 so only one upload job runs at a time in the dedicated queue.
+* [Follow-up][OSDEV-2657](https://opensupplyhub.atlassian.net/browse/OSDEV-2657) - Right-sized AWS Batch resources for partner Google Sheet uploads after monitoring showed the original 2 vCPU / 4096 MB allocation was excessive for workloads up to 10k rows per sheet (~0.1 CPU and ~400 MB observed). Reduced the partner data file upload job definition to 1 vCPU and 512 MB memory, switched the compute environment instance families from `c5`/`m5` to `c4`/`m4` (AWS Batch does not support `t3`/`t3a` in eu-west-1), and set `batch_partner_data_file_upload_ce_max_vcpus` to 1 so only one upload job runs at a time in the dedicated queue.
 
 ### Release instructions
 * Ensure that the following commands are included in the `post_deployment` command:


### PR DESCRIPTION
## Summary

Fixes Terraform apply failure after #1057 merge. AWS Batch in eu-west-1 does not accept `t3`/`t3a` as compute environment instance families (`ClientException: Instance type can only be one of [...]`).

Switch to `c4`/`m4`, which are supported and still smaller than the original `c5`/`m5`/`m4`/`c4` mix.

Fixes [OSDEV-2657](https://opensupplyhub.atlassian.net/browse/OSDEV-2657)

## Changes

- `variables.tf`: `t3`/`t3a` → `c4`/`m4`
- `RELEASE-NOTES.md`: correct 2.26.0 entry

## Test plan

- [ ] `terraform apply` succeeds for Development partner data file upload Batch compute environment
- [ ] Submit a partner upload job and confirm it runs on the updated CE

[OSDEV-2657]: https://opensupplyhub.atlassian.net/browse/OSDEV-2657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ