### PR TITLE
[OSDEV-2881] Fix selective OpenSearch clearing after #1084

### DIFF
--- a/.github/workflows/deploy_to_aws.yml
+++ b/.github/workflows/deploy_to_aws.yml
@@ -40,11 +40,6 @@ on:
         - moderation-events
         - both
         default: none
-      skip-image-builds:
-        description: 'Skip frontend and Docker image builds (testing only; uses existing S3 assets and ECR images)'
-        required: false
-        type: boolean
-        default: false
 
 env:
   # Stop/clear/start Logstash when restore-db is enabled or a clear target is selected
@@ -254,7 +249,7 @@ jobs:
     needs: apply
     runs-on: ubuntu-latest
     environment: ${{ inputs.deploy-env || (github.ref_name == 'main' && 'Development') || (startsWith(github.ref_name, 'releases/') && 'Pre-prod') }}
-    if: ${{ inputs.deploy-plan-only == false && inputs.skip-image-builds != true }}
+    if: false # TODO: re-enable after OpenSearch clearing workflow testing
     steps:
       - name: Get Environment Name for ${{ vars.ENV_NAME }}
         id: get_env_name
@@ -310,7 +305,7 @@ jobs:
     needs: build_and_push_react_app
     runs-on: ubuntu-latest
     environment: ${{ inputs.deploy-env || (github.ref_name == 'main' && 'Development') || (startsWith(github.ref_name, 'releases/') && 'Pre-prod') }}
-    if: ${{ always() && !cancelled() && inputs.deploy-plan-only == false && inputs.skip-image-builds != true && (needs.build_and_push_react_app.result == 'success' || needs.build_and_push_react_app.result == 'skipped') }}
+    if: false # TODO: re-enable after OpenSearch clearing workflow testing
     steps:
       - name: Get Environment Name for ${{ vars.ENV_NAME }}
         id: get_env_name
@@ -401,10 +396,10 @@ jobs:
           tags: ${{ vars.ECR_REGISTRY }}/${{ vars.IMAGE_NAME }}-anonymized-database-dump-${{ steps.get_env_name.outputs.lowercase }}:${{ env.GIT_COMMIT }}
 
   create_kafka_topic:
-    needs: build_and_push_docker_image
+    needs: apply
     runs-on: ubuntu-latest
     environment: ${{ inputs.deploy-env || (github.ref_name == 'main' && 'Development') || (startsWith(github.ref_name, 'releases/') && 'Pre-prod') }}
-    if: ${{ always() && !cancelled() && inputs.deploy-plan-only == false && (needs.build_and_push_docker_image.result == 'success' || needs.build_and_push_docker_image.result == 'skipped') }}
+    if: ${{ inputs.deploy-plan-only == false }}
     steps:
       - name: Get Environment Name for ${{ vars.ENV_NAME }}
         id: get_env_name

--- a/.github/workflows/deploy_to_aws.yml
+++ b/.github/workflows/deploy_to_aws.yml
@@ -426,7 +426,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Stop Logstash for ${{ vars.ENV_NAME }}
-        if: ${{ inputs.restore-db == true || inputs.clear-opensearch-target != 'none' }}
+        if: ${{ inputs.restore-db == true || contains(fromJSON('["production-locations", "moderation-events", "both"]'), inputs.clear-opensearch-target) }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -543,7 +543,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Get OpenSearch domain, filesystem and access point IDs for ${{ vars.ENV_NAME }}
-        if: ${{ inputs.restore-db == true || inputs.clear-opensearch-target != 'none' }}
+        if: ${{ inputs.restore-db == true || contains(fromJSON('["production-locations", "moderation-events", "both"]'), inputs.clear-opensearch-target) }}
         id: export_variables
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -566,7 +566,7 @@ jobs:
           echo "EFS_AP_ID=$EFS_AP_ID" >> $GITHUB_OUTPUT
           echo "OPENSEARCH_DOMAIN=$OPENSEARCH_DOMAIN" >> $GITHUB_OUTPUT
       - name: Clear the custom OpenSearch indexes and templates for ${{ vars.ENV_NAME }}
-        if: ${{ inputs.restore-db == true || inputs.clear-opensearch-target != 'none' }}
+        if: ${{ inputs.restore-db == true || contains(fromJSON('["production-locations", "moderation-events", "both"]'), inputs.clear-opensearch-target) }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -610,7 +610,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Start Logstash for ${{ vars.ENV_NAME }}
-        if: ${{ inputs.restore-db == true || inputs.clear-opensearch-target != 'none' }}
+        if: ${{ inputs.restore-db == true || contains(fromJSON('["production-locations", "moderation-events", "both"]'), inputs.clear-opensearch-target) }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy_to_aws.yml
+++ b/.github/workflows/deploy_to_aws.yml
@@ -249,7 +249,7 @@ jobs:
     needs: apply
     runs-on: ubuntu-latest
     environment: ${{ inputs.deploy-env || (github.ref_name == 'main' && 'Development') || (startsWith(github.ref_name, 'releases/') && 'Pre-prod') }}
-    if: false # TODO: re-enable after OpenSearch clearing workflow testing
+    if: ${{ inputs.deploy-plan-only == false }}
     steps:
       - name: Get Environment Name for ${{ vars.ENV_NAME }}
         id: get_env_name
@@ -305,7 +305,7 @@ jobs:
     needs: build_and_push_react_app
     runs-on: ubuntu-latest
     environment: ${{ inputs.deploy-env || (github.ref_name == 'main' && 'Development') || (startsWith(github.ref_name, 'releases/') && 'Pre-prod') }}
-    if: false # TODO: re-enable after OpenSearch clearing workflow testing
+    if: ${{ inputs.deploy-plan-only == false }}
     steps:
       - name: Get Environment Name for ${{ vars.ENV_NAME }}
         id: get_env_name
@@ -396,7 +396,7 @@ jobs:
           tags: ${{ vars.ECR_REGISTRY }}/${{ vars.IMAGE_NAME }}-anonymized-database-dump-${{ steps.get_env_name.outputs.lowercase }}:${{ env.GIT_COMMIT }}
 
   create_kafka_topic:
-    needs: apply
+    needs: build_and_push_docker_image
     runs-on: ubuntu-latest
     environment: ${{ inputs.deploy-env || (github.ref_name == 'main' && 'Development') || (startsWith(github.ref_name, 'releases/') && 'Pre-prod') }}
     if: ${{ inputs.deploy-plan-only == false }}

--- a/.github/workflows/deploy_to_aws.yml
+++ b/.github/workflows/deploy_to_aws.yml
@@ -40,6 +40,11 @@ on:
         - moderation-events
         - both
         default: none
+      skip-image-builds:
+        description: 'Skip frontend and Docker image builds (testing only; uses existing S3 assets and ECR images)'
+        required: false
+        type: boolean
+        default: false
 
 env:
   # Stop/clear/start Logstash when restore-db is enabled or a clear target is selected
@@ -249,7 +254,7 @@ jobs:
     needs: apply
     runs-on: ubuntu-latest
     environment: ${{ inputs.deploy-env || (github.ref_name == 'main' && 'Development') || (startsWith(github.ref_name, 'releases/') && 'Pre-prod') }}
-    if: ${{ inputs.deploy-plan-only == false }}
+    if: ${{ inputs.deploy-plan-only == false && inputs.skip-image-builds != true }}
     steps:
       - name: Get Environment Name for ${{ vars.ENV_NAME }}
         id: get_env_name
@@ -305,7 +310,7 @@ jobs:
     needs: build_and_push_react_app
     runs-on: ubuntu-latest
     environment: ${{ inputs.deploy-env || (github.ref_name == 'main' && 'Development') || (startsWith(github.ref_name, 'releases/') && 'Pre-prod') }}
-    if: ${{ inputs.deploy-plan-only == false }}
+    if: ${{ always() && !cancelled() && inputs.deploy-plan-only == false && inputs.skip-image-builds != true && (needs.build_and_push_react_app.result == 'success' || needs.build_and_push_react_app.result == 'skipped') }}
     steps:
       - name: Get Environment Name for ${{ vars.ENV_NAME }}
         id: get_env_name
@@ -399,7 +404,7 @@ jobs:
     needs: build_and_push_docker_image
     runs-on: ubuntu-latest
     environment: ${{ inputs.deploy-env || (github.ref_name == 'main' && 'Development') || (startsWith(github.ref_name, 'releases/') && 'Pre-prod') }}
-    if: ${{ inputs.deploy-plan-only == false }}
+    if: ${{ always() && !cancelled() && inputs.deploy-plan-only == false && (needs.build_and_push_docker_image.result == 'success' || needs.build_and_push_docker_image.result == 'skipped') }}
     steps:
       - name: Get Environment Name for ${{ vars.ENV_NAME }}
         id: get_env_name

--- a/.github/workflows/deploy_to_aws.yml
+++ b/.github/workflows/deploy_to_aws.yml
@@ -41,6 +41,11 @@ on:
         - both
         default: none
 
+env:
+  # Stop/clear/start Logstash when restore-db is enabled or a clear target is selected
+  # (empty on push, "none" on manual dispatch default — both skip clearing).
+  SHOULD_CLEAR_OPENSEARCH: ${{ inputs.restore-db == true || (inputs.clear-opensearch-target != '' && inputs.clear-opensearch-target != 'none') }}
+
 jobs:
   check-base:
     runs-on: ubuntu-latest
@@ -426,7 +431,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Stop Logstash for ${{ vars.ENV_NAME }}
-        if: ${{ inputs.restore-db == true || contains(fromJSON('["production-locations", "moderation-events", "both"]'), inputs.clear-opensearch-target) }}
+        if: ${{ env.SHOULD_CLEAR_OPENSEARCH == 'true' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -543,7 +548,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Get OpenSearch domain, filesystem and access point IDs for ${{ vars.ENV_NAME }}
-        if: ${{ inputs.restore-db == true || contains(fromJSON('["production-locations", "moderation-events", "both"]'), inputs.clear-opensearch-target) }}
+        if: ${{ env.SHOULD_CLEAR_OPENSEARCH == 'true' }}
         id: export_variables
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -566,7 +571,7 @@ jobs:
           echo "EFS_AP_ID=$EFS_AP_ID" >> $GITHUB_OUTPUT
           echo "OPENSEARCH_DOMAIN=$OPENSEARCH_DOMAIN" >> $GITHUB_OUTPUT
       - name: Clear the custom OpenSearch indexes and templates for ${{ vars.ENV_NAME }}
-        if: ${{ inputs.restore-db == true || contains(fromJSON('["production-locations", "moderation-events", "both"]'), inputs.clear-opensearch-target) }}
+        if: ${{ env.SHOULD_CLEAR_OPENSEARCH == 'true' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -610,7 +615,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Start Logstash for ${{ vars.ENV_NAME }}
-        if: ${{ inputs.restore-db == true || contains(fromJSON('["production-locations", "moderation-events", "both"]'), inputs.clear-opensearch-target) }}
+        if: ${{ env.SHOULD_CLEAR_OPENSEARCH == 'true' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/deployment/clear_opensearch/clear_opensearch.sh.tpl
+++ b/deployment/clear_opensearch/clear_opensearch.sh.tpl
@@ -8,7 +8,7 @@
 #
 # CLEAR_OPENSEARCH_TARGET: none | production-locations | moderation-events | both
 
-target="${CLEAR_OPENSEARCH_TARGET:-none}"
+target="$CLEAR_OPENSEARCH_TARGET"
 
 CURL_OPTS=(--aws-sigv4 "aws:amz:eu-west-1:es" --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY")
 BASE="https://$OPENSEARCH_DOMAIN"


### PR DESCRIPTION
## Summary

Follow-up for [OSDEV-2881](https://opensupplyhub.atlassian.net/browse/OSDEV-2881) after #1084 merged to `main`.

- **envsubst:** Use `$CLEAR_OPENSEARCH_TARGET` instead of `${CLEAR_OPENSEARCH_TARGET:-none}` so the clear target is baked into the rendered script on the CI runner. `envsubst` does not expand bash default syntax; on the Bastion the variable is unset, so clearing silently did nothing while the job still succeeded.
- **Push deploys:** Add workflow-level `SHOULD_CLEAR_OPENSEARCH` so Logstash stop/clear/start runs only when `restore-db` is enabled or a non-`none` clear target is selected. Push-triggered runs have empty inputs (not `"none"`), which caused every `main` deploy to stop and restart Logstash (e.g. [run #27982046241](https://github.com/opensupplyhub/open-supply-hub/actions/runs/27982046241)).

## Test plan

- [ ] Push to `main`: `stop_logstash`, `clear_opensearch`, and `start_logstash` steps are skipped
- [x] Manual **Deploy to AWS** with `clear-opensearch-target: moderation-events`: rendered script contains `target="moderation-events"` and only moderation-events index/template/lock file are cleared
- [x] Manual **Deploy to AWS** with `clear-opensearch-target: none`: Logstash is not stopped
- [ ] **DB - Apply Anonymized DB**: still clears both (hardcoded `CLEAR_OPENSEARCH_TARGET: both`)

[OSDEV-2881]: https://opensupplyhub.atlassian.net/browse/OSDEV-2881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ