### PR TITLE
[OSDEV-2948] Fix gp3 RDS storage requiring explicit IOPS

### DIFF
--- a/deployment/environments/terraform-test.tfvars
+++ b/deployment/environments/terraform-test.tfvars
@@ -26,6 +26,7 @@ rds_database_identifier = "opensupplyhub-enc-tst"
 rds_database_name = "opensupplyhub"
 rds_multi_az = false
 rds_storage_type = "gp3"
+rds_iops = 12000
 rds_storage_encrypted = true
 
 anonymized_database_instance_type = "db.t3.2xlarge"

--- a/deployment/terraform/database.tf
+++ b/deployment/terraform/database.tf
@@ -83,6 +83,7 @@ module "database_enc" {
   engine_version              = var.rds_engine_version
   instance_type               = var.rds_instance_type
   storage_type                = var.rds_storage_type
+  iops                        = var.rds_iops
   database_identifier         = var.rds_database_identifier
   database_name               = var.rds_database_name
   database_username           = var.rds_database_username

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -182,6 +182,14 @@ variable "rds_storage_type" {
   default = "gp2"
 }
 
+variable "rds_iops" {
+  # Required by AWS when rds_storage_type is "gp3" and allocated storage is at
+  # or above the striping threshold (>= 400 GiB for PostgreSQL), where the valid
+  # range is 12000-64000 and the 12000 baseline is included at no extra cost.
+  # Leave at 0 for gp2, where IOPS scale automatically with storage size.
+  default = 0
+}
+
 variable "rds_database_identifier" {
 }
 


### PR DESCRIPTION
The terraform-aws-postgresql-rds module always sets iops on the DB instance, defaulting to 0, which AWS rejects for gp3 volumes at/above the 400 GiB striping threshold (ModifyDBInstance InvalidParameterCombination). Expose an rds_iops variable, wire it into the module, and set it to the free 12000 baseline for the gp3 test environment.