### PR TITLE
[OSDEV-2971] Campaign filter and column in the claims moderation dashboard

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -40,6 +40,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### What's new
 * [OSDEV-2969](https://opensupplyhub.atlassian.net/browse/OSDEV-2969) - The claim form at `/claim/{os_id}` reads an optional `?campaign=` parameter (behind the `claim_campaigns` flag): it shows a campaign banner on the intro step and includes the code in the claim submission payload. Without the parameter (or with the flag off) the form is unchanged.
 * [OSDEV-2970](https://opensupplyhub.atlassian.net/browse/OSDEV-2970) - New Claims Campaigns dashboard at `/claim-campaigns` (behind the `claim_campaigns` flag): per-campaign KPI tiles, a campaign progress bar, a supplier table with claim statuses and copyable per-supplier claim links, and an outreach CSV download.
+* [OSDEV-2971](https://opensupplyhub.atlassian.net/browse/OSDEV-2971) - The claims moderation dashboard (`/dashboard/claims`) gains a Campaign column and a shareable campaign filter (`?campaigns=`); the superuser-only `/api/facility-claims/` endpoint accepts an optional `campaigns` query parameter. Permissions unchanged.
 * [OSDEV-2390](https://opensupplyhub.atlassian.net/browse/OSDEV-2390) - The Supply Chain Network drawer on production location pages now shows list upload dates under each uploaded list and a "Last contributed" date for API-only public contributors and anonymized contributor types.
 
 ### Release instructions

--- a/src/django/api/serializers/facility/facility_claim_list_query_params_serializer.py
+++ b/src/django/api/serializers/facility/facility_claim_list_query_params_serializer.py
@@ -20,3 +20,7 @@ class FacilityClaimListQueryParamsSerializer(Serializer):
         child=CharField(required=False),
         required=False,
     )
+    campaigns = ListField(
+        child=CharField(required=False),
+        required=False,
+    )

--- a/src/django/api/serializers/facility/facility_claim_serializer.py
+++ b/src/django/api/serializers/facility/facility_claim_serializer.py
@@ -14,12 +14,14 @@ class FacilityClaimSerializer(ModelSerializer):
     facility_address = SerializerMethodField()
     facility_country_name = SerializerMethodField()
     claim_decision = SerializerMethodField()
+    campaign_code = SerializerMethodField()
 
     class Meta:
         model = FacilityClaim
         fields = ('id', 'created_at', 'updated_at', 'contributor_id', 'os_id',
                   'contributor_name', 'facility_name', 'facility_address',
-                  'facility_country_name', 'status', 'claim_decision')
+                  'facility_country_name', 'status', 'claim_decision',
+                  'campaign_code')
 
     def get_facility_name(self, claim):
         return claim.facility.name
@@ -41,3 +43,6 @@ class FacilityClaimSerializer(ModelSerializer):
 
     def get_claim_decision(self, claim):
         return claim.status_change_date
+
+    def get_campaign_code(self, claim):
+        return claim.campaign.code if claim.campaign_id else None

--- a/src/django/api/tests/test_claim_campaign.py
+++ b/src/django/api/tests/test_claim_campaign.py
@@ -232,6 +232,42 @@ class ClaimCampaignAttributionTest(ClaimCampaignBaseTest):
         self.assertFalse(claim.via_link)
 
 
+class ClaimsQueueCampaignFilterTest(ClaimCampaignBaseTest):
+    def setUp(self):
+        super().setUp()
+
+        self.superuser = User.objects.create_superuser(
+            "superuser@example.com", "superuser"
+        )
+        self.client.login(
+            email="superuser@example.com", password="superuser"
+        )
+
+        self.campaign_claim = self.create_claim(
+            campaign=self.campaign, via_link=True
+        )
+        self.plain_claim = self.create_claim()
+
+        self.url = "/api/facility-claims/"
+
+    def test_filters_queue_by_campaign_code(self):
+        response = self.client.get(
+            self.url, {"campaigns": "EXAMPLE-FRESH-26"}
+        )
+        self.assertEqual(200, response.status_code)
+
+        rows = response.json()
+        self.assertEqual([self.campaign_claim.id], [r["id"] for r in rows])
+        self.assertEqual("EXAMPLE-FRESH-26", rows[0]["campaign_code"])
+
+    def test_unfiltered_queue_includes_campaign_column(self):
+        response = self.client.get(self.url)
+        self.assertEqual(200, response.status_code)
+
+        codes = {r["campaign_code"] for r in response.json()}
+        self.assertEqual({"EXAMPLE-FRESH-26", None}, codes)
+
+
 class ClaimCampaignEndpointTest(ClaimCampaignBaseTest):
     def setUp(self):
         super().setUp()

--- a/src/django/api/views/facility/facility_claim_view_set.py
+++ b/src/django/api/views/facility/facility_claim_view_set.py
@@ -78,17 +78,21 @@ class FacilityClaimViewSet(ModelViewSet):
 
         statuses = params.validated_data.get('statuses')
         countries = params.validated_data.get('countries')
+        campaigns = params.validated_data.get('campaigns')
 
         queryset = FacilityClaim.objects.select_related(
             'facility',
             'contributor',
             'contributor__admin',
-            'status_change_by'
+            'status_change_by',
+            'campaign'
         ).all().order_by('-id')
         if statuses:
             queryset = queryset.filter(status__in=statuses)
         if countries:
             queryset = queryset.filter(facility__country_code__in=countries)
+        if campaigns:
+            queryset = queryset.filter(campaign__code__in=campaigns)
 
         response_data = FacilityClaimSerializer(queryset, many=True).data
 

--- a/src/react/src/__tests__/components/DashboardClaims.test.js
+++ b/src/react/src/__tests__/components/DashboardClaims.test.js
@@ -1,0 +1,111 @@
+import React from 'react';
+import { Router, Route } from 'react-router-dom';
+import { waitFor } from '@testing-library/react';
+
+import history from '../../util/history';
+import apiRequest from '../../util/apiRequest';
+import renderWithProviders from '../../util/testUtils/renderWithProviders';
+import DashboardClaims from '../../components/DashboardClaims';
+
+jest.mock('../../util/apiRequest', () => ({
+    __esModule: true,
+    default: {
+        get: jest.fn(),
+    },
+}));
+
+// react-select does not render in jsdom; replace StyledSelect (used by the
+// campaign, claim status, and country filters) with its label.
+jest.mock('../../components/Filters/StyledSelect', () => {
+    // eslint-disable-next-line global-require
+    const mockReact = require('react');
+    const MockStyledSelect = ({ label, name }) =>
+        mockReact.createElement(
+            'div',
+            { 'data-testid': `select-${name}` },
+            label,
+        );
+    return { __esModule: true, default: MockStyledSelect };
+});
+
+const claims = [
+    {
+        id: 184,
+        created_at: '2026-06-14T10:45:53.857805Z',
+        updated_at: '2026-06-14T13:25:49.835368Z',
+        claim_decision: null,
+        contributor_id: 1002,
+        os_id: 'TR2024425AKVM2E',
+        contributor_name: 'Contributor B',
+        facility_name: 'Facility Beta',
+        facility_address: '456 Beta Avenue, Beta City, Türkiye',
+        facility_country_name: 'Türkiye',
+        status: 'PENDING',
+        campaign_code: 'EXAMPLE-FRESH-26',
+    },
+    {
+        id: 45,
+        created_at: '2026-06-13T05:38:41.859592Z',
+        updated_at: '2026-06-13T05:38:41.859607Z',
+        claim_decision: null,
+        contributor_id: 1003,
+        os_id: 'UK2661125AKVMHV',
+        contributor_name: 'Contributor C',
+        facility_name: 'Facility Gamma',
+        facility_address: '789 Gamma Road, Gamma City, United Kingdom',
+        facility_country_name: 'United Kingdom',
+        status: 'PENDING',
+        campaign_code: null,
+    },
+];
+
+const renderComponent = () =>
+    renderWithProviders(
+        <Router history={history}>
+            <Route path="/dashboard/claims" component={DashboardClaims} />
+        </Router>,
+    );
+
+describe('DashboardClaims campaign filter', () => {
+    beforeAll(() => {
+        window.scrollTo = jest.fn();
+    });
+
+    beforeEach(() => {
+        apiRequest.get.mockImplementation(url =>
+            Promise.resolve({
+                data: url.includes('facility-claims') ? claims : [],
+            }),
+        );
+    });
+
+    test('shows all claims and the campaign filter without a URL param', async () => {
+        history.push('/dashboard/claims');
+
+        const { getByText, getByTestId } = renderComponent();
+
+        await waitFor(() => {
+            expect(getByText('Facility Beta')).toBeInTheDocument();
+        });
+
+        expect(getByText('Facility Gamma')).toBeInTheDocument();
+        expect(getByText('2 results')).toBeInTheDocument();
+        expect(getByTestId('select-CAMPAIGNS')).toBeInTheDocument();
+    });
+
+    test('filters claims by the campaigns URL parameter', async () => {
+        history.push('/dashboard/claims?campaigns=EXAMPLE-FRESH-26');
+
+        const { getByText, queryByText } = renderComponent();
+
+        await waitFor(() => {
+            expect(getByText('Facility Beta')).toBeInTheDocument();
+        });
+
+        expect(queryByText('Facility Gamma')).not.toBeInTheDocument();
+        expect(getByText('1 results')).toBeInTheDocument();
+        expect(history.location.search).toContain(
+            'campaigns=EXAMPLE-FRESH-26',
+        );
+    });
+});

--- a/src/react/src/__tests__/components/DashboardClaimsListTable.test.js
+++ b/src/react/src/__tests__/components/DashboardClaimsListTable.test.js
@@ -16,7 +16,8 @@ const data = [
         "facility_name": "Facility Beta",
         "facility_address": "456 Beta Avenue, Beta City, Türkiye",
         "facility_country_name": "Türkiye",
-        "status": "APPROVED"
+        "status": "APPROVED",
+        "campaign_code": "EXAMPLE-FRESH-26"
     },
     {
         "id": 45,
@@ -158,6 +159,16 @@ describe('DashboardClaimsListTable component', () => {
                 </Route>
             </Router>
         );
+    });
+
+    it('shows a campaign column with the code or a placeholder', async () => {
+        expect(screen.getByText('Campaign')).toBeInTheDocument();
+
+        await waitFor(() => {
+            expect(screen.getByText('EXAMPLE-FRESH-26')).toBeInTheDocument();
+        });
+        // Claims without a campaign fall back to the placeholder.
+        expect(screen.getAllByText('N/A').length).toBeGreaterThan(0);
     });
 
     it('sort by claim id in ascending order', async () => {

--- a/src/react/src/components/DashboardClaims.jsx
+++ b/src/react/src/components/DashboardClaims.jsx
@@ -1,7 +1,8 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { arrayOf, bool, func, shape, string } from 'prop-types';
 import map from 'lodash/map';
+import uniq from 'lodash/uniq';
 import { withStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
@@ -24,6 +25,7 @@ import {
 
 import ClaimStatusFilter from './Filters/ClaimStatusFilter';
 import CountryNameFilter from './Filters/CountryNameFilter';
+import StyledSelect from './Filters/StyledSelect';
 import {
     updateClaimStatusFilter,
     updateCountryFilter,
@@ -87,8 +89,13 @@ const DashboardClaims = ({
     downloadClaims,
     downloadClaimsError,
 }) => {
-    const { countries, statuses } = getDashboardClaimsListParamsFromQueryString(
-        search,
+    const {
+        countries,
+        statuses,
+        campaigns,
+    } = getDashboardClaimsListParamsFromQueryString(search);
+    const [campaignFilter, setCampaignFilter] = useState(
+        campaigns.map(code => ({ value: code, label: code })),
     );
 
     useEffect(() => {
@@ -106,6 +113,7 @@ const DashboardClaims = ({
                 makeDashboardClaimListLink({
                     statuses,
                     countries,
+                    campaigns,
                 }),
             );
         }
@@ -140,6 +148,7 @@ const DashboardClaims = ({
             makeDashboardClaimListLink({
                 statuses: finalStatuses,
                 countries: finalCountries,
+                campaigns: map(campaignFilter, 'value'),
             }),
         );
     }, [countriesData]);
@@ -149,6 +158,19 @@ const DashboardClaims = ({
             makeDashboardClaimListLink({
                 countries: map(c, 'value'),
                 statuses: map(s, 'value'),
+                campaigns: map(campaignFilter, 'value'),
+            }),
+        );
+    };
+
+    const onCampaignFilterUpdate = selected => {
+        const next = selected || [];
+        setCampaignFilter(next);
+        push(
+            makeDashboardClaimListLink({
+                statuses,
+                countries,
+                campaigns: map(next, 'value'),
             }),
         );
     };
@@ -157,7 +179,22 @@ const DashboardClaims = ({
         return <Typography>{error}</Typography>;
     }
 
-    const claimsCount = data && data.length;
+    // The claims endpoint returns the full (unpaginated) result set for
+    // the selected statuses/countries, so the campaign filter is applied
+    // client-side rather than through the shared search filters store.
+    // The backend also supports ?campaigns= for API consumers.
+    const campaignCodes = uniq(
+        map(data || [], 'campaign_code').filter(Boolean),
+    );
+    const selectedCampaignCodes = map(campaignFilter, 'value');
+    const visibleData =
+        !data || selectedCampaignCodes.length === 0
+            ? data
+            : data.filter(claim =>
+                  selectedCampaignCodes.includes(claim.campaign_code),
+              );
+
+    const claimsCount = visibleData && visibleData.length;
 
     return (
         <Paper className={classes.container}>
@@ -165,7 +202,7 @@ const DashboardClaims = ({
                 <div className={classes.dashboardClaimsFilters}>
                     <DashboardDownloadDataButton
                         fetching={fetching}
-                        downloadPayload={data || []}
+                        downloadPayload={visibleData || []}
                         downloadData={downloadClaims}
                         downloadError={downloadClaimsError}
                     />
@@ -175,13 +212,28 @@ const DashboardClaims = ({
                         isDisabled={fetching}
                     />
                     <CountryNameFilter isDisabled={fetching} />
+                    {campaignCodes.length > 0 && (
+                        <div className="form__field">
+                            <StyledSelect
+                                label="Campaign"
+                                name="CAMPAIGNS"
+                                options={campaignCodes.map(code => ({
+                                    value: code,
+                                    label: code,
+                                }))}
+                                value={campaignFilter}
+                                onChange={onCampaignFilterUpdate}
+                                isDisabled={fetching}
+                            />
+                        </div>
+                    )}
                     <Grid item className={classes.numberResults}>
                         {claimsCount} results
                     </Grid>
                 </div>
                 <DashboardClaimsListTable
                     fetching={fetching}
-                    data={data}
+                    data={visibleData}
                     handleSortClaims={sortClaims}
                     handleGetClaims={getClaims}
                     handleGetCountries={fetchCountries}

--- a/src/react/src/components/DashboardClaimsListTable.jsx
+++ b/src/react/src/components/DashboardClaimsListTable.jsx
@@ -163,7 +163,7 @@ function DashboardClaimsListTable({
             {loading || fetching ? (
                 <TableBody>
                     <TableRow>
-                        <TableCell colSpan={8}>
+                        <TableCell colSpan={9}>
                             <CircularProgress
                                 size={25}
                                 className={classes.loaderStyle}
@@ -205,6 +205,9 @@ function DashboardClaimsListTable({
                             </TableCell>
                             <TableCell padding="dense">
                                 {claim.facility_country_name}
+                            </TableCell>
+                            <TableCell padding="dense">
+                                {claim.campaign_code || EMPTY_PLACEHOLDER}
                             </TableCell>
                             <TableCell padding="dense">
                                 {moment(claim.created_at).format('LL')}

--- a/src/react/src/components/DashboardClaimsListTableHeader.jsx
+++ b/src/react/src/components/DashboardClaimsListTableHeader.jsx
@@ -32,6 +32,12 @@ const claimsListHeadCells = [
         label: 'Country',
     },
     {
+        id: 'campaign_code',
+        numeric: false,
+        disablePadding: true,
+        label: 'Campaign',
+    },
+    {
         id: 'created_at',
         numeric: false,
         disablePadding: true,

--- a/src/react/src/util/util.js
+++ b/src/react/src/util/util.js
@@ -642,10 +642,12 @@ export const getDashboardClaimsListParamsFromQueryString = qs => {
     const {
         countries,
         statuses = dashboardClaimsListParamsDefaults.claimStatuses,
+        campaigns,
     } = querystring.parse(parseFilterQueryString(qs));
 
     const statusesArray = Array.isArray(statuses) ? statuses : [statuses];
     const countriesArray = Array.isArray(countries) ? countries : [countries];
+    const campaignsArray = Array.isArray(campaigns) ? campaigns : [campaigns];
 
     return Object.freeze({
         countries: uniq(compact(countriesArray)),
@@ -653,6 +655,7 @@ export const getDashboardClaimsListParamsFromQueryString = qs => {
             uniq(compact(statusesArray)),
             map(facilityClaimStatusChoices, 'value'),
         ),
+        campaigns: uniq(compact(campaignsArray)),
     });
 };
 
@@ -995,7 +998,11 @@ export const makeDashboardContributorListLink = ({
     }`;
 };
 
-export const makeDashboardClaimListLink = ({ statuses, countries }) => {
+export const makeDashboardClaimListLink = ({
+    statuses,
+    countries,
+    campaigns,
+}) => {
     const createClaimFilterParams = (key, claimParamValues) =>
         claimParamValues && claimParamValues.length > 0
             ? join(
@@ -1006,8 +1013,9 @@ export const makeDashboardClaimListLink = ({ statuses, countries }) => {
 
     const statusParams = createClaimFilterParams('statuses', statuses);
     const countryParams = createClaimFilterParams('countries', countries);
+    const campaignParams = createClaimFilterParams('campaigns', campaigns);
 
-    const params = [statusParams, countryParams]
+    const params = [statusParams, countryParams, campaignParams]
         .filter(param => param)
         .join('&');
 


### PR DESCRIPTION
Jira: [OSDEV-2971](https://opensupplyhub.atlassian.net/browse/OSDEV-2971) · Epic: [OSDEV-2966](https://opensupplyhub.atlassian.net/browse/OSDEV-2966) — stacked on #1108–#1111

- `/dashboard/claims` gains a Campaign column (code or N/A) and a Campaign multi-select filter styled like the existing Claim Status/Country filters; filter state syncs to `?campaigns=` so views are shareable, and Download data exports the filtered rows.
- Backend: `/api/facility-claims/` accepts an optional `campaigns` query param (filter on `campaign__code`); `campaign` added to `select_related`; permissions unchanged (superuser-only). The dashboard filters client-side since the endpoint returns the full result set in one response (noted in a code comment); the param serves API consumers.

Tests: 2 backend filter tests + 3 new FE tests (column, filter via URL, no-param) pass; flake8/eslint clean; RELEASE-NOTES updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OSDEV-2971]: https://opensupplyhub.atlassian.net/browse/OSDEV-2971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OSDEV-2966]: https://opensupplyhub.atlassian.net/browse/OSDEV-2966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ