### PR TITLE
[OSDEV-2967] Add ClaimCampaign model, campaign fields on FacilityClaim, Django admin, and feature switch

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -13,8 +13,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 #### Migrations
 * `0217_add_contribution_dates_to_index_contributors.py` - Updates the `index_contributors()` SQL function to include `list_uploaded_at` (from `FacilityList.created_at`) and `last_contributed_at` (from `FacilityListItem.updated_at`) in the indexed contributor JSON.
+* `0218_create_claim_campaign.py` - Creates the `api_claimcampaign` table, adds nullable `campaign` FK and `via_link` boolean columns to `api_facilityclaim` (and its history table), and creates the `claim_campaigns` waffle switch (off by default).
 
 ### Code/API changes
+* [OSDEV-2967](https://opensupplyhub.atlassian.net/browse/OSDEV-2967) - Added the `ClaimCampaign` model (contributor-owned claims campaigns with a unique human-readable code), `campaign`/`via_link` fields on `FacilityClaim`, Django admin registration (campaign code locked after creation), and the `claim_campaigns` feature switch. The new fields are excluded from `sync_databases`.
 * [OSDEV-2390](https://opensupplyhub.atlassian.net/browse/OSDEV-2390) - Contribution dates for the Supply Chain Network drawer:
   * Extended `index_contributors()` and `FacilityIndexDetailsSerializer.get_contributors()` to expose `list_uploaded_at` and `last_contributed_at` on public and anonymized contributor entries in the production location API response.
   * Added the `facility_index_backfill` package and `backfill_facility_index` management command for batched, parallel refresh of selected `FacilityIndex` fields using existing `index_*()` SQL functions, as a faster alternative to full `index_facilities_new` reindexing at scale.

--- a/src/django/api/admin.py
+++ b/src/django/api/admin.py
@@ -165,6 +165,18 @@ class FacilityClaimReviewNoteAdmin(SimpleHistoryAdmin):
     readonly_fields = ('claim', 'author')
 
 
+class ClaimCampaignAdmin(admin.ModelAdmin):
+    list_display = ('name', 'code', 'contributor', 'status')
+    search_fields = ('name', 'code')
+    readonly_fields = ('uuid', 'created_at', 'updated_at')
+
+    def get_readonly_fields(self, request, obj=None):
+        # The code is used in live campaign links; lock it after creation.
+        if obj:
+            return self.readonly_fields + ('code',)
+        return self.readonly_fields
+
+
 class FacilityAliasAdmin(SimpleHistoryAdmin):
     history_list_display = ('os_id', 'facility')
     readonly_fields = ('os_id', 'facility', 'reason')
@@ -399,6 +411,7 @@ admin_site.register(models.FacilityMatch, FacilityMatchAdmin)
 admin_site.register(models.FacilityClaim, FacilityClaimAdmin)
 admin_site.register(models.FacilityClaimReviewNote,
                     FacilityClaimReviewNoteAdmin)
+admin_site.register(models.ClaimCampaign, ClaimCampaignAdmin)
 admin_site.register(models.FacilityAlias, FacilityAliasAdmin)
 admin_site.register(Flag, FlagAdmin)
 admin_site.register(Sample, SampleAdmin)

--- a/src/django/api/management/commands/sync_databases.py
+++ b/src/django/api/management/commands/sync_databases.py
@@ -190,7 +190,11 @@ class DatabaseSynchronizer:
             },
             'excluded_fields': [
                 'created_at',
-                'updated_at'
+                'updated_at',
+                # Campaign attribution stays on the main instance;
+                # ClaimCampaign records are not synchronized.
+                'campaign',
+                'via_link'
             ]
         },
         'ExtendedField': {

--- a/src/django/api/migrations/0218_create_claim_campaign.py
+++ b/src/django/api/migrations/0218_create_claim_campaign.py
@@ -1,0 +1,109 @@
+import uuid
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+SWITCH_NAME = 'claim_campaigns'
+
+
+def create_switch(apps, schema_editor):
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.get_or_create(
+        name=SWITCH_NAME,
+        defaults={'active': False},
+    )
+
+
+def delete_switch(apps, schema_editor):
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.filter(name=SWITCH_NAME).delete()
+
+
+class Migration(migrations.Migration):
+    """
+    Migration to introduce the ClaimCampaign model, the campaign and
+    via_link fields on FacilityClaim, and the claim_campaigns switch.
+    """
+
+    dependencies = [
+        ('api', '0217_add_contribution_dates_to_index_contributors'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ClaimCampaign',
+            fields=[
+                ('id', models.AutoField(
+                    auto_created=True,
+                    primary_key=True,
+                    serialize=False,
+                    verbose_name='ID')),
+                ('uuid', models.UUIDField(
+                    default=uuid.uuid4,
+                    editable=False,
+                    help_text='Unique identifier for the claim campaign.',
+                    unique=True)),
+                ('name', models.CharField(
+                    help_text='The campaign name.',
+                    max_length=200)),
+                ('code', models.CharField(
+                    help_text=(
+                        'Unique human-readable campaign code used in '
+                        'claim links.'
+                    ),
+                    max_length=50,
+                    unique=True)),
+                ('status', models.CharField(
+                    choices=[('ACTIVE', 'Active'), ('CLOSED', 'Closed')],
+                    default='ACTIVE',
+                    help_text='The campaign status.',
+                    max_length=20)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+                ('contributor', models.ForeignKey(
+                    help_text='The contributor who owns this claim campaign.',
+                    on_delete=django.db.models.deletion.PROTECT,
+                    to='api.contributor')),
+            ],
+        ),
+        migrations.AddField(
+            model_name='facilityclaim',
+            name='campaign',
+            field=models.ForeignKey(
+                blank=True,
+                help_text='The claim campaign this claim is attributed to.',
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                to='api.claimcampaign'),
+        ),
+        migrations.AddField(
+            model_name='facilityclaim',
+            name='via_link',
+            field=models.BooleanField(
+                default=False,
+                help_text='Whether the claim was submitted via a campaign '
+                          'link.'),
+        ),
+        migrations.AddField(
+            model_name='historicalfacilityclaim',
+            name='campaign',
+            field=models.ForeignKey(
+                blank=True,
+                db_constraint=False,
+                help_text='The claim campaign this claim is attributed to.',
+                null=True,
+                on_delete=django.db.models.deletion.DO_NOTHING,
+                related_name='+',
+                to='api.claimcampaign'),
+        ),
+        migrations.AddField(
+            model_name='historicalfacilityclaim',
+            name='via_link',
+            field=models.BooleanField(
+                default=False,
+                help_text='Whether the claim was submitted via a campaign '
+                          'link.'),
+        ),
+        migrations.RunPython(create_switch, delete_switch),
+    ]

--- a/src/django/api/models/__init__.py
+++ b/src/django/api/models/__init__.py
@@ -43,6 +43,7 @@ from .facility.facility_claim_review_note import (
 from .facility.facility_claim_attachments import (
     FacilityClaimAttachments
 )
+from .facility.claim_campaign import ClaimCampaign
 from .facility.facility_list import FacilityList
 from .facility.facility_list_item import FacilityListItem
 from .facility.facility_list_item_temp import FacilityListItemTemp

--- a/src/django/api/models/facility/claim_campaign.py
+++ b/src/django/api/models/facility/claim_campaign.py
@@ -1,0 +1,48 @@
+import uuid
+
+from django.db import models
+
+
+class ClaimCampaign(models.Model):
+    """
+    A campaign run by a contributor (e.g. a brand) to get its suppliers
+    to claim their production location profiles.
+    """
+
+    class Status(models.TextChoices):
+        ACTIVE = 'ACTIVE', 'Active'
+        CLOSED = 'CLOSED', 'Closed'
+
+    uuid = models.UUIDField(
+        null=False,
+        default=uuid.uuid4,
+        unique=True,
+        editable=False,
+        help_text='Unique identifier for the claim campaign.'
+    )
+    contributor = models.ForeignKey(
+        'Contributor',
+        null=False,
+        on_delete=models.PROTECT,
+        help_text='The contributor who owns this claim campaign.')
+    name = models.CharField(
+        max_length=200,
+        null=False,
+        blank=False,
+        help_text='The campaign name.')
+    code = models.CharField(
+        max_length=50,
+        null=False,
+        blank=False,
+        unique=True,
+        help_text='Unique human-readable campaign code used in claim links.')
+    status = models.CharField(
+        max_length=20,
+        choices=Status.choices,
+        default=Status.ACTIVE,
+        help_text='The campaign status.')
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    def __str__(self):
+        return f'{self.name} ({self.code})'

--- a/src/django/api/models/facility/facility_claim.py
+++ b/src/django/api/models/facility/facility_claim.py
@@ -512,6 +512,15 @@ class FacilityClaim(models.Model):
         verbose_name='claimant linkedin profile url',
         help_text="Claimant's LinkedIn profile URL."
     )
+    campaign = models.ForeignKey(
+        'ClaimCampaign',
+        null=True,
+        blank=True,
+        on_delete=models.PROTECT,
+        help_text='The claim campaign this claim is attributed to.')
+    via_link = models.BooleanField(
+        default=False,
+        help_text='Whether the claim was submitted via a campaign link.')
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/src/django/api/tests/test_claim_campaign.py
+++ b/src/django/api/tests/test_claim_campaign.py
@@ -1,0 +1,113 @@
+from api.models import (
+    ClaimCampaign,
+    Contributor,
+    Facility,
+    FacilityClaim,
+    FacilityList,
+    FacilityListItem,
+    Source,
+    User,
+)
+from rest_framework.test import APITestCase
+
+from django.contrib.gis.geos import Point
+from django.db import IntegrityError, transaction
+from django.db.models import ProtectedError
+
+
+class ClaimCampaignBaseTest(APITestCase):
+    """
+    Shared fixtures for the claim campaign test suites. Holds no tests
+    of its own so subclasses do not re-run inherited ones.
+    """
+
+    def setUp(self):
+        self.user = User.objects.create(email="test@example.com")
+
+        self.contributor = Contributor.objects.create(
+            admin=self.user,
+            name="test contributor",
+            contrib_type=Contributor.OTHER_CONTRIB_TYPE,
+        )
+
+        self.facility_list = FacilityList.objects.create(
+            header="header", file_name="one", name="List"
+        )
+
+        self.source = Source.objects.create(
+            facility_list=self.facility_list,
+            source_type=Source.LIST,
+            is_active=True,
+            is_public=True,
+            contributor=self.contributor,
+        )
+
+        self.list_item = FacilityListItem.objects.create(
+            name="Item",
+            address="Address",
+            country_code="US",
+            sector=["Apparel"],
+            row_index=1,
+            geocoded_point=Point(0, 0),
+            status=FacilityListItem.CONFIRMED_MATCH,
+            source=self.source,
+        )
+
+        self.facility = Facility.objects.create(
+            name="Name",
+            address="Address",
+            country_code="US",
+            location=Point(0, 0),
+            created_from=self.list_item,
+        )
+
+        self.campaign = ClaimCampaign.objects.create(
+            contributor=self.contributor,
+            name="Fresh Produce Suppliers 2026",
+            code="EXAMPLE-FRESH-26",
+        )
+
+    def create_claim(self, **kwargs):
+        return FacilityClaim.objects.create(
+            contributor=self.contributor,
+            facility=self.facility,
+            contact_person="Name",
+            company_name="Test",
+            facility_description="description",
+            **kwargs,
+        )
+
+
+class ClaimCampaignTest(ClaimCampaignBaseTest):
+    def test_campaign_is_created_with_defaults(self):
+        self.assertIsNotNone(self.campaign.uuid)
+        self.assertEqual(ClaimCampaign.Status.ACTIVE, self.campaign.status)
+        self.assertEqual(
+            "Fresh Produce Suppliers 2026 (EXAMPLE-FRESH-26)",
+            str(self.campaign),
+        )
+
+    def test_duplicate_campaign_code_is_rejected(self):
+        with self.assertRaises(IntegrityError):
+            with transaction.atomic():
+                ClaimCampaign.objects.create(
+                    contributor=self.contributor,
+                    name="Another campaign",
+                    code="EXAMPLE-FRESH-26",
+                )
+
+    def test_claim_defaults_have_no_campaign(self):
+        claim = self.create_claim()
+        self.assertIsNone(claim.campaign)
+        self.assertFalse(claim.via_link)
+
+    def test_claim_can_be_attributed_to_campaign(self):
+        claim = self.create_claim(campaign=self.campaign, via_link=True)
+        claim.refresh_from_db()
+        self.assertEqual(self.campaign, claim.campaign)
+        self.assertTrue(claim.via_link)
+
+    def test_campaign_with_claims_cannot_be_deleted(self):
+        self.create_claim(campaign=self.campaign)
+        with self.assertRaises(ProtectedError):
+            self.campaign.delete()


### PR DESCRIPTION
Jira: [OSDEV-2967](https://opensupplyhub.atlassian.net/browse/OSDEV-2967) · Epic: [OSDEV-2966](https://opensupplyhub.atlassian.net/browse/OSDEV-2966) · Design: [Claims Campaign — v1 Design](https://opensupplyhub.atlassian.net/wiki/spaces/SD/pages/1369604130)

First of five stacked PRs for the Claims Campaign epic — this one is data-layer only (no API or UI changes).

- New `ClaimCampaign` model: contributor FK, name, unique human-readable `code`, ACTIVE/CLOSED status, uuid. Created by staff via Django admin (list/search registered; `code` locked after creation since it appears in live links).
- `FacilityClaim` gains nullable `campaign` FK (PROTECT) + `via_link` boolean; one migration (`0218`) also creates the `claim_campaigns` waffle switch (off by default).
- New fields excluded from `sync_databases` (ClaimCampaign rows are not synced).

Tests: `api.tests.test_claim_campaign` (5 model tests) pass in Docker; flake8 clean; RELEASE-NOTES updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OSDEV-2967]: https://opensupplyhub.atlassian.net/browse/OSDEV-2967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OSDEV-2966]: https://opensupplyhub.atlassian.net/browse/OSDEV-2966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ