### PR TITLE
[OSDEV-3030] Switch parent-companies endpoint to compressed response cache

### DIFF
--- a/src/django/api/views/__init__.py
+++ b/src/django/api/views/__init__.py
@@ -69,7 +69,7 @@ from .make_report import (
     _report_hubspot_error_to_rollbar,
 )
 from .number_of_workers_ranges import number_of_workers_ranges
-from .parent_companies import parent_companies
+from .parent_companies import ParentCompanies
 from .product_types import product_types
 from .sectors import sectors
 from .claim_statuses import claim_statuses

--- a/src/django/api/views/parent_companies.py
+++ b/src/django/api/views/parent_companies.py
@@ -1,69 +1,67 @@
-from rest_framework.decorators import (
-    api_view,
-    throttle_classes,
-)
 from rest_framework.response import Response
-from django.conf import settings
+from rest_framework.views import APIView
 from django.db.models import F, Func
-from django.views.decorators.cache import cache_page
 
 from ..models.contributor.contributor import Contributor
 from ..models.facility.facility_index import FacilityIndex
+from ..view_response_cache import cache_view_response
 
 
-@api_view(['GET'])
-@throttle_classes([])
-@cache_page(
-    settings.MEMCACHED_VIEW_CACHE_TIMEOUT_SECONDS,
-    cache="view_cache",
-)
-def parent_companies(_):
-    """
-    Returns list parent companies submitted by contributors, as a list of
-    tuples of Key and contributor name (suitable for populating a choice list),
-    sorted alphabetically.
+class ParentCompanies(APIView):
+    throttle_classes = []
+
+    @cache_view_response('parent_companies')
+    def get(self, request):
+        """
+        Returns list parent companies submitted by contributors, as a list of
+        tuples of Key and contributor name (suitable for populating a choice
+        list), sorted alphabetically.
 
 
-    ## Sample Response
+        ## Sample Response
 
-        [
-            [1, "Brand A"],
-            ["Non-Contributor", "Non-Contributor"],
-            [2, "Contributor B"]
-        ]
+            [
+                [1, "Brand A"],
+                ["Non-Contributor", "Non-Contributor"],
+                [2, "Contributor B"]
+            ]
 
-    """
-    ids = (
-        FacilityIndex
-        .objects
-        .annotate(
-            parent_companies=Func(F('parent_company_id'), function='unnest')
+        """
+        ids = (
+            FacilityIndex
+            .objects
+            .annotate(
+                parent_companies=Func(
+                    F('parent_company_id'), function='unnest'
+                )
+            )
+            .values_list('parent_companies', flat=True)
+            .distinct()
         )
-        .values_list('parent_companies', flat=True)
-        .distinct()
-    )
-    contributors = (
-        Contributor
-        .objects
-        .order_by_active_and_verified()
-        .order_by('name', '-is_verified', '-has_active_sources')
-        .filter(id__in=ids)
-        .values('name')
-        .values_list('id', 'name')
-    )
-    contrib_lookup = {name: id for (id, name) in contributors}
-
-    names = (
-        FacilityIndex
-        .objects
-        .annotate(
-            parent_companies=Func(F('parent_company_name'), function='unnest')
+        contributors = (
+            Contributor
+            .objects
+            .order_by_active_and_verified()
+            .order_by('name', '-is_verified', '-has_active_sources')
+            .filter(id__in=ids)
+            .values('name')
+            .values_list('id', 'name')
         )
-        .values_list('parent_companies', flat=True)
-        .order_by('parent_companies')
-        .distinct()
-    )
-    return Response([
-        (contrib_lookup[name] if name in contrib_lookup else name, name)
-        for name in names
-    ])
+        contrib_lookup = {name: id for (id, name) in contributors}
+
+        names = (
+            FacilityIndex
+            .objects
+            .annotate(
+                parent_companies=Func(
+                    F('parent_company_name'), function='unnest'
+                )
+            )
+            .values_list('parent_companies', flat=True)
+            .order_by('parent_companies')
+            .distinct()
+        )
+        return Response([
+            (contrib_lookup[name] if name in contrib_lookup else name, name)
+            for name in names
+        ])

--- a/src/django/oar/urls.py
+++ b/src/django/oar/urls.py
@@ -106,7 +106,7 @@ public_apis = [
     path('api/claim-statuses/', views.claim_statuses, name='claim_statuses'),
     path('api/facility-processing-types/', views.facility_processing_types,
          name='facility_processing_types'),
-    path('api/parent-companies/', views.parent_companies,
+    path('api/parent-companies/', views.ParentCompanies.as_view(),
          name='parent_companies'),
     path('api/product-types/', views.product_types, name='product_types'),
     path('api/sectors/', views.sectors, name='sectors'),


### PR DESCRIPTION
## Summary

Replace `cache_page` on `GET /api/parent-companies/` with the reusable `cache_view_response` decorator so the large filter-option payload can be zlib-compressed and stored in memcached without hitting the ~5 MB per-item limit. Convert the endpoint from a function-based `@api_view` to a `ParentCompanies` `APIView` so it matches how `cache_view_response` is used elsewhere (e.g. facilities list/detail).

## Context

[OSDEV-3030](https://opensupplyhub.atlassian.net/browse/OSDEV-3030) — `cache_page` could not cache this endpoint because the parent-company choice list exceeds memcached's item size limit. The endpoint was left uncached, so every facilities search page load re-ran expensive `FacilityIndex` unnest/distinct queries.

## Test plan

- [ ] `docker compose exec django python manage.py test api.tests.test_parent_company_choice_view`
- [ ] Hit `GET /api/parent-companies/` twice and confirm the second request is served from cache (no repeated DB work)
- [ ] Confirm response shape is unchanged (list of `[id, name]` tuples)

[OSDEV-3030]: https://opensupplyhub.atlassian.net/browse/OSDEV-3030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ