### PR TITLE
OSDEV-2587: [Data Centers] Add "Data Center" to the facility-type taxonomy (back-end classification)

### DIFF
--- a/src/django/api/facility_type_processing_type.py
+++ b/src/django/api/facility_type_processing_type.py
@@ -384,6 +384,16 @@ PRINTING_PROCESSING = 'printing product dyeing and laundering'
 ASSEMBLY_PROCESSING = 'final product assembly'
 WAREHOUSING_PROCESSING = 'warehousing distribution'
 OFFICE_PROCESSING = 'office hq'
+DATA_CENTER = 'data center'
+
+# Cleaned input variants that should resolve to the Data Center facility type.
+DATA_CENTER_ALIASES = {
+    'data center',
+    'data centre',
+    'datacenter',
+    'datacentre',
+    'dc',
+}
 
 ALL_FACILITY_TYPES = {
     RAW_MATERIAL_PROCESSING: 'Raw Material Processing or Production',
@@ -392,6 +402,7 @@ ALL_FACILITY_TYPES = {
     ASSEMBLY_PROCESSING: 'Final Product Assembly',
     WAREHOUSING_PROCESSING: 'Warehousing / Distribution',
     OFFICE_PROCESSING: 'Office / HQ',
+    DATA_CENTER: 'Data Center'
 }
 
 ALL_FACILITY_TYPE_CHOICES = [(k, v) for k, v in
@@ -404,6 +415,7 @@ FACILITY_PROCESSING_TYPES = {
     ASSEMBLY_PROCESSING: ASSEMBLY_PROCESSING_TYPES,
     WAREHOUSING_PROCESSING: WAREHOUSING_PROCESSING_TYPES,
     OFFICE_PROCESSING: OFFICE_PROCESSING_TYPES,
+    DATA_CENTER: {},
 }
 
 # Create a look-up of processing type -> facility type for
@@ -480,6 +492,12 @@ def get_facility_and_processing_type(facility_or_processing_type, sector=None):
 
     if cleaned_input is None:
         return (None, None, None, None)
+
+    # Data centers are classified regardless of the sector taxonomy below,
+    # which only covers apparel/goods-production sectors.
+    if cleaned_input in DATA_CENTER_ALIASES:
+        return (FACILITY_TYPE, EXACT_MATCH, ALL_FACILITY_TYPES[DATA_CENTER],
+                None)
 
     if sector is None or 'Apparel' not in sector:
         # No taxonomy for non-apparel sectors has been created.

--- a/src/django/api/tests/test_facility_and_processing_type.py
+++ b/src/django/api/tests/test_facility_and_processing_type.py
@@ -3,6 +3,7 @@ from api.facility_type_processing_type import (
     ALL_FACILITY_TYPES,
     ALL_PROCESSING_TYPES,
     ASSEMBLY,
+    DATA_CENTER,
     EXACT_MATCH,
     FACILITY_TYPE,
     FUZZY_MATCH,
@@ -118,3 +119,56 @@ class FacilityAndProcessingTypeTest(TestCase):
             facility_type_input, self.nonapparel_sector
         )
         self.assertEqual(output, expected_output)
+
+    def test_exact_data_center_facility_type_match(self):
+        facility_type_input = "Data Center"
+        expected_output = (
+            FACILITY_TYPE,
+            EXACT_MATCH,
+            ALL_FACILITY_TYPES[DATA_CENTER],
+            None,
+        )
+        output = get_facility_and_processing_type(
+            facility_type_input, self.sector
+        )
+        self.assertEqual(output, expected_output)
+
+    def test_data_center_facility_type_match_sector_nonapparel(self):
+        # Data centers must resolve even though the sector is not apparel;
+        # the data-center branch runs before the apparel-only sector gate.
+        facility_type_input = "Data Center"
+        expected_output = (
+            FACILITY_TYPE,
+            EXACT_MATCH,
+            ALL_FACILITY_TYPES[DATA_CENTER],
+            None,
+        )
+        output = get_facility_and_processing_type(
+            facility_type_input, self.nonapparel_sector
+        )
+        self.assertEqual(output, expected_output)
+
+    def test_data_center_facility_type_match_sector_none(self):
+        facility_type_input = "Data Center"
+        expected_output = (
+            FACILITY_TYPE,
+            EXACT_MATCH,
+            ALL_FACILITY_TYPES[DATA_CENTER],
+            None,
+        )
+        output = get_facility_and_processing_type(facility_type_input, None)
+        self.assertEqual(output, expected_output)
+
+    def test_data_center_alias_match(self):
+        expected_output = (
+            FACILITY_TYPE,
+            EXACT_MATCH,
+            ALL_FACILITY_TYPES[DATA_CENTER],
+            None,
+        )
+        for facility_type_input in ["datacenter", "data centre", "DC"]:
+            with self.subTest(facility_type_input=facility_type_input):
+                output = get_facility_and_processing_type(
+                    facility_type_input, self.nonapparel_sector
+                )
+                self.assertEqual(output, expected_output)


### PR DESCRIPTION
## Jira Ticket
[OSDEV-2587](https://opensupplyhub.atlassian.net/browse/OSDEV-2587)

---
## Summary of Changes
Data centers are classified on OS Hub as a `Facility` whose `facility_type` resolves to "Data Center" (reusing the existing extended-field / `location_type` pipeline rather than a new discriminator column). This change makes "Data Center" resolvable in the facility-type taxonomy.

In `api/facility_type_processing_type.py`:
- Added "Data Center" to `ALL_FACILITY_TYPES` and defined the `DATA_CENTER` constant plus a `DATA_CENTER_ALIASES` set (`data center`, `data centre`, `datacenter`, `datacentre`, `dc`).
- In `get_facility_and_processing_type`, a data-center input resolves to the Data Center facility type **before** the existing sector gate. Root cause: the matcher returns `SKIPPED_MATCHING` for any non-apparel sector, and data-center contributions won't carry an apparel sector — so without this branch "Data Center" would never resolve. The branch only fires for data-center inputs, so existing apparel/production matching is unchanged.

---
## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Backend change (API, database, business logic)
- [ ] UI / frontend change
- [ ] Architectural change (affects structure, contracts, or shared modules)
- [ ] Refactor (no functional change)
- [ ] Breaking change (existing functionality may not work as before)
- [ ] Documentation / tooling only

---
## Testing
Added unit tests in `api/tests/test_facility_and_processing_type.py` covering:
- Exact "Data Center" match (Apparel sector).
- Resolution under a non-apparel sector and with `sector=None` (verifies the pre-gate branch).
- Alias variants (`datacenter`, `data centre`, `DC`).
- Regression: an existing production facility type still resolves as before.

Run: `docker compose exec django python manage.py test api.tests.test_facility_and_processing_type`

---
## Known TODO Items
- The `is_data_center()` classification helper is handled separately (OSDEV-3067).
- Facility types resolve by exact match on the cleaned input against a fixed alias set; free-form variants (e.g. "AI data center") are not matched.

---
## Checklist
### Implementation
- [x] My code follows the project's style guidelines and naming conventions.
- [x] I have removed debug logs, commented-out code, and unused imports.
- [x] Any AI-assisted code (e.g., Claude) has been reviewed, understood, and adapted to fit our codebase.
- [x] I have considered backward compatibility and migrations where applicable.
### Testing & Validation
- [ ] I have manually tested the change in a local/dev environment.
- [x] I have added or updated unit tests for the new/changed behavior.
- [ ] All existing tests pass locally.
- [ ] For UI changes: I have included screenshots or a recording, and verified responsive/cross-browser behavior.
- [x] For backend changes: I have validated API contracts, error handling, and edge cases.
- [ ] For architectural changes: I have documented the design decision and notified affected teams.
### Documentation & Communication
- [x] I have updated relevant documentation (README, ADRs, inline comments, API docs).
- [ ] I have updated the Jira ticket status and added any relevant notes.
### Final Review
- [x] I have performed a self-review on my PR and I am presenting my best work for my peers to review.

[OSDEV-2587]: https://opensupplyhub.atlassian.net/browse/OSDEV-2587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ