### PR TITLE
[OSDEV-2969] Claim form reads campaign URL parameter and shows campaign banner

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -37,6 +37,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * [OSDEV-2907](https://opensupplyhub.atlassian.net/browse/OSDEV-2907) - Fixed the RBA `sync_databases` AWS Batch job failing on every model with `KeyError` for missing database settings (e.g. `OPTIONS`, `TIME_ZONE`). Regression from the Django 3.2→5.2 upgrade: Django 3 lazily filled defaults when a runtime database alias first connected, but Django 5 only normalizes aliases present at startup. The dynamically configured source connection now inherits the normalized `default` database config and overrides only connection credentials, so Django's PostgreSQL backend can open connections and iterate via `chunked_cursor()`.
 
 ### What's new
+* [OSDEV-2969](https://opensupplyhub.atlassian.net/browse/OSDEV-2969) - The claim form at `/claim/{os_id}` reads an optional `?campaign=` parameter (behind the `claim_campaigns` flag): it shows a campaign banner on the intro step and includes the code in the claim submission payload. Without the parameter (or with the flag off) the form is unchanged.
 * [OSDEV-2390](https://opensupplyhub.atlassian.net/browse/OSDEV-2390) - The Supply Chain Network drawer on production location pages now shows list upload dates under each uploaded list and a "Last contributed" date for API-only public contributors and anonymized contributor types.
 
 ### Release instructions

--- a/src/react/src/__tests__/components/ClaimIntro.test.js
+++ b/src/react/src/__tests__/components/ClaimIntro.test.js
@@ -181,6 +181,61 @@ describe('ClaimIntro component', () => {
             expect(state.claimForm.completedSteps).toEqual([]);
         });
 
+        test('stores the campaign code and shows the banner when the flag is on', () => {
+            history.push(`/claim/${mockOsID}?campaign=EXAMPLE-FRESH-26`);
+            const preloadedState = {
+                auth: { user: { user: { isAnon: false } } },
+                featureFlags: {
+                    fetching: false,
+                    flags: { claim_campaigns: true },
+                },
+            };
+
+            const { reduxStore, getByText } = renderWithProviders(
+                <Router history={history}>
+                    <ClaimIntro match={mockMatch} />
+                </Router>,
+                { preloadedState }
+            );
+
+            expect(reduxStore.getState().claimForm.formData.campaign).toBe(
+                'EXAMPLE-FRESH-26'
+            );
+            expect(getByText(/part of a claims campaign/)).toBeInTheDocument();
+            expect(getByText('EXAMPLE-FRESH-26')).toBeInTheDocument();
+        });
+
+        test('ignores the campaign code when the flag is off', () => {
+            history.push(`/claim/${mockOsID}?campaign=EXAMPLE-FRESH-26`);
+            const preloadedState = {
+                auth: { user: { user: { isAnon: false } } },
+                featureFlags: {
+                    fetching: false,
+                    flags: { claim_campaigns: false },
+                },
+            };
+
+            const { reduxStore, queryByText } = renderWithProviders(
+                <Router history={history}>
+                    <ClaimIntro match={mockMatch} />
+                </Router>,
+                { preloadedState }
+            );
+
+            expect(reduxStore.getState().claimForm.formData.campaign).toBe('');
+            expect(
+                queryByText(/part of a claims campaign/)
+            ).not.toBeInTheDocument();
+        });
+
+        test('shows no banner without a campaign parameter', () => {
+            const { queryByText } = renderComponent();
+
+            expect(
+                queryByText(/part of a claims campaign/)
+            ).not.toBeInTheDocument();
+        });
+
         test('updates osIdToClaim when it is not set initially', () => {
             const testOsID = 'LOCATION_003';
             const preloadedState = {

--- a/src/react/src/actions/claimForm.js
+++ b/src/react/src/actions/claimForm.js
@@ -74,6 +74,10 @@ export function submitClaimFormData(osID, freeEmissionsEstimateHasErrors) {
 
         const filteredFormData = filterFreeEmissionsEstimateFields(formData);
 
+        if (!filteredFormData.campaign) {
+            delete filteredFormData.campaign;
+        }
+
         const postData = new FormData();
         toPairs(filteredFormData).forEach(([key, value]) => {
             appendFormField(postData, key, value);

--- a/src/react/src/components/InitialClaimFlow/ClaimCampaignBanner/ClaimCampaignBanner.jsx
+++ b/src/react/src/components/InitialClaimFlow/ClaimCampaignBanner/ClaimCampaignBanner.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { object, string } from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+
+import { claimCampaignBannerStyles } from './styles';
+
+// The campaign code only enters the claim form state when the
+// claim_campaigns feature flag is active (see ClaimIntro), so an empty
+// code is the single gate here.
+const ClaimCampaignBanner = ({ classes, campaignCode }) => {
+    if (!campaignCode) {
+        return null;
+    }
+
+    return (
+        <div className={classes.banner}>
+            <Typography>
+                This claim is part of a claims campaign (code{' '}
+                <span className={classes.code}>{campaignCode}</span>
+                ). Your progress will be visible to the campaign organizer.
+            </Typography>
+        </div>
+    );
+};
+
+ClaimCampaignBanner.defaultProps = {
+    campaignCode: '',
+};
+
+ClaimCampaignBanner.propTypes = {
+    campaignCode: string,
+    classes: object.isRequired,
+};
+
+export default withStyles(claimCampaignBannerStyles)(ClaimCampaignBanner);

--- a/src/react/src/components/InitialClaimFlow/ClaimCampaignBanner/styles.js
+++ b/src/react/src/components/InitialClaimFlow/ClaimCampaignBanner/styles.js
@@ -1,0 +1,18 @@
+import COLOURS from '../../../util/COLOURS';
+
+export const claimCampaignBannerStyles = () =>
+    Object.freeze({
+        banner: Object.freeze({
+            backgroundColor: COLOURS.PURPLE_TINT,
+            border: `1px solid ${COLOURS.PURPLE}`,
+            borderRadius: '4px',
+            padding: '12px 16px',
+            marginBottom: '24px',
+        }),
+        code: Object.freeze({
+            fontWeight: 600,
+            color: COLOURS.PURPLE_TEXT,
+        }),
+    });
+
+export default claimCampaignBannerStyles;

--- a/src/react/src/components/InitialClaimFlow/ClaimIntro/ClaimIntro.jsx
+++ b/src/react/src/components/InitialClaimFlow/ClaimIntro/ClaimIntro.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
@@ -10,26 +10,45 @@ import ClaimInfoSection from './ClaimInfoSection';
 import AppOverflow from '../../AppOverflow';
 import ModerationPauseBanner from '../../ModerationPauseBanner';
 import RequireAuthNotice from '../../RequireAuthNotice';
+import ClaimCampaignBanner from '../ClaimCampaignBanner/ClaimCampaignBanner';
 import { claimIntroStyles } from './styles';
 import withScrollReset from '../HOCs/withScrollReset';
-import { resetClaimForm, updateOsIdToClaim } from '../../../actions/claimForm';
+import {
+    resetClaimForm,
+    updateOsIdToClaim,
+    updateClaimFormField,
+} from '../../../actions/claimForm';
 import {
     claimDetailsRoute,
     facilityDetailsRoute,
+    CLAIM_CAMPAIGNS,
 } from '../../../util/constants';
+import { convertFeatureFlagsObjectToListOfActiveFlags } from '../../../util/util';
 import useClaimIntroOsIdTracking from './hooks';
 
 const ClaimIntro = ({
     classes,
     history,
+    location,
     osID,
     userHasSignedIn,
     resetForm,
     updateOsId,
     osIdToClaim,
+    campaignCode,
+    campaignFlagActive,
+    setCampaignCode,
 }) => {
     // Track OS ID changes and reset form when switching between locations.
     useClaimIntroOsIdTracking(osID, osIdToClaim, updateOsId, resetForm);
+
+    // Attach an optional claim campaign code from the URL to the form.
+    useEffect(() => {
+        const campaign = new URLSearchParams(location.search).get('campaign');
+        if (campaign && campaignFlagActive) {
+            setCampaignCode(campaign);
+        }
+    }, [location.search, campaignFlagActive, setCampaignCode]);
 
     if (!userHasSignedIn) {
         return (
@@ -55,6 +74,7 @@ const ClaimIntro = ({
             <ModerationPauseBanner />
             <AppOverflow>
                 <div className={classes.container}>
+                    <ClaimCampaignBanner campaignCode={campaignCode} />
                     <div className={classes.heroSection}>
                         <Typography
                             variant="title"
@@ -103,9 +123,15 @@ ClaimIntro.propTypes = {
         goBack: PropTypes.func.isRequired,
         push: PropTypes.func.isRequired,
     }).isRequired,
+    location: PropTypes.shape({
+        search: PropTypes.string.isRequired,
+    }).isRequired,
     resetForm: PropTypes.func.isRequired,
     updateOsId: PropTypes.func.isRequired,
     osIdToClaim: PropTypes.string.isRequired,
+    campaignCode: PropTypes.string.isRequired,
+    campaignFlagActive: PropTypes.bool.isRequired,
+    setCampaignCode: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = (
@@ -113,7 +139,8 @@ const mapStateToProps = (
         auth: {
             user: { user },
         },
-        claimForm: { osIdToClaim },
+        claimForm: { osIdToClaim, formData: { campaign } = {} },
+        featureFlags: { flags },
     },
     {
         match: {
@@ -124,11 +151,17 @@ const mapStateToProps = (
     osID,
     userHasSignedIn: !user.isAnon,
     osIdToClaim,
+    campaignCode: campaign || '',
+    campaignFlagActive: convertFeatureFlagsObjectToListOfActiveFlags(
+        flags,
+    ).includes(CLAIM_CAMPAIGNS),
 });
 
 export const mapDispatchToProps = dispatch => ({
     resetForm: () => dispatch(resetClaimForm()),
     updateOsId: osID => dispatch(updateOsIdToClaim(osID)),
+    setCampaignCode: value =>
+        dispatch(updateClaimFormField({ field: 'campaign', value })),
 });
 
 export default connect(

--- a/src/react/src/reducers/ClaimFormReducer.js
+++ b/src/react/src/reducers/ClaimFormReducer.js
@@ -19,6 +19,7 @@ const initialState = Object.freeze({
     formData: Object.freeze({
         // Eligibility step.
         claimantLocationRelationship: null,
+        campaign: '',
 
         // Contact step.
         pointOfContactEmail: '',

--- a/src/react/src/util/constants.jsx
+++ b/src/react/src/util/constants.jsx
@@ -591,6 +591,7 @@ export const ENABLE_V1_CLAIMS_FLOW = 'enable_v1_claims_flow';
 export const ENABLE_PRODUCTION_LOCATION_PAGE =
     'enable_production_location_page';
 export const ENABLE_MODERATION_PAUSE_INFO = 'enable_moderation_pause_info';
+export const CLAIM_CAMPAIGNS = 'claim_campaigns';
 
 export const DEFAULT_COUNTRY_CODE = 'IE';
 


### PR DESCRIPTION
Jira: [OSDEV-2969](https://opensupplyhub.atlassian.net/browse/OSDEV-2969) · Epic: [OSDEV-2966](https://opensupplyhub.atlassian.net/browse/OSDEV-2966) — stacked on #1108/#1109

- `/claim/{os_id}` reads an optional `?campaign=CODE` param. With the `claim_campaigns` flag on: a banner on the claim intro explains the campaign, and the code rides along in the submission payload (`campaign` field). Single flag gate where the URL is read — no code enters form state when the flag is off.
- Without the param (or flag off) the form is exactly today's form; empty campaign is stripped from the payload.

Tests: 15 ClaimIntro tests pass (param parsed + banner, flag off → ignored, no param → no banner); eslint clean; RELEASE-NOTES updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OSDEV-2969]: https://opensupplyhub.atlassian.net/browse/OSDEV-2969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OSDEV-2966]: https://opensupplyhub.atlassian.net/browse/OSDEV-2966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ