### PR TITLE
[OSDEV-2390] Set backfill parallel workers by environment in post_deployment

### DIFF
--- a/src/django/api/facility_index_backfill/README.md
+++ b/src/django/api/facility_index_backfill/README.md
@@ -40,7 +40,22 @@ python manage.py backfill_facility_index --fields contributors --dry-run
 python manage.py backfill_facility_index --fields contributors,claim_info
 ```
 
-`post_deployment` may invoke this command after migrations when a release requires a targeted backfill.
+### Post-deployment wiring (temporary)
+
+When a release changes an `index_*()` function, **temporarily** add a `backfill_facility_index` call to `post_deployment` so the backfill runs automatically on deploy. **Remove that call once the release code freeze is complete and the release has been deployed everywhere** — `post_deployment` is not a permanent home for backfills.
+
+Example wiring (remove after deploy):
+
+```python
+call_command(
+    'backfill_facility_index',
+    fields='contributors',
+    parallel=backfill_parallel_worker_count(),
+    batch_size=10000,
+)
+```
+
+If environments differ in CLI memory, add a temporary `BACKFILL_PARALLEL_BY_ENVIRONMENT` map and `backfill_parallel_worker_count()` helper in `post_deployment.py`. Remove those helpers together with the backfill call.
 
 ## How it works
 
@@ -85,7 +100,9 @@ For example, **`--parallel 10` needs about 2 GB RSS** (11 processes). Row data i
 
 Choose `--parallel` to fit the CLI/ECS task memory limit (`cli_fargate_memory` in Terraform). If the task is killed with OOM, reduce `--parallel` before increasing batch size.
 
-`post_deployment` uses a fixed worker count per environment (see `BACKFILL_PARALLEL_BY_ENVIRONMENT` in `post_deployment.py`). **Development** uses **`--parallel 2`**: the CLI task is 1 GB and the database is small (on the order of 1,000 production locations today), so one or two workers is enough. Other environments use **`--parallel 10`**.
+When a backfill is wired into `post_deployment`, worker count may be set per environment via a temporary `BACKFILL_PARALLEL_BY_ENVIRONMENT` map in `post_deployment.py` (remove with the backfill call). For example, **Development** may use **`--parallel 2`** when the CLI task has 1 GB memory and the database is small; larger environments may use **`--parallel 10`**.
+
+For manual runs outside `post_deployment`, pass `--parallel` directly on the command line.
 
 ### Production observations (19 Jun 2026)
 
@@ -125,7 +142,7 @@ Column expressions should match `index_facilities()` in `src/django/sqls/0171_in
    python manage.py backfill_facility_index --fields your_group --parallel 4
    ```
 
-5. Wire the group into `post_deployment` if it must run automatically on deploy.
+5. If it must run automatically on deploy, **temporarily** wire the group into `post_deployment`, then remove that call after the release code freeze is complete and the release has been deployed everywhere.
 
 When a change affects related columns (e.g. `contributors` and `contributors_count`), define them in the **same** field group so one pass keeps data consistent.
 

--- a/src/django/api/facility_index_backfill/README.md
+++ b/src/django/api/facility_index_backfill/README.md
@@ -57,6 +57,24 @@ call_command(
 
 If environments differ in CLI memory, add a temporary `BACKFILL_PARALLEL_BY_ENVIRONMENT` map and `backfill_parallel_worker_count()` helper in `post_deployment.py`. Remove those helpers together with the backfill call.
 
+```python
+from django.conf import settings
+
+# Each worker is a full Django subprocess (~150–200 MB RSS).
+BACKFILL_PARALLEL_BY_ENVIRONMENT = {
+    'Development': 2,
+    'Test': 10,
+    'Staging': 10,
+    'Preprod': 10,
+    'Production': 10,
+    'Rba': 10,
+}
+
+
+def backfill_parallel_worker_count() -> int:
+    return BACKFILL_PARALLEL_BY_ENVIRONMENT[settings.ENVIRONMENT]
+```
+
 ## How it works
 
 ```

--- a/src/django/api/facility_index_backfill/README.md
+++ b/src/django/api/facility_index_backfill/README.md
@@ -73,6 +73,20 @@ mod(abs(hashtext(id::text)), workers) = worker_id
 
 Each worker processes disjoint id ranges using keyset pagination (`id > last_id ORDER BY id LIMIT batch_size`), so batches stay fast at scale.
 
+### CLI memory and worker count
+
+Each `--parallel` worker is a separate `manage.py` subprocess that bootstraps the full Django stack. The orchestrator process stays alive while workers run, so peak container memory is roughly:
+
+```
+(orchestrator + N workers) × ~150–200 MB per process
+```
+
+For example, **`--parallel 10` needs about 2 GB RSS** (11 processes). Row data is not held in Python — only Django startup dominates memory.
+
+Choose `--parallel` to fit the CLI/ECS task memory limit (`cli_fargate_memory` in Terraform). If the task is killed with OOM, reduce `--parallel` before increasing batch size.
+
+`post_deployment` uses a fixed worker count per environment (see `BACKFILL_PARALLEL_BY_ENVIRONMENT` in `post_deployment.py`). **Development** uses **`--parallel 2`**: the CLI task is 1 GB and the database is small (on the order of 1,000 production locations today), so one or two workers is enough. Other environments use **`--parallel 10`**.
+
 ### Production observations (19 Jun 2026)
 
 Reference run on **Production** RDS (`db.m6in.4xlarge` at the time) backfilling the **`contributors`** field group with **`--parallel 10`** and **`--batch-size 10000`**:

--- a/src/django/api/management/commands/post_deployment.py
+++ b/src/django/api/management/commands/post_deployment.py
@@ -1,5 +1,22 @@
-from django.core.management.base import BaseCommand
+from django.conf import settings
 from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+# Post-deploy backfill worker counts by environment. Each worker is a full
+# Django subprocess (~150–200 MB RSS); see facility_index_backfill/README.md.
+BACKFILL_PARALLEL_BY_ENVIRONMENT = {
+    'Development': 2,
+    'Test': 10,
+    'Staging': 10,
+    'Preprod': 10,
+    'Production': 10,
+    'Rba': 10,
+}
+
+
+def backfill_parallel_worker_count() -> int:
+    """Return post-deploy backfill parallelism for the current environment."""
+    return BACKFILL_PARALLEL_BY_ENVIRONMENT[settings.ENVIRONMENT]
 
 
 class Command(BaseCommand):
@@ -13,6 +30,6 @@ class Command(BaseCommand):
         call_command(
             'backfill_facility_index',
             fields='contributors',
-            parallel=10,
+            parallel=backfill_parallel_worker_count(),
             batch_size=10000,
         )

--- a/src/django/api/management/commands/post_deployment.py
+++ b/src/django/api/management/commands/post_deployment.py
@@ -2,8 +2,11 @@ from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
 
-# Post-deploy backfill worker counts by environment. Each worker is a full
-# Django subprocess (~150–200 MB RSS); see facility_index_backfill/README.md.
+# Temporary for 2.27.0 — remove this map and the backfill_facility_index call
+# below once the 2.27.0 code freeze is complete and the release has been
+# deployed everywhere. See facility_index_backfill/README.md.
+#
+# Each worker is a full Django subprocess (~150–200 MB RSS).
 BACKFILL_PARALLEL_BY_ENVIRONMENT = {
     'Development': 2,
     'Test': 10,
@@ -15,7 +18,11 @@ BACKFILL_PARALLEL_BY_ENVIRONMENT = {
 
 
 def backfill_parallel_worker_count() -> int:
-    """Return post-deploy backfill parallelism for the current environment."""
+    """Return post-deploy backfill parallelism for the current environment.
+
+    Temporary for 2.27.0 — remove with BACKFILL_PARALLEL_BY_ENVIRONMENT after
+    the 2.27.0 code freeze is complete.
+    """
     return BACKFILL_PARALLEL_BY_ENVIRONMENT[settings.ENVIRONMENT]
 
 
@@ -27,6 +34,8 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         call_command('migrate')
         call_command('reindex_database')
+        # Temporary for 2.27.0 — remove after the code freeze is complete and
+        # the release has been deployed everywhere.
         call_command(
             'backfill_facility_index',
             fields='contributors',


### PR DESCRIPTION
## Summary

Follow-up to #1077. Post-deploy `backfill_facility_index` runs with `--parallel 10`, which OOMs on Development because the CLI Fargate task has 1024 MB memory while each worker is a full Django subprocess (~150–200 MB RSS).

- Add a temporary `BACKFILL_PARALLEL_BY_ENVIRONMENT` map in `post_deployment`: Development uses **2** workers; Test, Staging, Preprod, Production, and Rba use **10**.
- Document CLI memory sizing, temporary post-deployment wiring, and example helper code in `facility_index_backfill/README.md`.
- Note in code that the backfill call and helpers are temporary and should be removed after the 2.27.0 code freeze.

## Test plan

- [ ] Confirm `backfill_parallel_worker_count()` returns `2` when `settings.ENVIRONMENT` is `Development`
- [ ] Confirm post-deploy backfill on Development completes without OOM at `--parallel 2`
- [ ] Verify non-Dev environments still run backfill with `--parallel 10`