### PR TITLE
[OSDEV-2980] Sample: close duplicate-check race with per-contributor advisory lock

### DIFF
--- a/src/django/api/moderation_event_actions/creation/location_contribution/duplicate_check.py
+++ b/src/django/api/moderation_event_actions/creation/location_contribution/duplicate_check.py
@@ -1,0 +1,151 @@
+'''
+Shared duplicate-detection logic for SLC CREATE submissions.
+
+Used by two call sites that must never drift apart:
+- DuplicateSubmissionProcessor runs the fast, user-facing check early in
+  the contribution chain, before the geocoding call, so a duplicate fails
+  quickly and cheaply. That check is advisory only: two concurrent
+  identical requests can both pass it, because neither event exists yet
+  when the other one looks.
+- ModerationEventCreator runs the authoritative re-check under a
+  per-contributor advisory lock immediately before inserting the
+  ModerationEvent row, which closes that race.
+'''
+
+import re
+from datetime import timedelta
+from difflib import SequenceMatcher
+
+from django.utils import timezone
+from rest_framework import status
+
+from api.constants import APIV1LocationContributionErrorMessages
+from api.models.moderation_event import ModerationEvent
+
+# How far back to look for a recent submission by the same contributor.
+# Sized to cover the worst-case lag before a contributor's own new location
+# becomes visible via the pre-submission search: up to 15 minutes for the
+# auto-approval automation to pick up the pending moderation event, plus up
+# to another 15 minutes for the Logstash pipeline to reindex the approved
+# facility into the production-locations OpenSearch index.
+DUPLICATE_CHECK_WINDOW_MINUTES = 30
+
+# Both name and address must be at least this similar (SequenceMatcher ratio,
+# 0-1) for two submissions to be considered the same location. Country must
+# match exactly. Requiring all three keeps this conservative, since a
+# single-field fuzzy match (e.g. name only) has previously produced false
+# positives elsewhere in this codebase (see ContributorManager.filter_by_name).
+NAME_SIMILARITY_THRESHOLD = 0.9
+ADDRESS_SIMILARITY_THRESHOLD = 0.9
+
+# Matches any numeric token in a cleaned name or address, e.g. "990" and
+# "19123" in "990 spring garden st. philadelphia pa 19123", or "2" in "blue
+# horizon facility unit 2". A distinguishing number (street number, suite/
+# unit/building number, zip code) can appear anywhere in either field, not
+# just at the start, so this isn't anchored to a fixed position.
+NUMBER_TOKEN_PATTERN = re.compile(r'\d+')
+
+
+def applies_to(event_dto) -> bool:
+    '''
+    The duplicate check covers SLC CREATE submissions without an explicit
+    override. Other sources (e.g. API) are excluded: the check exists for
+    the SLC form's auto-approval flow, and API integrators submitting
+    programmatically must not be rejected against a recent SLC submission.
+    Requires SourceProcessor to have populated event_dto.source.
+    '''
+    return (
+        event_dto.request_type == ModerationEvent.RequestType.CREATE.value
+        and event_dto.source == ModerationEvent.Source.SLC.value
+        and not event_dto.raw_data.get('duplicate_override')
+    )
+
+
+def find_recent_duplicate(event_dto):
+    '''
+    Return the most similar recent non-rejected SLC CREATE moderation event
+    by the same contributor, or None. Rejected submissions are excluded,
+    since a rejected event won't become a real facility and resubmitting
+    after a rejection is legitimate.
+    '''
+    cutoff = timezone.now() - timedelta(
+        minutes=DUPLICATE_CHECK_WINDOW_MINUTES
+    )
+    recent_events = ModerationEvent.objects.filter(
+        contributor=event_dto.contributor,
+        source=ModerationEvent.Source.SLC.value,
+        request_type=ModerationEvent.RequestType.CREATE.value,
+        created_at__gte=cutoff,
+    ).exclude(status=ModerationEvent.Status.REJECTED.value)
+
+    new_country = event_dto.cleaned_data.get('country_code')
+    new_name = event_dto.cleaned_data.get('clean_name', '')
+    new_address = event_dto.cleaned_data.get('clean_address', '')
+
+    for candidate in recent_events:
+        if candidate.cleaned_data.get('country_code') != new_country:
+            continue
+
+        candidate_name = candidate.cleaned_data.get('clean_name', '')
+        if numbers_differ(new_name, candidate_name):
+            continue
+
+        name_similarity = SequenceMatcher(
+            None, new_name, candidate_name
+        ).ratio()
+        if name_similarity < NAME_SIMILARITY_THRESHOLD:
+            continue
+
+        candidate_address = candidate.cleaned_data.get('clean_address', '')
+        if numbers_differ(new_address, candidate_address):
+            continue
+
+        address_similarity = SequenceMatcher(
+            None, new_address, candidate_address
+        ).ratio()
+        if address_similarity < ADDRESS_SIMILARITY_THRESHOLD:
+            continue
+
+        return candidate
+
+    return None
+
+
+def set_duplicate_error(event_dto, duplicate) -> None:
+    '''Populate the DTO with the 409 duplicate error payload.'''
+    event_dto.errors = {
+        'detail': (
+            APIV1LocationContributionErrorMessages
+            .POSSIBLE_DUPLICATE_SUBMISSION
+        ),
+        'duplicate_of': {
+            'moderation_id': str(duplicate.uuid),
+            'created_at': duplicate.created_at,
+            'name': duplicate.cleaned_data.get('name'),
+            'address': duplicate.cleaned_data.get('address'),
+            'country': duplicate.cleaned_data.get('country_code'),
+        }
+    }
+    event_dto.status_code = status.HTTP_409_CONFLICT
+
+
+def numbers_differ(value: str, other_value: str) -> bool:
+    '''
+    A single-digit change in a distinguishing number (a street number, a
+    suite/unit/building number, a zip code) barely moves the overall
+    SequenceMatcher ratio, so an otherwise near-identical name or address
+    for a genuinely different location (the building next door, a
+    different suite in the same building, a different unit sharing a
+    base name) could still clear the similarity threshold. Comparing all
+    numeric tokens found anywhere in the value (order-sensitive, since
+    these numbers aren't anchored to one position), and requiring an
+    exact match when both values contain at least one, catches that
+    case. Values without any numbers fall back to the overall similarity
+    ratio only.
+    '''
+    numbers = NUMBER_TOKEN_PATTERN.findall(value)
+    other_numbers = NUMBER_TOKEN_PATTERN.findall(other_value)
+    if not numbers or not other_numbers:
+        return False
+
+    return numbers != other_numbers

--- a/src/django/api/moderation_event_actions/creation/location_contribution/processors/duplicate_submission_processor.py
+++ b/src/django/api/moderation_event_actions/creation/location_contribution/processors/duplicate_submission_processor.py
@@ -1,39 +1,9 @@
-import re
-from datetime import timedelta
-from difflib import SequenceMatcher
-
-from django.utils import timezone
-from rest_framework import status
-
 from api.moderation_event_actions.creation.location_contribution \
     .processors.contribution_processor import ContributionProcessor
 from api.moderation_event_actions.creation.dtos.create_moderation_event_dto \
     import CreateModerationEventDTO
-from api.models.moderation_event import ModerationEvent
-from api.constants import APIV1LocationContributionErrorMessages
-
-# How far back to look for a recent submission by the same contributor.
-# Sized to cover the worst-case lag before a contributor's own new location
-# becomes visible via the pre-submission search: up to 15 minutes for the
-# auto-approval automation to pick up the pending moderation event, plus up
-# to another 15 minutes for the Logstash pipeline to reindex the approved
-# facility into the production-locations OpenSearch index.
-DUPLICATE_CHECK_WINDOW_MINUTES = 30
-
-# Both name and address must be at least this similar (SequenceMatcher ratio,
-# 0-1) for two submissions to be considered the same location. Country must
-# match exactly. Requiring all three keeps this conservative, since a
-# single-field fuzzy match (e.g. name only) has previously produced false
-# positives elsewhere in this codebase (see ContributorManager.filter_by_name).
-NAME_SIMILARITY_THRESHOLD = 0.9
-ADDRESS_SIMILARITY_THRESHOLD = 0.9
-
-# Matches any numeric token in a cleaned name or address, e.g. "990" and
-# "19123" in "990 spring garden st. philadelphia pa 19123", or "2" in "blue
-# horizon facility unit 2". A distinguishing number (street number, suite/
-# unit/building number, zip code) can appear anywhere in either field, not
-# just at the start, so this isn't anchored to a fixed position.
-NUMBER_TOKEN_PATTERN = re.compile(r'\d+')
+from api.moderation_event_actions.creation.location_contribution \
+    import duplicate_check
 
 
 class DuplicateSubmissionProcessor(ContributionProcessor):
@@ -43,108 +13,24 @@ class DuplicateSubmissionProcessor(ContributionProcessor):
     the last few minutes. Queries ModerationEvent directly (not the
     OpenSearch production-locations index), since the index may not have
     caught up yet with the contributor's own just-created submission.
-    Rejected submissions are excluded, since a rejected event won't become
-    a real facility and resubmitting after a rejection is legitimate.
+
+    This check is advisory only: it runs early so a duplicate fails fast,
+    before the geocoding call, but two concurrent identical requests can
+    both pass it. The authoritative re-check runs in
+    ModerationEventCreator under a per-contributor advisory lock — do not
+    remove either call site without the other.
     '''
 
     def process(
             self,
             event_dto: CreateModerationEventDTO) -> CreateModerationEventDTO:
-        if event_dto.request_type != ModerationEvent.RequestType.CREATE.value:
+        if not duplicate_check.applies_to(event_dto):
             return super().process(event_dto)
 
-        if event_dto.raw_data.get('duplicate_override'):
-            return super().process(event_dto)
-
-        duplicate = self.__find_recent_duplicate(event_dto)
+        duplicate = duplicate_check.find_recent_duplicate(event_dto)
         if duplicate is not None:
-            event_dto.errors = {
-                'detail': (
-                    APIV1LocationContributionErrorMessages
-                    .POSSIBLE_DUPLICATE_SUBMISSION
-                ),
-                'duplicate_of': {
-                    'moderation_id': str(duplicate.uuid),
-                    'created_at': duplicate.created_at,
-                    'name': duplicate.cleaned_data.get('name'),
-                    'address': duplicate.cleaned_data.get('address'),
-                    'country': duplicate.cleaned_data.get('country_code'),
-                }
-            }
-            event_dto.status_code = status.HTTP_409_CONFLICT
+            duplicate_check.set_duplicate_error(event_dto, duplicate)
 
             return event_dto
 
         return super().process(event_dto)
-
-    @staticmethod
-    def __find_recent_duplicate(event_dto: CreateModerationEventDTO):
-        cutoff = timezone.now() - timedelta(
-            minutes=DUPLICATE_CHECK_WINDOW_MINUTES
-        )
-        recent_events = ModerationEvent.objects.filter(
-            contributor=event_dto.contributor,
-            source=ModerationEvent.Source.SLC.value,
-            request_type=ModerationEvent.RequestType.CREATE.value,
-            created_at__gte=cutoff,
-        ).exclude(status=ModerationEvent.Status.REJECTED.value)
-
-        new_country = event_dto.cleaned_data.get('country_code')
-        new_name = event_dto.cleaned_data.get('clean_name', '')
-        new_address = event_dto.cleaned_data.get('clean_address', '')
-
-        for candidate in recent_events:
-            if candidate.cleaned_data.get('country_code') != new_country:
-                continue
-
-            candidate_name = candidate.cleaned_data.get('clean_name', '')
-            if DuplicateSubmissionProcessor.__numbers_differ(
-                new_name, candidate_name
-            ):
-                continue
-
-            name_similarity = SequenceMatcher(
-                None, new_name, candidate_name
-            ).ratio()
-            if name_similarity < NAME_SIMILARITY_THRESHOLD:
-                continue
-
-            candidate_address = candidate.cleaned_data.get(
-                'clean_address', ''
-            )
-            if DuplicateSubmissionProcessor.__numbers_differ(
-                new_address, candidate_address
-            ):
-                continue
-
-            address_similarity = SequenceMatcher(
-                None, new_address, candidate_address
-            ).ratio()
-            if address_similarity < ADDRESS_SIMILARITY_THRESHOLD:
-                continue
-
-            return candidate
-
-        return None
-
-    @staticmethod
-    def __numbers_differ(value: str, other_value: str) -> bool:
-        '''
-        A single-digit change in a distinguishing number (a street number, a
-        suite/unit/building number, a zip code) barely moves the overall
-        SequenceMatcher ratio, so an otherwise near-identical name or address
-        for a genuinely different location (the building next door, a
-        different suite in the same building, a different unit sharing a
-        base name) could still clear the similarity threshold. Comparing all
-        numeric tokens found anywhere in the value (order-sensitive, since
-        these numbers aren't anchored to one position), and requiring an
-        exact match when both values contain at least one, catches that
-        case. Values without any numbers fall back to the overall similarity
-        ratio only.
-        '''
-        numbers = NUMBER_TOKEN_PATTERN.findall(value)
-        other_numbers = NUMBER_TOKEN_PATTERN.findall(other_value)
-        if not numbers or not other_numbers:
-            return False
-
-        return numbers != other_numbers

--- a/src/django/api/moderation_event_actions/creation/moderation_event_creator.py
+++ b/src/django/api/moderation_event_actions/creation/moderation_event_creator.py
@@ -1,9 +1,18 @@
+from django.db import connection, transaction
+
 from api.moderation_event_actions.creation.event_creation_strategy import (
     EventCreationStrategy
 )
 from api.moderation_event_actions.creation.dtos.create_moderation_event_dto \
     import CreateModerationEventDTO
+from api.moderation_event_actions.creation.location_contribution \
+    import duplicate_check
 from api.models.moderation_event import ModerationEvent
+
+# Namespace for pg_advisory_xact_lock so the duplicate-check lock can't
+# collide with any other advisory lock usage. Arbitrary but must stay
+# unique within the application.
+DUPLICATE_LOCK_NAMESPACE = 2980
 
 
 class ModerationEventCreator:
@@ -19,7 +28,52 @@ class ModerationEventCreator:
         if processed_event.errors:
             return event_dto
 
-        event_dto.moderation_event = ModerationEvent.objects.create(
+        if duplicate_check.applies_to(processed_event):
+            return self.__create_serialized_per_contributor(
+                event_dto, processed_event
+            )
+
+        event_dto.moderation_event = self.__create_event(processed_event)
+
+        return event_dto
+
+    def __create_serialized_per_contributor(
+            self,
+            event_dto: CreateModerationEventDTO,
+            processed_event: CreateModerationEventDTO
+            ) -> CreateModerationEventDTO:
+        '''
+        Close the duplicate-check race: two concurrent identical requests
+        can both pass DuplicateSubmissionProcessor's early check, because
+        neither moderation event exists yet when the other one looks. The
+        per-contributor pg_advisory_xact_lock serializes the authoritative
+        re-check and the insert, so the second request's re-check sees the
+        first request's committed row and returns 409. The lock is held
+        only for this query + insert (no external calls) and is released
+        automatically at transaction end.
+        '''
+        with transaction.atomic():
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    'SELECT pg_advisory_xact_lock(%s, %s)',
+                    [DUPLICATE_LOCK_NAMESPACE, processed_event.contributor.id],
+                )
+
+            duplicate = duplicate_check.find_recent_duplicate(processed_event)
+            if duplicate is not None:
+                duplicate_check.set_duplicate_error(
+                    processed_event, duplicate
+                )
+                return event_dto
+
+            event_dto.moderation_event = self.__create_event(processed_event)
+
+        return event_dto
+
+    @staticmethod
+    def __create_event(
+            processed_event: CreateModerationEventDTO) -> ModerationEvent:
+        return ModerationEvent.objects.create(
             contributor=processed_event.contributor,
             request_type=processed_event.request_type,
             raw_data=processed_event.raw_data,
@@ -29,5 +83,3 @@ class ModerationEventCreator:
             os=processed_event.os,
             backfilled_fields=processed_event.backfilled_fields,
         )
-
-        return event_dto

--- a/src/django/api/tests/test_duplicate_submission_processor.py
+++ b/src/django/api/tests/test_duplicate_submission_processor.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest.mock import patch
 
 from django.contrib.gis.geos import Point
 from django.utils import timezone
@@ -18,6 +19,9 @@ from api.moderation_event_actions.creation.location_contribution \
     .location_contribution import LocationContribution
 from api.moderation_event_actions.creation.dtos.create_moderation_event_dto \
     import CreateModerationEventDTO
+from api.moderation_event_actions.creation.location_contribution \
+    .processors.duplicate_submission_processor \
+    import DuplicateSubmissionProcessor
 
 
 class TestDuplicateSubmissionProcessor(APITestCase):
@@ -360,3 +364,47 @@ class TestDuplicateSubmissionProcessor(APITestCase):
         # Confirm the duplicate check itself never triggers for UPDATE
         # requests, even though an identical CREATE submission exists.
         self.assertNotEqual(result.status_code, status.HTTP_409_CONFLICT)
+
+    def test_api_source_submission_is_not_checked_against_slc_submission(
+        self
+    ):
+        first_result = self._submit(self.contributor, self.base_input_data)
+        self.assertEqual(first_result.status_code, status.HTTP_202_ACCEPTED)
+
+        # An identical submission through the API source must not be
+        # rejected against the recent SLC submission - the duplicate check
+        # is scoped to the SLC form flow on both sides.
+        api_input_data = {
+            **self.base_input_data,
+            'source': 'API',
+        }
+        second_result = self._submit(self.contributor, api_input_data)
+
+        self.assertEqual(second_result.status_code, status.HTTP_202_ACCEPTED)
+        self.assertIsNotNone(second_result.moderation_event)
+
+    def test_creator_recheck_catches_duplicate_missed_by_processor(self):
+        first_result = self._submit(self.contributor, self.base_input_data)
+        self.assertEqual(first_result.status_code, status.HTTP_202_ACCEPTED)
+
+        # Simulate the concurrent-submission race: the processor-level
+        # check runs before the twin event exists (here: bypassed
+        # entirely), so only the authoritative re-check in
+        # ModerationEventCreator can catch the duplicate at insert time.
+        with patch.object(
+            DuplicateSubmissionProcessor,
+            'process',
+            lambda self, event_dto: (
+                self._next.process(event_dto) if self._next else event_dto
+            ),
+        ):
+            second_result = self._submit(
+                self.contributor, self.base_input_data
+            )
+
+        self.assertEqual(second_result.status_code, status.HTTP_409_CONFLICT)
+        self.assertIsNone(second_result.moderation_event)
+        self.assertEqual(
+            second_result.errors['duplicate_of']['moderation_id'],
+            str(first_result.moderation_event.uuid)
+        )


### PR DESCRIPTION
Sample implementation for the concurrency discussion on #1156 (Vadim's race-condition comment) — offered for cherry-picking or as a review aid, not as a competing PR. Base is the #1156 branch, so the diff shows only the delta on top of James's work.

## What

Two concurrent identical submissions can both pass the duplicate check, because neither moderation event exists yet when the other one looks, and both then create events. This closes that race with double-checked locking:

- **`duplicate_check.py` (new)**: the detection logic extracted verbatim from `DuplicateSubmissionProcessor` into a shared module (`applies_to` / `find_recent_duplicate` / `set_duplicate_error`), so the two call sites below cannot drift apart.
- **`DuplicateSubmissionProcessor`** keeps the early check — fast user-facing 409 before the geocoder call — now documented as advisory-only.
- **`ModerationEventCreator`** re-checks authoritatively inside `transaction.atomic()` while holding `pg_advisory_xact_lock(2980, contributor_id)`, immediately before the `ModerationEvent` insert. The second of two racing requests waits a few milliseconds for the lock, then its re-check sees the first request's committed row and returns the same 409 payload. The lock is per-contributor (no cross-contributor contention), held only for one indexed query + one insert (no external calls inside the critical section), and self-releases at transaction end.

The shared `applies_to` gate also checks `event_dto.source == SLC` — which doubles as the fix for the other review thread (API-source CREATEs being rejected against recent SLC submissions), since the incoming-side gate now mirrors the candidate query's `source=SLC` filter.

Deliberately **not** addressed here: the `duplicate_override` validation question (truthiness vs strict boolean / body vs query param) — `applies_to` centralizes that check so whatever is decided lands in one place.

## Tests

- `test_creator_recheck_catches_duplicate_missed_by_processor` — simulates the race by bypassing the processor-level check, asserting the creator-level re-check returns the 409 with the correct `duplicate_of` payload.
- `test_api_source_submission_is_not_checked_against_slc_submission` — regression test for the source scoping.
- Full affected suites green: `test_duplicate_submission_processor` (18) + `test_location_contribution_strategy` + `test_partner_data_file_upload` (49) via docker compose; flake8 clean.

A true-concurrency test (threads + `TransactionTestCase`) was deliberately skipped as flake-prone; the race path is instead covered deterministically by the bypass test above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)