### PR TITLE
[OSDEV-2786] Disable contributor indexing trigger during 0219 migration

### DIFF
--- a/src/django/api/migrations/0219_add_contributor_anonymise_in_paid_products.py
+++ b/src/django/api/migrations/0219_add_contributor_anonymise_in_paid_products.py
@@ -1,6 +1,24 @@
 from django.db import migrations, models
 
 
+DROP_CONTRIBUTOR_INDEXING_TRIGGER = '''
+DROP TRIGGER IF EXISTS contributor_post_insert_update_indexing_trigger ON
+api_contributor;
+'''
+
+CREATE_CONTRIBUTOR_INDEXING_TRIGGER = '''
+CREATE TRIGGER contributor_post_insert_update_indexing_trigger
+    AFTER
+INSERT
+	OR
+UPDATE
+	ON
+	api_contributor
+	FOR EACH ROW
+    EXECUTE FUNCTION handle_contributor_post_update_insert_indexing_trigger();
+'''
+
+
 ANONYMISE_IN_PAID_PRODUCTS_VERBOSE_NAME = (
     'Anonymise contributor name in paid products'
 )
@@ -20,6 +38,10 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunSQL(
+            sql=DROP_CONTRIBUTOR_INDEXING_TRIGGER,
+            reverse_sql=CREATE_CONTRIBUTOR_INDEXING_TRIGGER,
+        ),
         migrations.SeparateDatabaseAndState(
             database_operations=[
                 migrations.RunSQL(
@@ -75,5 +97,9 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
+        ),
+        migrations.RunSQL(
+            sql=CREATE_CONTRIBUTOR_INDEXING_TRIGGER,
+            reverse_sql=DROP_CONTRIBUTOR_INDEXING_TRIGGER,
         ),
     ]


### PR DESCRIPTION
Migration `0219_add_contributor_anonymise_in_paid_products` adds a column to `api_contributor`. The `contributor_post_insert_update_indexing_trigger` fires on every row touched by that change and can kick off per-row OpenSearch reindexing, making deploys slow and I/O-heavy. 

This wraps the column add with a targeted drop/recreate of only that trigger so indexing on other tables stays enabled. Follow-up to #1121, which replaced the full-table backfill with a metadata-only `ADD COLUMN ... NOT NULL DEFAULT false`.