### PR TITLE
[Quickfix-v.2.25][OSDEV-2861] Rename Spotlight search filter label to Spotlight Partners

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -53,7 +53,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### What's new
 * [OSDEV-2657](https://opensupplyhub.atlassian.net/browse/OSDEV-2657) - Moderators can submit partner Google Sheets through Django admin (**Partner Data File Uploads**) to apply partner-field production location updates without using the API. Each row with a valid `os_id` creates a pending moderation event; row-level outcomes appear in `error` and `moderation_id` columns added to the sheet.
-* [Follow-up][OSDEV-2861](https://opensupplyhub.atlassian.net/browse/OSDEV-2861) - Renamed the platform search filter label from **Spotlight Data Partners** to **Spotlight Partners** on the homepage and facilities search sidebars, aligning with product terminology introduced in [OSDEV-2542](https://opensupplyhub.atlassian.net/browse/OSDEV-2542).
+* [OSDEV-2861](https://opensupplyhub.atlassian.net/browse/OSDEV-2861) - Renamed the platform search filter label from **Spotlight Data Partners** to **Spotlight Partners** on the homepage and facilities search sidebars, aligning with product terminology introduced in [OSDEV-2542](https://opensupplyhub.atlassian.net/browse/OSDEV-2542).
 
 ### Release instructions
 * Ensure that the following commands are included in the `post_deployment` command:

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -53,6 +53,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### What's new
 * [OSDEV-2657](https://opensupplyhub.atlassian.net/browse/OSDEV-2657) - Moderators can submit partner Google Sheets through Django admin (**Partner Data File Uploads**) to apply partner-field production location updates without using the API. Each row with a valid `os_id` creates a pending moderation event; row-level outcomes appear in `error` and `moderation_id` columns added to the sheet.
+* [Follow-up][OSDEV-2861](https://opensupplyhub.atlassian.net/browse/OSDEV-2861) - Renamed the platform search filter label from **Spotlight Data Partners** to **Spotlight Partners** on the homepage and facilities search sidebars, aligning with product terminology introduced in [OSDEV-2542](https://opensupplyhub.atlassian.net/browse/OSDEV-2542).
 
 ### Release instructions
 * Ensure that the following commands are included in the `post_deployment` command:

--- a/src/react/src/components/Filters/DataPartnersFilter/DataPartnersFilter.jsx
+++ b/src/react/src/components/Filters/DataPartnersFilter/DataPartnersFilter.jsx
@@ -27,7 +27,7 @@ const DataPartnersFilter = ({
         <div className="form__field">
             <NestedSelect
                 name={DATA_PARTNERS}
-                label="Spotlight Data Partners"
+                label="Spotlight Partners"
                 optionsData={groups}
                 sectors={selectedContributors}
                 updateSector={onContributorChange}


### PR DESCRIPTION
## Summary

Quickfix for `releases/v.2.25`: rename the user-facing Spotlight partner search filter label from "Spotlight Data Partners" to **Spotlight Partners** on homepage and facilities search, aligning with product terminology from [OSDEV-2542](https://opensupplyhub.atlassian.net/browse/OSDEV-2542).

Implements [OSDEV-2861](https://opensupplyhub.atlassian.net/browse/OSDEV-2861)

## What changed
- Updated `DataPartnersFilter` `NestedSelect` label.
- Added `[Follow-up][OSDEV-2861]` entry to Release 2.25.0 **What's new** in `doc/release/RELEASE-NOTES.md`.

## Test plan
- [ ] Homepage search shows filter label **Spotlight Partners**
- [ ] `/facilities` sidebar search shows the same label
- [ ] Filter behavior and query-string sync unchanged

[OSDEV-2542]: https://opensupplyhub.atlassian.net/browse/OSDEV-2542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OSDEV-2861]: https://opensupplyhub.atlassian.net/browse/OSDEV-2861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OSDEV-2861]: https://opensupplyhub.atlassian.net/browse/OSDEV-2861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ