### PR TITLE
[OSDEV-2861] Rename Spotlight search filter label to Spotlight Partners

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -69,6 +69,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### What's new
 * [OSDEV-2657](https://opensupplyhub.atlassian.net/browse/OSDEV-2657) - Moderators can submit partner Google Sheets through Django admin (**Partner Data File Uploads**) to apply partner-field production location updates without using the API. Each row with a valid `os_id` creates a pending moderation event; row-level outcomes appear in `error` and `moderation_id` columns added to the sheet.
 * [OSDEV-2788](https://opensupplyhub.atlassian.net/browse/OSDEV-2788) - A banner has been added to the "Add data" and "Claim a Production Location" pages notifying contributors about the upcoming data moderation pause, hidden behind the enable_moderation_pause_info waffle switch.
+* [Follow-up][OSDEV-2861](https://opensupplyhub.atlassian.net/browse/OSDEV-2861) - Renamed the platform search filter label from **Spotlight Data Partners** to **Spotlight Partners** on the homepage and facilities search sidebars, aligning with product terminology introduced in [OSDEV-2542](https://opensupplyhub.atlassian.net/browse/OSDEV-2542).
 
 ### Release instructions
 * Ensure that the following commands are included in the `post_deployment` command:

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -69,7 +69,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### What's new
 * [OSDEV-2657](https://opensupplyhub.atlassian.net/browse/OSDEV-2657) - Moderators can submit partner Google Sheets through Django admin (**Partner Data File Uploads**) to apply partner-field production location updates without using the API. Each row with a valid `os_id` creates a pending moderation event; row-level outcomes appear in `error` and `moderation_id` columns added to the sheet.
 * [OSDEV-2788](https://opensupplyhub.atlassian.net/browse/OSDEV-2788) - A banner has been added to the "Add data" and "Claim a Production Location" pages notifying contributors about the upcoming data moderation pause, hidden behind the enable_moderation_pause_info waffle switch.
-* [Follow-up][OSDEV-2861](https://opensupplyhub.atlassian.net/browse/OSDEV-2861) - Renamed the platform search filter label from **Spotlight Data Partners** to **Spotlight Partners** on the homepage and facilities search sidebars, aligning with product terminology introduced in [OSDEV-2542](https://opensupplyhub.atlassian.net/browse/OSDEV-2542).
+* [OSDEV-2861](https://opensupplyhub.atlassian.net/browse/OSDEV-2861) - Renamed the platform search filter label from **Spotlight Data Partners** to **Spotlight Partners** on the homepage and facilities search sidebars, aligning with product terminology introduced in [OSDEV-2542](https://opensupplyhub.atlassian.net/browse/OSDEV-2542).
 
 ### Release instructions
 * Ensure that the following commands are included in the `post_deployment` command:

--- a/src/react/src/components/Filters/DataPartnersFilter/DataPartnersFilter.jsx
+++ b/src/react/src/components/Filters/DataPartnersFilter/DataPartnersFilter.jsx
@@ -27,7 +27,7 @@ const DataPartnersFilter = ({
         <div className="form__field">
             <NestedSelect
                 name={DATA_PARTNERS}
-                label="Spotlight Data Partners"
+                label="Spotlight Partners"
                 optionsData={groups}
                 sectors={selectedContributors}
                 updateSector={onContributorChange}


### PR DESCRIPTION
Rename the user-facing Spotlight partner search filter label from "Spotlight Data Partners" to "Spotlight Partners" so it matches product terminology used elsewhere on the platform.

Implements [OSDEV-2861](https://opensupplyhub.atlassian.net/browse/OSDEV-2861)

Related: [OSDEV-2542](https://opensupplyhub.atlassian.net/browse/OSDEV-2542)

## What changed
- Updated the `DataPartnersFilter` `NestedSelect` label on homepage and facilities search sidebars.

## Test plan
- [ ] Open homepage search and confirm the filter label reads **Spotlight Partners**
- [ ] Open `/facilities` sidebar search and confirm the same label
- [ ] Confirm filter behavior and query-string sync are unchanged

[OSDEV-2861]: https://opensupplyhub.atlassian.net/browse/OSDEV-2861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OSDEV-2542]: https://opensupplyhub.atlassian.net/browse/OSDEV-2542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ