### PR TITLE
[OSDEV-2786] Optimize anonymise_in_paid_products migration

### DIFF
--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 #### Migrations
 * `0217_add_contribution_dates_to_index_contributors.py` - Updates the `index_contributors()` SQL function to include `list_uploaded_at` (from `FacilityList.created_at`) and `last_contributed_at` (from `FacilityListItem.updated_at`) in the indexed contributor JSON.
 * `0218_add_updated_at_to_index_claim_info.py` - Updates the `index_claim_info()` SQL function to include the claim's `updated_at` timestamp in the indexed `claim_info` JSON, so the claimed section can display the latest edit date instead of the original claim date. See OSDEV-2679.
-* `0219_add_contributor_anonymise_in_paid_products.py` - Adds the `anonymise_in_paid_products` boolean field (defaulting to `False`) to the `Contributor` model (and its `HistoricalContributor` mirror).
+* `0219_add_contributor_anonymise_in_paid_products.py` - Adds the `anonymise_in_paid_products` boolean field (`NOT NULL`, `db_default=False`) to the `Contributor` model (and its `HistoricalContributor` mirror). The column is added in a single `ADD COLUMN ... NOT NULL DEFAULT false` statement per table (a PostgreSQL 11+ metadata-only operation), avoiding a full-table `UPDATE` backfill.
 
 #### Schema changes
 * [OSDEV-2786](https://opensupplyhub.atlassian.net/browse/OSDEV-2786) - Added `anonymise_in_paid_products` boolean column to `api_contributor` (defaults to `False`). When enabled for a contributor, that contributor is anonymised in OS Hub's paid products regardless of contributor type. No reindex is required — masking happens at response build time.

--- a/src/django/api/migrations/0219_add_contributor_anonymise_in_paid_products.py
+++ b/src/django/api/migrations/0219_add_contributor_anonymise_in_paid_products.py
@@ -27,30 +27,14 @@ class Migration(migrations.Migration):
                         '''
                         ALTER TABLE api_contributor
                         ADD COLUMN IF NOT EXISTS
-                        anonymise_in_paid_products boolean;
-                        ''',
-                        '''
-                        UPDATE api_contributor
-                        SET anonymise_in_paid_products = false
-                        WHERE anonymise_in_paid_products IS NULL;
-                        ''',
-                        '''
-                        ALTER TABLE api_contributor
-                        ALTER COLUMN anonymise_in_paid_products SET NOT NULL;
+                        anonymise_in_paid_products boolean
+                        NOT NULL DEFAULT false;
                         ''',
                         '''
                         ALTER TABLE api_historicalcontributor
                         ADD COLUMN IF NOT EXISTS
-                        anonymise_in_paid_products boolean;
-                        ''',
-                        '''
-                        UPDATE api_historicalcontributor
-                        SET anonymise_in_paid_products = false
-                        WHERE anonymise_in_paid_products IS NULL;
-                        ''',
-                        '''
-                        ALTER TABLE api_historicalcontributor
-                        ALTER COLUMN anonymise_in_paid_products SET NOT NULL;
+                        anonymise_in_paid_products boolean
+                        NOT NULL DEFAULT false;
                         ''',
                     ],
                     reverse_sql=[
@@ -71,6 +55,7 @@ class Migration(migrations.Migration):
                     name='anonymise_in_paid_products',
                     field=models.BooleanField(
                         default=False,
+                        db_default=False,
                         help_text=ANONYMISE_IN_PAID_PRODUCTS_HELP_TEXT,
                         verbose_name=(
                             ANONYMISE_IN_PAID_PRODUCTS_VERBOSE_NAME
@@ -82,6 +67,7 @@ class Migration(migrations.Migration):
                     name='anonymise_in_paid_products',
                     field=models.BooleanField(
                         default=False,
+                        db_default=False,
                         help_text=ANONYMISE_IN_PAID_PRODUCTS_HELP_TEXT,
                         verbose_name=(
                             ANONYMISE_IN_PAID_PRODUCTS_VERBOSE_NAME

--- a/src/django/api/models/contributor/contributor.py
+++ b/src/django/api/models/contributor/contributor.py
@@ -141,6 +141,7 @@ class Contributor(models.Model):
     anonymise_in_paid_products = models.BooleanField(
         'Anonymise contributor name in paid products',
         default=False,
+        db_default=False,
         help_text=(
             "When enabled, this contributor's name is anonymised in OS Hub "
             'paid products - the bulk data download and the programmatic API '


### PR DESCRIPTION
## Summary

Optimizes migration `0219_add_contributor_anonymise_in_paid_products.py`, a follow-up to the OSDEV-2786 feature (#1087), so it applies quickly on large tables.

- **Drop the full-table backfill.** The original ran `ADD COLUMN` (nullable) → `UPDATE ... SET false` → `ALTER COLUMN SET NOT NULL` for both `api_contributor` and `api_historicalcontributor`. The `UPDATE` rewrites every row and generates a lot of WAL. This is replaced with a single `ADD COLUMN ... NOT NULL DEFAULT false` per table, which on PostgreSQL 11+ is a metadata-only operation (no table rewrite).
- **Carry the DB default forward, explicitly.** The `DEFAULT false` now stays on the column, and the field declares `db_default=False` — both on `Contributor.anonymise_in_paid_products` and in the migration's `state_operations` — so Django's recorded state matches the actual DB schema (no schema-vs-state divergence, no spurious `makemigrations` diff).

`state_operations` and `reverse_sql` behavior are otherwise unchanged.

## Notes

- Relies on PostgreSQL 11+ for the metadata-only `ADD COLUMN ... DEFAULT` behavior (the case in all our environments).
- Requires Django 5.0+ for `db_default` (repo is on 5.2).

## Test plan

- [ ] `docker compose exec django python manage.py migrate` applies cleanly
- [ ] `docker compose exec django python manage.py makemigrations --check` reports no changes
- [ ] Column `anonymise_in_paid_products` exists on `api_contributor` / `api_historicalcontributor` as `NOT NULL` with `DEFAULT false`
- [ ] Reverse migration drops the columns