### PR TITLE
[Quickfix-v.2.25][OSDEV-2768] Fix registration success banner rendering inline

### DIFF
--- a/src/react/src/components/RegisterForm.jsx
+++ b/src/react/src/components/RegisterForm.jsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import Grid from '@material-ui/core/Grid';
 import memoize from 'lodash/memoize';
-
 import AppGrid from './AppGrid';
 import AppOverflow from './AppOverflow';
 import ShowOnly from './ShowOnly';
@@ -89,53 +88,55 @@ class RegisterForm extends Component {
             return (
                 <AppOverflow>
                     <AppGrid title="Registration was successful!">
-                        <p>
-                            Check your email for instructions about how to
-                            verify your account.
-                        </p>
-                        <div
-                            style={{
-                                backgroundColor: '#f5f0ff',
-                                border: '1px solid #8428FA',
-                                borderRadius: '4px',
-                                padding: '16px 20px',
-                                marginTop: '24px',
-                                marginBottom: '48px',
-                            }}
-                        >
-                            <p
+                        <Grid item xs={12}>
+                            <p>
+                                Check your email for instructions about how to
+                                verify your account.
+                            </p>
+                            <div
                                 style={{
-                                    margin: '0 0 12px',
-                                    fontWeight: 'bold',
+                                    backgroundColor: '#f5f0ff',
+                                    border: '1px solid #8428FA',
+                                    borderRadius: '4px',
+                                    padding: '16px 20px',
+                                    marginTop: '24px',
+                                    marginBottom: '48px',
                                 }}
                             >
-                                If you haven&apos;t received the email after 24
-                                hours, please follow these steps:
-                            </p>
-                            <ol style={{ margin: 0, paddingLeft: '20px' }}>
-                                <li style={{ marginBottom: '8px' }}>
-                                    <strong>Check your spam folder:</strong> The
-                                    verification email might have been marked as
-                                    spam.
-                                </li>
-                                <li style={{ marginBottom: '8px' }}>
-                                    <strong>Allowlist our domain:</strong> Add{' '}
-                                    <strong>@opensupplyhub.org</strong> to your
-                                    email provider&apos;s safe sender list to
-                                    prevent future emails from being blocked or
-                                    filtered.
-                                </li>
-                                <li>
-                                    <strong>
-                                        Contact your email provider or IT
-                                        department:
-                                    </strong>{' '}
-                                    Ask them to confirm that emails from{' '}
-                                    <strong>@opensupplyhub.org</strong> are not
-                                    being blocked or restricted.
-                                </li>
-                            </ol>
-                        </div>
+                                <p
+                                    style={{
+                                        margin: '0 0 12px',
+                                        fontWeight: 'bold',
+                                    }}
+                                >
+                                    If you haven&apos;t received the email after
+                                    24 hours, please follow these steps:
+                                </p>
+                                <ol style={{ margin: 0, paddingLeft: '20px' }}>
+                                    <li style={{ marginBottom: '8px' }}>
+                                        <strong>Check your spam folder:</strong>{' '}
+                                        The verification email might have been
+                                        marked as spam.
+                                    </li>
+                                    <li style={{ marginBottom: '8px' }}>
+                                        <strong>Allowlist our domain:</strong>{' '}
+                                        Add <strong>@opensupplyhub.org</strong>{' '}
+                                        to your email provider&apos;s safe
+                                        sender list to prevent future emails
+                                        from being blocked or filtered.
+                                    </li>
+                                    <li>
+                                        <strong>
+                                            Contact your email provider or IT
+                                            department:
+                                        </strong>{' '}
+                                        Ask them to confirm that emails from{' '}
+                                        <strong>@opensupplyhub.org</strong> are
+                                        not being blocked or restricted.
+                                    </li>
+                                </ol>
+                            </div>
+                        </Grid>
                     </AppGrid>
                 </AppOverflow>
             );


### PR DESCRIPTION
Follow-up fix for [OSDEV-2768](https://opensupplyhub.atlassian.net/browse/OSDEV-2768)

**Found this layout issue on the preprod:**
<img width="1685" height="393" alt="Screenshot from 2026-06-10 18-15-56" src="https://github.com/user-attachments/assets/3adf5788-10da-416f-b483-9b9d9746cb15" />

**Fixed version:**
<img width="1937" height="467" alt="image" src="https://github.com/user-attachments/assets/023b77a5-a581-4e4f-80ba-11aadbb3c9cb" />


[OSDEV-2768]: https://opensupplyhub.atlassian.net/browse/OSDEV-2768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ