### PR TITLE
[OSDEV-2968] Attach campaigns to claim submissions with auto-attribution

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Code/API changes
 * [OSDEV-2967](https://opensupplyhub.atlassian.net/browse/OSDEV-2967) - Added the `ClaimCampaign` model (contributor-owned claims campaigns with a unique human-readable code), `campaign`/`via_link` fields on `FacilityClaim`, Django admin registration (campaign code locked after creation), and the `claim_campaigns` feature switch. The new fields are excluded from `sync_databases`.
+* [OSDEV-2968](https://opensupplyhub.atlassian.net/browse/OSDEV-2968) - Claim submissions accept an optional `campaign` code and are auto-attributed to active claims campaigns: a valid link code wins (`via_link=true`); otherwise a claim is attributed only when exactly one active campaign's currently-active uploaded list contains the facility. Runs only while the `claim_campaigns` switch is on; an invalid code never blocks a claim.
 * [OSDEV-2390](https://opensupplyhub.atlassian.net/browse/OSDEV-2390) - Contribution dates for the Supply Chain Network drawer:
   * Extended `index_contributors()` and `FacilityIndexDetailsSerializer.get_contributors()` to expose `list_uploaded_at` and `last_contributed_at` on public and anonymized contributor entries in the production location API response.
   * Added the `facility_index_backfill` package and `backfill_facility_index` management command for batched, parallel refresh of selected `FacilityIndex` fields using existing `index_*()` SQL functions, as a faster alternative to full `index_facilities_new` reindexing at scale.

--- a/src/django/api/serializers/facility/facility_create_claim_serializer.py
+++ b/src/django/api/serializers/facility/facility_create_claim_serializer.py
@@ -103,6 +103,11 @@ class FacilityCreateClaimSerializer(serializers.Serializer):
         required=False,
         allow_blank=True,
     )
+    campaign = serializers.CharField(
+        max_length=50,
+        required=False,
+        allow_blank=True,
+    )
     point_of_contact_person_name = serializers.CharField(
         max_length=200,
         required=False,

--- a/src/django/api/services/claim_campaign_service.py
+++ b/src/django/api/services/claim_campaign_service.py
@@ -1,0 +1,45 @@
+from waffle import switch_is_active
+
+from api.models import ClaimCampaign, FacilityListItem
+
+
+def resolve_claim_campaign(facility, code):
+    """
+    Attribute a facility claim to an active claim campaign.
+
+    A valid code for an ACTIVE campaign wins and marks the claim as
+    submitted via a campaign link. Without a usable code, the claim is
+    attributed only when exactly one ACTIVE campaign belongs to a
+    contributor that has the facility on a currently-active uploaded
+    list (replaced lists do not count); an ambiguous match (two or more
+    campaigns) attributes nothing. An invalid or unknown code never
+    blocks the claim.
+
+    While the claim_campaigns switch is off no attribution happens at
+    all, so existing claim behavior is fully unchanged.
+
+    Returns a (campaign, via_link) tuple.
+    """
+    if not switch_is_active('claim_campaigns'):
+        return None, False
+
+    if code:
+        campaign = ClaimCampaign.objects.filter(
+            code=code,
+            status=ClaimCampaign.Status.ACTIVE,
+        ).first()
+        if campaign is not None:
+            return campaign, True
+
+    campaigns = list(
+        ClaimCampaign.objects.filter(
+            status=ClaimCampaign.Status.ACTIVE,
+            contributor__in=FacilityListItem.objects.filter(
+                facility=facility,
+                source__is_active=True,
+            ).values('source__contributor'),
+        )[:2]
+    )
+    if len(campaigns) == 1:
+        return campaigns[0], False
+    return None, False

--- a/src/django/api/tests/test_claim_campaign.py
+++ b/src/django/api/tests/test_claim_campaign.py
@@ -9,6 +9,7 @@ from api.models import (
     User,
 )
 from rest_framework.test import APITestCase
+from waffle.testutils import override_switch
 
 from django.contrib.gis.geos import Point
 from django.db import IntegrityError, transaction
@@ -111,3 +112,121 @@ class ClaimCampaignTest(ClaimCampaignBaseTest):
         self.create_claim(campaign=self.campaign)
         with self.assertRaises(ProtectedError):
             self.campaign.delete()
+
+
+@override_switch("claim_campaigns", active=True)
+class ClaimCampaignAttributionTest(ClaimCampaignBaseTest):
+    def setUp(self):
+        super().setUp()
+
+        self.password = "example123"
+        self.user.set_password(self.password)
+        self.user.save()
+
+        # Matched list items carry the facility reference; the roster
+        # lookup relies on it.
+        self.list_item.facility = self.facility
+        self.list_item.save()
+
+        self.claim_url = f"/api/facilities/{self.facility.id}/claim/"
+        self.claim_data = {
+            "your_name": "John Doe",
+            "your_title": "Facility Manager",
+            "your_business_website": "https://example.com",
+            "business_website": "https://facility.com",
+            "business_linkedin_profile": "",
+            "facility_description": "description",
+        }
+
+        self.client.login(email=self.user.email, password=self.password)
+
+    def post_claim(self, **extra):
+        response = self.client.post(
+            self.claim_url, {**self.claim_data, **extra}
+        )
+        self.assertEqual(200, response.status_code)
+        return FacilityClaim.objects.get(facility=self.facility)
+
+    @override_switch("claim_a_facility", active=True)
+    def test_claim_with_valid_code_is_attributed_via_link(self):
+        claim = self.post_claim(campaign="EXAMPLE-FRESH-26")
+        self.assertEqual(self.campaign, claim.campaign)
+        self.assertTrue(claim.via_link)
+
+    @override_switch("claim_a_facility", active=True)
+    def test_claim_without_code_is_attributed_from_single_roster(self):
+        claim = self.post_claim()
+        self.assertEqual(self.campaign, claim.campaign)
+        self.assertFalse(claim.via_link)
+
+    @override_switch("claim_a_facility", active=True)
+    def test_claim_without_code_and_ambiguous_rosters_is_not_attributed(
+        self,
+    ):
+        other_user = User.objects.create(email="other@example.com")
+        other_contributor = Contributor.objects.create(
+            admin=other_user,
+            name="other contributor",
+            contrib_type=Contributor.OTHER_CONTRIB_TYPE,
+        )
+        other_list = FacilityList.objects.create(
+            header="header", file_name="two", name="Other list"
+        )
+        other_source = Source.objects.create(
+            facility_list=other_list,
+            source_type=Source.LIST,
+            is_active=True,
+            is_public=True,
+            contributor=other_contributor,
+        )
+        FacilityListItem.objects.create(
+            name="Item",
+            address="Address",
+            country_code="US",
+            sector=["Apparel"],
+            row_index=1,
+            geocoded_point=Point(0, 0),
+            status=FacilityListItem.CONFIRMED_MATCH,
+            source=other_source,
+            facility=self.facility,
+        )
+        ClaimCampaign.objects.create(
+            contributor=other_contributor,
+            name="Other campaign",
+            code="OTHER-26",
+        )
+
+        claim = self.post_claim()
+        self.assertIsNone(claim.campaign)
+        self.assertFalse(claim.via_link)
+
+    @override_switch("claim_a_facility", active=True)
+    def test_claim_with_unusable_code_is_created_without_campaign(self):
+        self.campaign.status = ClaimCampaign.Status.CLOSED
+        self.campaign.save()
+
+        claim = self.post_claim(campaign="UNKNOWN-CODE")
+        self.assertIsNone(claim.campaign)
+        self.assertFalse(claim.via_link)
+
+    @override_switch("claim_a_facility", active=True)
+    def test_claim_from_replaced_list_is_not_attributed(self):
+        self.source.is_active = False
+        self.source.save()
+
+        claim = self.post_claim()
+        self.assertIsNone(claim.campaign)
+        self.assertFalse(claim.via_link)
+
+    @override_switch("claim_a_facility", active=True)
+    def test_unknown_code_falls_back_to_roster_attribution(self):
+        claim = self.post_claim(campaign="TYPO-CODE")
+        self.assertEqual(self.campaign, claim.campaign)
+        self.assertFalse(claim.via_link)
+
+    @override_switch("claim_a_facility", active=True)
+    @override_switch("claim_campaigns", active=False)
+    def test_no_attribution_while_switch_is_off(self):
+        claim = self.post_claim(campaign="EXAMPLE-FRESH-26")
+        self.assertIsNone(claim.campaign)
+        self.assertFalse(claim.via_link)

--- a/src/django/api/views/facility/facilities_view_set.py
+++ b/src/django/api/views/facility/facilities_view_set.py
@@ -45,6 +45,7 @@ from django.conf import settings
 from django.views.decorators.cache import cache_page
 from django.utils.decorators import method_decorator
 
+from api.services.claim_campaign_service import resolve_claim_campaign
 from api.models import (
     Contributor,
     Facility,
@@ -1037,9 +1038,16 @@ class FacilitiesViewSet(ListModelMixin,
             serializer.is_valid(raise_exception=True)
             validated_data = serializer.validated_data
 
+            campaign, via_link = resolve_claim_campaign(
+                facility,
+                validated_data.get("campaign"),
+            )
+
             facility_claim = FacilityClaim.objects.create(
                 facility=facility,
                 contributor=contributor,
+                campaign=campaign,
+                via_link=via_link,
                 contact_person=validated_data.get("your_name"),
                 job_title=validated_data.get("your_title"),
                 point_of_contact_person_name=validated_data.get(


### PR DESCRIPTION
Jira: [OSDEV-2968](https://opensupplyhub.atlassian.net/browse/OSDEV-2968) · Epic: [OSDEV-2966](https://opensupplyhub.atlassian.net/browse/OSDEV-2966) — stacked on #1108

- Claim submissions accept an optional `campaign` code; `resolve_claim_campaign()` attributes claims to active campaigns: valid link code → `via_link=true`; otherwise attributed only when exactly one active campaign's currently-active list contains the facility (ambiguous → none).
- Fully gated by the `claim_campaigns` switch: while off, no lookup runs and claims behave exactly as today.
- An invalid/unknown code never blocks the claim (treated as no code). No new endpoints; claim validation/review untouched.

Tests: 8 attribution paths (link / roster / ambiguous / invalid code / replaced list / switch off) — 12 tests pass in Docker; flake8 clean; RELEASE-NOTES updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OSDEV-2968]: https://opensupplyhub.atlassian.net/browse/OSDEV-2968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OSDEV-2966]: https://opensupplyhub.atlassian.net/browse/OSDEV-2966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ