### PR TITLE
[OSDEV-2970] Brand-facing Claims Campaigns dashboard behind feature switch

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Code/API changes
 * [OSDEV-2967](https://opensupplyhub.atlassian.net/browse/OSDEV-2967) - Added the `ClaimCampaign` model (contributor-owned claims campaigns with a unique human-readable code), `campaign`/`via_link` fields on `FacilityClaim`, Django admin registration (campaign code locked after creation), and the `claim_campaigns` feature switch. The new fields are excluded from `sync_databases`.
 * [OSDEV-2968](https://opensupplyhub.atlassian.net/browse/OSDEV-2968) - Claim submissions accept an optional `campaign` code and are auto-attributed to active claims campaigns: a valid link code wins (`via_link=true`); otherwise a claim is attributed only when exactly one active campaign's currently-active uploaded list contains the facility. Runs only while the `claim_campaigns` switch is on; an invalid code never blocks a claim.
+* [OSDEV-2970](https://opensupplyhub.atlassian.net/browse/OSDEV-2970) - Added `GET /api/claim-campaigns/`: a read-only, switch-gated (404 when off) endpoint returning the requesting user's own claims campaigns with per-supplier claim statuses (only already-public values: unclaimed/pending/claimed) computed from the contributor's currently-active uploaded lists.
 * [OSDEV-2390](https://opensupplyhub.atlassian.net/browse/OSDEV-2390) - Contribution dates for the Supply Chain Network drawer:
   * Extended `index_contributors()` and `FacilityIndexDetailsSerializer.get_contributors()` to expose `list_uploaded_at` and `last_contributed_at` on public and anonymized contributor entries in the production location API response.
   * Added the `facility_index_backfill` package and `backfill_facility_index` management command for batched, parallel refresh of selected `FacilityIndex` fields using existing `index_*()` SQL functions, as a faster alternative to full `index_facilities_new` reindexing at scale.
@@ -38,6 +39,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### What's new
 * [OSDEV-2969](https://opensupplyhub.atlassian.net/browse/OSDEV-2969) - The claim form at `/claim/{os_id}` reads an optional `?campaign=` parameter (behind the `claim_campaigns` flag): it shows a campaign banner on the intro step and includes the code in the claim submission payload. Without the parameter (or with the flag off) the form is unchanged.
+* [OSDEV-2970](https://opensupplyhub.atlassian.net/browse/OSDEV-2970) - New Claims Campaigns dashboard at `/claim-campaigns` (behind the `claim_campaigns` flag): per-campaign KPI tiles, a campaign progress bar, a supplier table with claim statuses and copyable per-supplier claim links, and an outreach CSV download.
 * [OSDEV-2390](https://opensupplyhub.atlassian.net/browse/OSDEV-2390) - The Supply Chain Network drawer on production location pages now shows list upload dates under each uploaded list and a "Last contributed" date for API-only public contributors and anonymized contributor types.
 
 ### Release instructions

--- a/src/django/api/serializers/facility/claim_campaign_serializer.py
+++ b/src/django/api/serializers/facility/claim_campaign_serializer.py
@@ -1,0 +1,75 @@
+from rest_framework import serializers
+
+from api.constants import FacilityClaimStatuses
+from api.models.facility.claim_campaign import ClaimCampaign
+from api.models.facility.facility_claim import FacilityClaim
+from api.models.facility.facility_list_item import FacilityListItem
+
+
+class ClaimCampaignSerializer(serializers.ModelSerializer):
+    """
+    Read-only representation of a claim campaign for the campaign
+    owner's dashboard, including per-supplier claim statuses for the
+    facilities on the contributor's uploaded lists.
+    """
+
+    suppliers = serializers.SerializerMethodField()
+
+    class Meta:
+        model = ClaimCampaign
+        fields = (
+            'id',
+            'name',
+            'code',
+            'status',
+            'created_at',
+            'suppliers',
+        )
+
+    def get_suppliers(self, campaign):
+        # Every campaign of a contributor shares the same roster, so
+        # compute it once per request instead of once per campaign.
+        cache = self.context.setdefault('suppliers_by_contributor', {})
+        if campaign.contributor_id not in cache:
+            cache[campaign.contributor_id] = self.build_suppliers(
+                campaign.contributor_id
+            )
+        return cache[campaign.contributor_id]
+
+    @staticmethod
+    def build_suppliers(contributor_id):
+        facilities = {
+            item.facility.id: item.facility
+            for item in FacilityListItem.objects.filter(
+                source__contributor_id=contributor_id,
+                source__is_active=True,
+                facility__isnull=False,
+            ).select_related('facility')
+        }
+
+        claim_statuses = {}
+        claims = FacilityClaim.objects.filter(
+            facility_id__in=facilities.keys(),
+            status__in=[
+                FacilityClaimStatuses.APPROVED,
+                FacilityClaimStatuses.PENDING,
+            ],
+        ).values_list('facility_id', 'status')
+        for facility_id, status in claims:
+            # An approved claim outranks a pending one.
+            if claim_statuses.get(facility_id) != 'claimed':
+                claim_statuses[facility_id] = (
+                    'claimed'
+                    if status == FacilityClaimStatuses.APPROVED
+                    else 'pending'
+                )
+
+        return [
+            {
+                'os_id': facility.id,
+                'name': facility.name,
+                'country_code': facility.country_code,
+                'claim_status': claim_statuses.get(facility.id, 'unclaimed'),
+            }
+            for facility in facilities.values()
+        ]

--- a/src/django/api/tests/test_claim_campaign.py
+++ b/src/django/api/tests/test_claim_campaign.py
@@ -230,3 +230,102 @@ class ClaimCampaignAttributionTest(ClaimCampaignBaseTest):
         claim = self.post_claim(campaign="EXAMPLE-FRESH-26")
         self.assertIsNone(claim.campaign)
         self.assertFalse(claim.via_link)
+
+
+class ClaimCampaignEndpointTest(ClaimCampaignBaseTest):
+    def setUp(self):
+        super().setUp()
+
+        self.password = "example123"
+        self.user.set_password(self.password)
+        self.user.save()
+
+        # Matched list items carry the facility reference; the roster
+        # lookup relies on it.
+        self.list_item.facility = self.facility
+        self.list_item.save()
+
+        self.url = "/api/claim-campaigns/"
+        self.client.login(email=self.user.email, password=self.password)
+
+    @override_switch("claim_campaigns", active=False)
+    def test_returns_not_found_when_switch_is_off(self):
+        response = self.client.get(self.url)
+        self.assertEqual(404, response.status_code)
+
+    @override_switch("claim_campaigns", active=True)
+    def test_requires_authentication(self):
+        self.client.logout()
+        response = self.client.get(self.url)
+        self.assertEqual(401, response.status_code)
+
+    @override_switch("claim_campaigns", active=True)
+    def test_lists_own_campaign_with_unclaimed_supplier(self):
+        response = self.client.get(self.url)
+        self.assertEqual(200, response.status_code)
+
+        [campaign] = response.json()
+        self.assertEqual("EXAMPLE-FRESH-26", campaign["code"])
+        self.assertEqual("ACTIVE", campaign["status"])
+
+        [supplier] = campaign["suppliers"]
+        self.assertEqual(self.facility.id, supplier["os_id"])
+        self.assertEqual("unclaimed", supplier["claim_status"])
+
+    @override_switch("claim_campaigns", active=True)
+    def test_supplier_statuses_follow_claims(self):
+        claim = FacilityClaim.objects.create(
+            contributor=self.contributor,
+            facility=self.facility,
+            contact_person="Name",
+            company_name="Test",
+            facility_description="description",
+        )
+
+        [supplier] = self.client.get(self.url).json()[0]["suppliers"]
+        self.assertEqual("pending", supplier["claim_status"])
+
+        claim.status = "APPROVED"
+        claim.save()
+
+        [supplier] = self.client.get(self.url).json()[0]["suppliers"]
+        self.assertEqual("claimed", supplier["claim_status"])
+
+    @override_switch("claim_campaigns", active=True)
+    def test_does_not_list_other_contributors_campaigns(self):
+        other_user = User.objects.create(email="other2@example.com")
+        other_contributor = Contributor.objects.create(
+            admin=other_user,
+            name="other contributor 2",
+            contrib_type=Contributor.OTHER_CONTRIB_TYPE,
+        )
+        ClaimCampaign.objects.create(
+            contributor=other_contributor,
+            name="Not mine",
+            code="NOT-MINE-26",
+        )
+
+        codes = [c["code"] for c in self.client.get(self.url).json()]
+        self.assertEqual(["EXAMPLE-FRESH-26"], codes)
+
+    @override_switch("claim_campaigns", active=True)
+    def test_replaced_list_items_leave_the_roster(self):
+        self.source.is_active = False
+        self.source.save()
+
+        [campaign] = self.client.get(self.url).json()
+        self.assertEqual([], campaign["suppliers"])
+
+    @override_switch("claim_campaigns", active=True)
+    def test_campaigns_share_the_contributor_roster(self):
+        ClaimCampaign.objects.create(
+            contributor=self.contributor,
+            name="Second campaign",
+            code="EXAMPLE-SECOND-26",
+        )
+
+        campaigns = self.client.get(self.url).json()
+        self.assertEqual(2, len(campaigns))
+        self.assertEqual(
+            campaigns[0]["suppliers"], campaigns[1]["suppliers"]
+        )

--- a/src/django/api/views/__init__.py
+++ b/src/django/api/views/__init__.py
@@ -30,6 +30,7 @@ from .country.all_countries import all_countries
 from .facility.facility_activity_report_view_set import (
     FacilityActivityReportViewSet
 )
+from .facility.claim_campaign_view_set import ClaimCampaignViewSet
 from .facility.facility_claim_view_set import FacilityClaimViewSet
 from .facility.facilities_view_set import FacilitiesViewSet
 from .facility.facility_list_view_set import FacilityListViewSet

--- a/src/django/api/views/facility/claim_campaign_view_set.py
+++ b/src/django/api/views/facility/claim_campaign_view_set.py
@@ -1,0 +1,34 @@
+from rest_framework.exceptions import NotFound
+from rest_framework.mixins import ListModelMixin
+from rest_framework.viewsets import GenericViewSet
+from waffle import switch_is_active
+
+from api.models.facility.claim_campaign import ClaimCampaign
+from api.permissions import IsRegisteredAndConfirmed
+from api.serializers.facility.claim_campaign_serializer import (
+    ClaimCampaignSerializer,
+)
+
+
+class ClaimCampaignViewSet(ListModelMixin, GenericViewSet):
+    """
+    Read-only list of the requesting user's own claim campaigns with
+    per-supplier claim statuses. Statuses expose only what is already
+    public (unclaimed / pending / claimed).
+    """
+
+    serializer_class = ClaimCampaignSerializer
+    permission_classes = (IsRegisteredAndConfirmed,)
+    pagination_class = None
+
+    def get_queryset(self):
+        if not switch_is_active('claim_campaigns'):
+            raise NotFound()
+
+        contributor = getattr(self.request.user, 'contributor', None)
+        if contributor is None:
+            return ClaimCampaign.objects.none()
+
+        return ClaimCampaign.objects.filter(
+            contributor=contributor,
+        ).order_by('-created_at')

--- a/src/django/oar/urls.py
+++ b/src/django/oar/urls.py
@@ -42,6 +42,8 @@ router.register('facility-lists', views.FacilityListViewSet, 'facility-list')
 router.register('facilities', views.FacilitiesViewSet, 'facility')
 router.register('facility-claims', views.FacilityClaimViewSet,
                 'facility-claim')
+router.register('claim-campaigns', views.ClaimCampaignViewSet,
+                'claim-campaign')
 router.register('facility-matches', views.FacilityMatchViewSet,
                 'facility-match')
 router.register('api-blocks', views.ApiBlockViewSet, 'api-block')

--- a/src/react/src/Routes.jsx
+++ b/src/react/src/Routes.jsx
@@ -38,6 +38,7 @@ import SearchByNameAndAddressResult from './components/Contribute/SearchByNameAn
 import ProductionLocationInfo from './components/Contribute/ProductionLocationInfo';
 import withProductionLocationSubmit from './components/Contribute/HOC/withProductionLocationSubmit';
 import ClaimIntro from './components/InitialClaimFlow/ClaimIntro/ClaimIntro';
+import ClaimCampaigns from './components/ClaimCampaigns/ClaimCampaigns';
 
 import { sessionLogin } from './actions/auth';
 import { fetchFeatureFlags, refreshFeatureFlags } from './actions/featureFlags';
@@ -61,8 +62,10 @@ import {
     claimFacilityRoute,
     claimIntroRoute,
     claimDetailsRoute,
+    claimCampaignsRoute,
     claimedFacilitiesRoute,
     CLAIM_A_FACILITY,
+    CLAIM_CAMPAIGNS,
     settingsRoute,
     InfoLink,
     InfoPaths,
@@ -153,6 +156,18 @@ class Routes extends Component {
                                     exact
                                     path={claimIntroRoute}
                                     component={ClaimIntro}
+                                />
+                                <Route
+                                    exact
+                                    path={claimCampaignsRoute}
+                                    render={() => (
+                                        <FeatureFlag
+                                            flag={CLAIM_CAMPAIGNS}
+                                            alternative={<RouteNotFound />}
+                                        >
+                                            <Route component={ClaimCampaigns} />
+                                        </FeatureFlag>
+                                    )}
                                 />
                                 <Route
                                     exact

--- a/src/react/src/__tests__/components/ClaimCampaigns.test.js
+++ b/src/react/src/__tests__/components/ClaimCampaigns.test.js
@@ -1,0 +1,135 @@
+import React from 'react';
+import { Router } from 'react-router-dom';
+import { fireEvent, waitFor } from '@testing-library/react';
+import { saveAs } from 'file-saver';
+
+import history from '../../util/history';
+import apiRequest from '../../util/apiRequest';
+import renderWithProviders from '../../util/testUtils/renderWithProviders';
+import ClaimCampaigns from '../../components/ClaimCampaigns/ClaimCampaigns';
+
+jest.mock('../../util/apiRequest', () => ({
+    __esModule: true,
+    default: {
+        get: jest.fn(),
+    },
+}));
+
+jest.mock('file-saver', () => ({
+    saveAs: jest.fn(),
+}));
+
+beforeAll(() => {
+    window.scrollTo = jest.fn();
+    // jsdom in this suite has no Blob; DownloadCSV needs one.
+    global.Blob = jest.fn(content => ({ content }));
+});
+
+const mockCampaigns = [
+    {
+        id: 1,
+        name: 'Fresh Produce Suppliers 2026',
+        code: 'EXAMPLE-FRESH-26',
+        status: 'ACTIVE',
+        created_at: '2026-05-12T00:00:00Z',
+        suppliers: [
+            {
+                os_id: 'BD2024199KXPL2M',
+                name: 'Green Delta Produce Ltd',
+                country_code: 'BD',
+                claim_status: 'claimed',
+            },
+            {
+                os_id: 'VN2024310ZZL8KD',
+                name: 'Hai Phong Packhouse Co',
+                country_code: 'VN',
+                claim_status: 'unclaimed',
+            },
+        ],
+    },
+];
+
+const renderComponent = (userHasSignedIn = true) => {
+    const preloadedState = {
+        auth: {
+            user: {
+                user: { isAnon: !userHasSignedIn },
+            },
+        },
+    };
+
+    return renderWithProviders(
+        <Router history={history}>
+            <ClaimCampaigns />
+        </Router>,
+        { preloadedState },
+    );
+};
+
+describe('ClaimCampaigns component', () => {
+    beforeEach(() => {
+        apiRequest.get.mockClear();
+    });
+
+    test('requires login', () => {
+        const { getByText } = renderComponent(false);
+
+        expect(
+            getByText('Log in to view your claims campaigns'),
+        ).toBeInTheDocument();
+        expect(apiRequest.get).not.toHaveBeenCalled();
+    });
+
+    test('renders campaigns with suppliers and statuses', async () => {
+        apiRequest.get.mockResolvedValue({ data: mockCampaigns });
+
+        const { getByText, getAllByText } = renderComponent();
+
+        await waitFor(() => {
+            expect(
+                getByText('Fresh Produce Suppliers 2026'),
+            ).toBeInTheDocument();
+        });
+
+        expect(apiRequest.get).toHaveBeenCalledWith('/api/claim-campaigns/');
+        expect(getByText('EXAMPLE-FRESH-26')).toBeInTheDocument();
+        expect(getByText('Suppliers invited')).toBeInTheDocument();
+        expect(getByText('50% of suppliers claimed')).toBeInTheDocument();
+        expect(getByText('Claimed (1)')).toBeInTheDocument();
+        expect(getByText('Pending review (0)')).toBeInTheDocument();
+        expect(getByText('Not started (1)')).toBeInTheDocument();
+        expect(getByText('Green Delta Produce Ltd')).toBeInTheDocument();
+        // KPI tile label + supplier row chip
+        expect(getAllByText('Claimed').length).toBeGreaterThanOrEqual(2);
+        expect(getAllByText('Not started').length).toBeGreaterThanOrEqual(2);
+    });
+
+    test('downloads the supplier CSV', async () => {
+        apiRequest.get.mockResolvedValue({ data: mockCampaigns });
+
+        const { getByText } = renderComponent();
+
+        await waitFor(() => {
+            expect(getByText('Download CSV')).toBeInTheDocument();
+        });
+
+        fireEvent.click(getByText('Download CSV'));
+
+        await waitFor(() => {
+            expect(saveAs).toHaveBeenCalledTimes(1);
+        });
+        expect(saveAs.mock.calls[0][1]).toBe('EXAMPLE-FRESH-26_suppliers.csv');
+    });
+
+    test('shows the empty state when the account has no campaigns', async () => {
+        apiRequest.get.mockResolvedValue({ data: [] });
+
+        const { getByText } = renderComponent();
+
+        await waitFor(() => {
+            expect(
+                getByText(/Your account has no claims campaigns yet/),
+            ).toBeInTheDocument();
+        });
+    });
+});

--- a/src/react/src/actions/claimCampaigns.js
+++ b/src/react/src/actions/claimCampaigns.js
@@ -1,0 +1,33 @@
+import { createAction } from 'redux-act';
+
+import apiRequest from '../util/apiRequest';
+import { logErrorAndDispatchFailure } from '../util/util';
+
+export const startFetchClaimCampaigns = createAction(
+    'START_FETCH_CLAIM_CAMPAIGNS',
+);
+export const failFetchClaimCampaigns = createAction(
+    'FAIL_FETCH_CLAIM_CAMPAIGNS',
+);
+export const completeFetchClaimCampaigns = createAction(
+    'COMPLETE_FETCH_CLAIM_CAMPAIGNS',
+);
+
+export function fetchClaimCampaigns() {
+    return dispatch => {
+        dispatch(startFetchClaimCampaigns());
+
+        return apiRequest
+            .get('/api/claim-campaigns/')
+            .then(({ data }) => dispatch(completeFetchClaimCampaigns(data)))
+            .catch(err =>
+                dispatch(
+                    logErrorAndDispatchFailure(
+                        err,
+                        'An error prevented fetching claim campaigns',
+                        failFetchClaimCampaigns,
+                    ),
+                ),
+            );
+    };
+}

--- a/src/react/src/components/ClaimCampaigns/ClaimCampaigns.jsx
+++ b/src/react/src/components/ClaimCampaigns/ClaimCampaigns.jsx
@@ -1,0 +1,416 @@
+import React, { useEffect, useState } from 'react';
+import { arrayOf, bool, func, number, object, shape, string } from 'prop-types';
+import { connect } from 'react-redux';
+import { withStyles } from '@material-ui/core/styles';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
+import moment from 'moment';
+import Button from '@material-ui/core/Button';
+import Chip from '@material-ui/core/Chip';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import MenuItem from '@material-ui/core/MenuItem';
+import Paper from '@material-ui/core/Paper';
+import Select from '@material-ui/core/Select';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import Typography from '@material-ui/core/Typography';
+
+import AppOverflow from '../AppOverflow';
+import RequireAuthNotice from '../RequireAuthNotice';
+import { fetchClaimCampaigns } from '../../actions/claimCampaigns';
+import { claimIntroRoute } from '../../util/constants';
+import { DownloadCSV, joinDataIntoCSVString } from '../../util/util';
+import COLOURS from '../../util/COLOURS';
+import { claimCampaignsStyles } from './styles';
+
+const STATUS_LABELS = Object.freeze({
+    claimed: 'Claimed',
+    pending: 'Pending review',
+    unclaimed: 'Not started',
+});
+
+const STATUS_COLORS = Object.freeze({
+    claimed: COLOURS.MATERIAL_GREEN,
+    pending: COLOURS.ORANGE,
+    unclaimed: COLOURS.DARK_GREY,
+});
+
+const STATUS_ORDER = Object.freeze(['claimed', 'pending', 'unclaimed']);
+
+const campaignPropType = shape({
+    id: number.isRequired,
+    code: string.isRequired,
+    name: string.isRequired,
+    status: string.isRequired,
+    created_at: string.isRequired,
+    suppliers: arrayOf(
+        shape({
+            os_id: string.isRequired,
+            name: string.isRequired,
+            country_code: string.isRequired,
+            claim_status: string.isRequired,
+        }),
+    ).isRequired,
+});
+
+const makeCampaignClaimLink = (osID, code) =>
+    `${window.location.origin}${claimIntroRoute.replace(
+        ':osID',
+        osID,
+    )}?campaign=${code}`;
+
+// Exports the rows currently shown, so filtering to "Not started" first
+// yields exactly the outreach list.
+const downloadSupplierCSV = (campaign, suppliers) =>
+    DownloadCSV(
+        joinDataIntoCSVString([
+            [
+                'facility_name',
+                'os_id',
+                'country_code',
+                'claim_status',
+                'claim_link',
+            ],
+            ...suppliers.map(s => [
+                s.name,
+                s.os_id,
+                s.country_code,
+                STATUS_LABELS[s.claim_status] || s.claim_status,
+                makeCampaignClaimLink(s.os_id, campaign.code),
+            ]),
+        ]),
+        `${campaign.code}_suppliers.csv`,
+    );
+
+const StatusSquare = ({ status, classes }) => (
+    <span
+        className={classes.statusSquare}
+        style={{ backgroundColor: STATUS_COLORS[status] }}
+    />
+);
+
+StatusSquare.propTypes = {
+    status: string.isRequired,
+    classes: object.isRequired,
+};
+
+const SupplierStatusChip = ({ status, classes }) => (
+    <Chip
+        label={
+            <span className={classes.chipContent}>
+                <span
+                    className={classes.statusDot}
+                    style={{ backgroundColor: STATUS_COLORS[status] }}
+                />
+                {STATUS_LABELS[status] || status}
+            </span>
+        }
+        className={
+            {
+                claimed: classes.statusClaimed,
+                pending: classes.statusPending,
+            }[status] || classes.statusUnclaimed
+        }
+    />
+);
+
+SupplierStatusChip.propTypes = {
+    status: string.isRequired,
+    classes: object.isRequired,
+};
+
+const KpiTile = ({ value, label, status, classes }) => (
+    <div className={classes.kpiTile}>
+        <span className={classes.kpiValue}>{value}</span>
+        <span className={classes.kpiLabel}>
+            {status && <StatusSquare status={status} classes={classes} />}
+            {label}
+        </span>
+    </div>
+);
+
+KpiTile.defaultProps = {
+    status: null,
+};
+
+KpiTile.propTypes = {
+    value: number.isRequired,
+    label: string.isRequired,
+    status: string,
+    classes: object.isRequired,
+};
+
+const CampaignCard = ({ campaign, classes }) => {
+    const [statusFilter, setStatusFilter] = useState('ALL');
+
+    const counts = { claimed: 0, pending: 0, unclaimed: 0 };
+    campaign.suppliers.forEach(s => {
+        counts[s.claim_status] = (counts[s.claim_status] || 0) + 1;
+    });
+    const total = campaign.suppliers.length;
+    const percentClaimed = total
+        ? Math.round((counts.claimed / total) * 100)
+        : 0;
+
+    const suppliers =
+        statusFilter === 'ALL'
+            ? campaign.suppliers
+            : campaign.suppliers.filter(s => s.claim_status === statusFilter);
+
+    return (
+        <Paper className={classes.campaignCard}>
+            <div className={classes.campaignHeader}>
+                <div>
+                    <span className={classes.campaignName}>
+                        {campaign.name}
+                    </span>
+                    <Typography className={classes.campaignMeta}>
+                        {total} suppliers ·{' '}
+                        {campaign.status === 'ACTIVE' ? 'Active' : 'Closed'}{' '}
+                        campaign · created{' '}
+                        {moment(campaign.created_at).format('D MMM YYYY')}
+                    </Typography>
+                </div>
+                <div className={classes.codeBox}>
+                    <span className={classes.codeLabel}>Campaign code</span>
+                    <span className={classes.code}>{campaign.code}</span>
+                    <CopyToClipboard text={campaign.code}>
+                        <Button size="small" color="primary">
+                            Copy
+                        </Button>
+                    </CopyToClipboard>
+                </div>
+            </div>
+
+            <div className={classes.kpiRow}>
+                <KpiTile
+                    value={total}
+                    label="Suppliers invited"
+                    classes={classes}
+                />
+                {STATUS_ORDER.map(status => (
+                    <KpiTile
+                        key={status}
+                        value={counts[status]}
+                        label={STATUS_LABELS[status]}
+                        status={status}
+                        classes={classes}
+                    />
+                ))}
+            </div>
+
+            <div className={classes.progressPanel}>
+                <div className={classes.progressHeader}>
+                    <Typography className={classes.progressTitle}>
+                        Campaign progress
+                    </Typography>
+                    <Typography className={classes.campaignMeta}>
+                        {percentClaimed}% of suppliers claimed
+                    </Typography>
+                </div>
+                <div className={classes.segmentBar}>
+                    {STATUS_ORDER.map(
+                        status =>
+                            counts[status] > 0 && (
+                                <span
+                                    key={status}
+                                    className={classes.segment}
+                                    style={{
+                                        width: `${
+                                            (counts[status] / total) * 100
+                                        }%`,
+                                        backgroundColor: STATUS_COLORS[status],
+                                    }}
+                                >
+                                    {counts[status]}
+                                </span>
+                            ),
+                    )}
+                </div>
+                <div className={classes.legend}>
+                    {STATUS_ORDER.map(status => (
+                        <span key={status} className={classes.legendItem}>
+                            <StatusSquare status={status} classes={classes} />
+                            {STATUS_LABELS[status]} ({counts[status]})
+                        </span>
+                    ))}
+                </div>
+            </div>
+
+            <div className={classes.tableTools}>
+                <Typography variant="subheading">Suppliers</Typography>
+                <div className={classes.tableToolsActions}>
+                    <Select
+                        value={statusFilter}
+                        onChange={e => setStatusFilter(e.target.value)}
+                    >
+                        <MenuItem value="ALL">All statuses</MenuItem>
+                        <MenuItem value="claimed">Claimed</MenuItem>
+                        <MenuItem value="pending">Pending review</MenuItem>
+                        <MenuItem value="unclaimed">Not started</MenuItem>
+                    </Select>
+                    <Button
+                        variant="outlined"
+                        color="primary"
+                        onClick={() => downloadSupplierCSV(campaign, suppliers)}
+                    >
+                        Download CSV
+                    </Button>
+                </div>
+            </div>
+
+            <Table>
+                <TableHead>
+                    <TableRow>
+                        <TableCell>Facility</TableCell>
+                        <TableCell>OS ID</TableCell>
+                        <TableCell>Country</TableCell>
+                        <TableCell>Claim status</TableCell>
+                        <TableCell>Unique claim link</TableCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                    {suppliers.map(supplier => (
+                        <TableRow key={supplier.os_id}>
+                            <TableCell>{supplier.name}</TableCell>
+                            <TableCell>{supplier.os_id}</TableCell>
+                            <TableCell>{supplier.country_code}</TableCell>
+                            <TableCell>
+                                <SupplierStatusChip
+                                    status={supplier.claim_status}
+                                    classes={classes}
+                                />
+                            </TableCell>
+                            <TableCell>
+                                <CopyToClipboard
+                                    text={makeCampaignClaimLink(
+                                        supplier.os_id,
+                                        campaign.code,
+                                    )}
+                                >
+                                    <Button color="primary">Copy link</Button>
+                                </CopyToClipboard>
+                            </TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+        </Paper>
+    );
+};
+
+CampaignCard.propTypes = {
+    campaign: campaignPropType.isRequired,
+    classes: object.isRequired,
+};
+
+const ClaimCampaigns = ({
+    classes,
+    userHasSignedIn,
+    fetching,
+    campaigns,
+    error,
+    fetchCampaigns,
+}) => {
+    useEffect(() => {
+        if (userHasSignedIn) {
+            fetchCampaigns();
+        }
+    }, [userHasSignedIn, fetchCampaigns]);
+
+    if (!userHasSignedIn) {
+        return (
+            <RequireAuthNotice
+                title="Claims Campaigns"
+                text="Log in to view your claims campaigns"
+            />
+        );
+    }
+
+    if (fetching) {
+        return (
+            <div className={classes.emptyMessage}>
+                <CircularProgress />
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <Typography className={classes.emptyMessage}>
+                An error prevented loading your claims campaigns.
+            </Typography>
+        );
+    }
+
+    return (
+        <AppOverflow>
+            <div className={classes.container}>
+                <Typography
+                    variant="title"
+                    component="h1"
+                    className={classes.title}
+                >
+                    Claims Campaigns
+                </Typography>
+                <Typography className={classes.subtitle}>
+                    Track which of your suppliers have claimed their production
+                    location profiles.
+                </Typography>
+
+                {!campaigns || campaigns.length === 0 ? (
+                    <Typography className={classes.emptyMessage}>
+                        Your account has no claims campaigns yet. Campaigns are
+                        created for you by the OS Hub team — contact your
+                        account manager to get started.
+                    </Typography>
+                ) : (
+                    campaigns.map(campaign => (
+                        <CampaignCard
+                            key={campaign.id}
+                            campaign={campaign}
+                            classes={classes}
+                        />
+                    ))
+                )}
+            </div>
+        </AppOverflow>
+    );
+};
+
+ClaimCampaigns.defaultProps = {
+    campaigns: null,
+    error: null,
+};
+
+ClaimCampaigns.propTypes = {
+    classes: object.isRequired,
+    userHasSignedIn: bool.isRequired,
+    fetching: bool.isRequired,
+    campaigns: arrayOf(campaignPropType),
+    error: arrayOf(string),
+    fetchCampaigns: func.isRequired,
+};
+
+const mapStateToProps = ({
+    auth: {
+        user: { user },
+    },
+    claimCampaigns: { fetching, data, error },
+}) => ({
+    userHasSignedIn: !user.isAnon,
+    fetching,
+    campaigns: data,
+    error,
+});
+
+const mapDispatchToProps = dispatch => ({
+    fetchCampaigns: () => dispatch(fetchClaimCampaigns()),
+});
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(withStyles(claimCampaignsStyles)(ClaimCampaigns));

--- a/src/react/src/components/ClaimCampaigns/styles.js
+++ b/src/react/src/components/ClaimCampaigns/styles.js
@@ -1,0 +1,170 @@
+import COLOURS from '../../util/COLOURS';
+
+export const claimCampaignsStyles = theme =>
+    Object.freeze({
+        container: Object.freeze({
+            maxWidth: '1072px',
+            margin: '0 auto',
+            padding: '24px 16px 64px',
+        }),
+        title: Object.freeze({
+            fontWeight: theme.typography.fontWeightBold,
+            marginBottom: '4px',
+        }),
+        subtitle: Object.freeze({
+            color: COLOURS.DARK_GREY,
+            marginBottom: '24px',
+        }),
+        campaignCard: Object.freeze({
+            padding: '20px 24px',
+            marginBottom: '16px',
+        }),
+        campaignHeader: Object.freeze({
+            display: 'flex',
+            alignItems: 'flex-start',
+            justifyContent: 'space-between',
+            flexWrap: 'wrap',
+            gap: '12px',
+        }),
+        campaignName: Object.freeze({
+            fontWeight: theme.typography.fontWeightBold,
+            fontSize: '24px',
+            display: 'block',
+        }),
+        campaignMeta: Object.freeze({
+            color: COLOURS.DARK_GREY,
+        }),
+        codeBox: Object.freeze({
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
+            padding: '4px 8px 4px 12px',
+            border: `1px dashed ${COLOURS.PURPLE}`,
+            borderRadius: '6px',
+            backgroundColor: COLOURS.PURPLE_TINT,
+        }),
+        codeLabel: Object.freeze({
+            color: COLOURS.DARK_GREY,
+        }),
+        code: Object.freeze({
+            fontFamily: 'monospace',
+            fontWeight: 600,
+            color: COLOURS.PURPLE_TEXT,
+        }),
+        kpiRow: Object.freeze({
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: '12px',
+            margin: '20px 0 12px',
+        }),
+        kpiTile: Object.freeze({
+            flex: '1 1 140px',
+            border: `1px solid ${COLOURS.GREY}`,
+            borderRadius: '8px',
+            padding: '14px 16px',
+        }),
+        kpiValue: Object.freeze({
+            display: 'block',
+            fontSize: '28px',
+            fontWeight: theme.typography.fontWeightBold,
+            lineHeight: 1.2,
+        }),
+        kpiLabel: Object.freeze({
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
+            color: COLOURS.DARK_GREY,
+        }),
+        statusSquare: Object.freeze({
+            display: 'inline-block',
+            width: '10px',
+            height: '10px',
+            borderRadius: '2px',
+            flexShrink: 0,
+        }),
+        progressPanel: Object.freeze({
+            border: `1px solid ${COLOURS.GREY}`,
+            borderRadius: '8px',
+            padding: '14px 16px',
+            marginBottom: '8px',
+        }),
+        progressHeader: Object.freeze({
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            marginBottom: '10px',
+        }),
+        progressTitle: Object.freeze({
+            fontWeight: theme.typography.fontWeightBold,
+        }),
+        segmentBar: Object.freeze({
+            display: 'flex',
+            height: '22px',
+            borderRadius: '4px',
+            overflow: 'hidden',
+            gap: '2px',
+        }),
+        segment: Object.freeze({
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: COLOURS.WHITE,
+            fontSize: '12px',
+            fontWeight: 600,
+            minWidth: '18px',
+        }),
+        legend: Object.freeze({
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: '16px',
+            marginTop: '10px',
+            color: COLOURS.DARK_GREY,
+        }),
+        legendItem: Object.freeze({
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
+        }),
+        chipContent: Object.freeze({
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
+        }),
+        statusDot: Object.freeze({
+            display: 'inline-block',
+            width: '8px',
+            height: '8px',
+            borderRadius: '50%',
+            flexShrink: 0,
+        }),
+        tableTools: Object.freeze({
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            margin: '16px 0 8px',
+        }),
+        tableToolsActions: Object.freeze({
+            display: 'flex',
+            alignItems: 'center',
+            gap: '16px',
+        }),
+        statusClaimed: Object.freeze({
+            backgroundColor: COLOURS.LIGHT_GREEN,
+            color: COLOURS.GREEN_TEXT,
+        }),
+        statusPending: Object.freeze({
+            backgroundColor: COLOURS.LIGHT_AMBER,
+            color: COLOURS.ORANGE,
+        }),
+        statusUnclaimed: Object.freeze({
+            backgroundColor: COLOURS.LIGHTEST_GREY,
+            color: COLOURS.DARK_GREY,
+        }),
+        emptyMessage: Object.freeze({
+            padding: '48px 16px',
+            textAlign: 'center',
+            color: COLOURS.DARK_GREY,
+        }),
+    });
+
+export default claimCampaignsStyles;

--- a/src/react/src/reducers/ClaimCampaignsReducer.js
+++ b/src/react/src/reducers/ClaimCampaignsReducer.js
@@ -1,0 +1,35 @@
+import { createReducer } from 'redux-act';
+import update from 'immutability-helper';
+
+import {
+    startFetchClaimCampaigns,
+    failFetchClaimCampaigns,
+    completeFetchClaimCampaigns,
+} from '../actions/claimCampaigns';
+
+const initialState = Object.freeze({
+    fetching: false,
+    data: null,
+    error: null,
+});
+
+export default createReducer(
+    {
+        [startFetchClaimCampaigns]: state =>
+            update(state, {
+                fetching: { $set: true },
+                error: { $set: null },
+            }),
+        [failFetchClaimCampaigns]: (state, error) =>
+            update(state, {
+                fetching: { $set: false },
+                error: { $set: error },
+            }),
+        [completeFetchClaimCampaigns]: (state, data) =>
+            update(state, {
+                fetching: { $set: false },
+                data: { $set: data },
+            }),
+    },
+    initialState,
+);

--- a/src/react/src/reducers/index.js
+++ b/src/react/src/reducers/index.js
@@ -38,6 +38,7 @@ import ContributeProductionLocationReducer from './ContributeProductionLocationR
 import DashboardModerationQueueReducer from './DashboardModerationQueueReducer';
 import DashboardContributionRecordReducer from './DashboardContributionRecordReducer';
 import ClaimFormReducer from './ClaimFormReducer';
+import ClaimCampaignsReducer from './ClaimCampaignsReducer';
 import PartnerFieldGroupsReducer from './PartnerFieldGroupsReducer';
 import PartnerGroupContributorsReducer from './PartnerGroupContributorsReducer';
 import SectionNavigationReducer from './SectionNavigationReducer';
@@ -75,6 +76,7 @@ export default combineReducers({
     dashboardModerationQueue: DashboardModerationQueueReducer,
     dashboardContributionRecord: DashboardContributionRecordReducer,
     claimForm: ClaimFormReducer,
+    claimCampaigns: ClaimCampaignsReducer,
     partnerFieldGroups: PartnerFieldGroupsReducer,
     partnerGroupContributors: PartnerGroupContributorsReducer,
     sectionNavigation: SectionNavigationReducer,

--- a/src/react/src/util/constants.jsx
+++ b/src/react/src/util/constants.jsx
@@ -350,6 +350,7 @@ export const productionLocationsRoute = '/production-locations';
 export const productionLocationDetailsRoute = '/production-locations/:osID';
 export const claimFacilityRoute = '/facilities/:osID/claim';
 export const claimIntroRoute = '/claim/:osID';
+export const claimCampaignsRoute = '/claim-campaigns';
 export const claimDetailsRoute = '/claim/:osID/details';
 export const profileRoute = '/profile/:id';
 export const aboutProcessingRoute = `${InfoLink}/${InfoPaths.dataQuality}`;

--- a/src/react/src/util/util.js
+++ b/src/react/src/util/util.js
@@ -60,6 +60,8 @@ import {
     OTHER,
     FEATURE_COLLECTION,
     CLAIM_A_FACILITY,
+    CLAIM_CAMPAIGNS,
+    claimCampaignsRoute,
     inputTypesEnum,
     registrationFieldsEnum,
     registrationFormFields,
@@ -1549,6 +1551,15 @@ export const createUserDropdownLinks = (
             Object.freeze({
                 label: 'My Facilities',
                 href: '/claimed',
+            }),
+        );
+    }
+
+    if (includes(activeFeatureFlags, CLAIM_CAMPAIGNS)) {
+        links.push(
+            Object.freeze({
+                label: 'Claims Campaigns',
+                href: claimCampaignsRoute,
             }),
         );
     }


### PR DESCRIPTION
Jira: [OSDEV-2970](https://opensupplyhub.atlassian.net/browse/OSDEV-2970) · Epic: [OSDEV-2966](https://opensupplyhub.atlassian.net/browse/OSDEV-2966) — stacked on #1108–#1110 · [Prototype #detail view](https://tylerheath1.github.io/reports/projects/prototype-claims-campaign.html#detail)

- New `GET /api/claim-campaigns/`: read-only, `IsRegisteredAndConfirmed`, 404 while the switch is off, returns only the requesting user's own campaigns. Per-supplier statuses come from the contributor's currently-active lists and expose only already-public values (unclaimed/pending/claimed — never denied). Roster computed once per request (shared across the user's campaigns).
- New `/claim-campaigns` route + nav entry (flag-gated): one card per campaign with KPI tiles, segmented progress bar, supplier table (status chips, copy-link per supplier), per-campaign status filter, and an outreach CSV download (client-side, exports the filtered rows with claim links).
- No permission changes anywhere; the superuser-only `/api/facility-claims/` endpoint is untouched.

Tests: 7 endpoint tests (auth, switch-off 404, tenant scoping, statuses, active-list roster, shared roster) + 4 component tests pass; flake8/eslint clean; RELEASE-NOTES updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OSDEV-2970]: https://opensupplyhub.atlassian.net/browse/OSDEV-2970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OSDEV-2966]: https://opensupplyhub.atlassian.net/browse/OSDEV-2966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ