### PR TITLE
[OSDEV-2867] CI attach/detach Preprod SNS on shared Test Chatbot

### DIFF
--- a/.github/workflows/deploy_to_aws.yml
+++ b/.github/workflows/deploy_to_aws.yml
@@ -235,6 +235,19 @@ jobs:
           SETTINGS_BUCKET: oshub-settings-${{ steps.get_env_name.outputs.lowercase }}
           AWS_DEFAULT_REGION: "eu-west-1"
 
+      # Preprod is ephemeral and shares Test's Chatbot Slack channel config. Attach
+      # after apply so Chatbot creates a real SNS subscription (ARN-only updates
+      # before the topic exists do not backfill). See doc/ops/monitoring.md.
+      - name: Attach Preprod SNS topic to shared Chatbot config
+        if: ${{ vars.ENV_NAME == 'Preprod' }}
+        run: ./deployment/sync_chatbot_sns_topic attach
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: "eu-west-1"
+          CHATBOT_CONFIGURATION_NAME: chatbotOpenSupplyHubTestGlobalAlarms
+          SNS_TOPIC_NAME: topicOpenSupplyHubPreprodGlobalNotifications
+
       - name: Delete debug log from S3 bucket for ${{ vars.ENV_NAME }}
         if: always()
         continue-on-error: true

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -99,6 +99,18 @@ jobs:
           terraform_version: 1.13.3
           terraform_wrapper: false
 
+      # Detach before destroy so Test's Chatbot config does not keep a stale
+      # Preprod SNS ARN. See doc/ops/monitoring.md.
+      - name: Detach Preprod SNS topic from shared Chatbot config
+        if: ${{ vars.ENV_NAME == 'Preprod' }}
+        run: ./deployment/sync_chatbot_sns_topic detach
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: "eu-west-1"
+          CHATBOT_CONFIGURATION_NAME: chatbotOpenSupplyHubTestGlobalAlarms
+          SNS_TOPIC_NAME: topicOpenSupplyHubPreprodGlobalNotifications
+
       - name: Terraform destroy for ${{ vars.ENV_NAME }}
         run: ./deployment/infra destroy
         env:

--- a/deployment/sync_chatbot_sns_topic
+++ b/deployment/sync_chatbot_sns_topic
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 #
 # Attach or detach an SNS topic ARN on a shared AWS Chatbot Slack channel
 # configuration (used for ephemeral Preprod in the Dev/Test/Preprod account).

--- a/deployment/sync_chatbot_sns_topic
+++ b/deployment/sync_chatbot_sns_topic
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# Attach or detach an SNS topic ARN on a shared AWS Chatbot Slack channel
+# configuration (used for ephemeral Preprod in the Dev/Test/Preprod account).
+#
+# Chatbot may store an SNS ARN without creating a subscription if the topic did
+# not exist yet. "attach" always removes then re-adds the ARN so a live topic
+# gets a real subscription. "detach" removes the ARN before the topic is
+# destroyed.
+#
+# Usage:
+#   ./deployment/sync_chatbot_sns_topic attach|detach
+#
+# Required env:
+#   AWS_DEFAULT_REGION (or AWS_REGION)
+#   CHATBOT_CONFIGURATION_NAME  e.g. chatbotOpenSupplyHubTestGlobalAlarms
+#   SNS_TOPIC_NAME              e.g. topicOpenSupplyHubPreprodGlobalNotifications
+#     OR SNS_TOPIC_ARN
+#
+set -euo pipefail
+
+function usage() {
+  echo "Usage: $(basename "$0") attach|detach" >&2
+  exit 1
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+fi
+
+ACTION="$1"
+REGION="${AWS_DEFAULT_REGION:-${AWS_REGION:-}}"
+CONFIGURATION_NAME="${CHATBOT_CONFIGURATION_NAME:-}"
+TOPIC_NAME="${SNS_TOPIC_NAME:-}"
+TOPIC_ARN="${SNS_TOPIC_ARN:-}"
+
+if [[ -z "$REGION" ]]; then
+  echo "AWS_DEFAULT_REGION (or AWS_REGION) is required" >&2
+  exit 1
+fi
+
+if [[ -z "$CONFIGURATION_NAME" ]]; then
+  echo "CHATBOT_CONFIGURATION_NAME is required" >&2
+  exit 1
+fi
+
+if [[ -z "$TOPIC_ARN" ]]; then
+  if [[ -z "$TOPIC_NAME" ]]; then
+    echo "SNS_TOPIC_ARN or SNS_TOPIC_NAME is required" >&2
+    exit 1
+  fi
+  ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+  TOPIC_ARN="arn:aws:sns:${REGION}:${ACCOUNT_ID}:${TOPIC_NAME}"
+fi
+
+if [[ "$ACTION" != "attach" && "$ACTION" != "detach" ]]; then
+  usage
+fi
+
+echo "Action: ${ACTION}"
+echo "Chatbot configuration: ${CONFIGURATION_NAME}"
+echo "SNS topic ARN: ${TOPIC_ARN}"
+
+function load_config() {
+  aws chatbot describe-slack-channel-configurations \
+    --region "$REGION" \
+    --output json \
+    | jq -c --arg name "$CONFIGURATION_NAME" '
+        .SlackChannelConfigurations
+        | map(select(.ConfigurationName == $name))
+        | .[0] // empty
+      '
+}
+
+CONFIG_JSON="$(load_config)"
+
+if [[ -z "$CONFIG_JSON" || "$CONFIG_JSON" == "null" ]]; then
+  echo "Chatbot Slack channel configuration '${CONFIGURATION_NAME}' not found in ${REGION}" >&2
+  exit 1
+fi
+
+CHAT_CONFIGURATION_ARN="$(jq -r '.ChatConfigurationArn' <<<"$CONFIG_JSON")"
+SLACK_CHANNEL_ID="$(jq -r '.SlackChannelId' <<<"$CONFIG_JSON")"
+IAM_ROLE_ARN="$(jq -r '.IamRoleArn' <<<"$CONFIG_JSON")"
+LOGGING_LEVEL="$(jq -r '.LoggingLevel // "ERROR"' <<<"$CONFIG_JSON")"
+CURRENT_TOPICS_JSON="$(jq -c '.SnsTopicArns // []' <<<"$CONFIG_JSON")"
+GUARDRAIL_JSON="$(jq -c '.GuardrailPolicyArns // []' <<<"$CONFIG_JSON")"
+
+echo "ChatConfigurationArn: ${CHAT_CONFIGURATION_ARN}"
+echo "Current SNS topics: ${CURRENT_TOPICS_JSON}"
+
+function update_topics() {
+  local topics_json="$1"
+  local payload
+  payload="$(
+    jq -n \
+      --arg chatArn "$CHAT_CONFIGURATION_ARN" \
+      --arg channelId "$SLACK_CHANNEL_ID" \
+      --arg iamRole "$IAM_ROLE_ARN" \
+      --arg loggingLevel "$LOGGING_LEVEL" \
+      --argjson topics "$topics_json" \
+      --argjson guardrails "$GUARDRAIL_JSON" \
+      '{
+        ChatConfigurationArn: $chatArn,
+        SlackChannelId: $channelId,
+        IamRoleArn: $iamRole,
+        LoggingLevel: $loggingLevel,
+        SnsTopicArns: $topics
+      }
+      + (if ($guardrails | length) > 0 then {GuardrailPolicyArns: $guardrails} else {} end)'
+  )"
+
+  echo "Updating Chatbot SNS topics to: ${topics_json}"
+  aws chatbot update-slack-channel-configuration \
+    --region "$REGION" \
+    --cli-input-json "$payload"
+}
+
+WITHOUT_TOPIC_JSON="$(
+  jq -c --arg arn "$TOPIC_ARN" 'map(select(. != $arn))' <<<"$CURRENT_TOPICS_JSON"
+)"
+
+case "$ACTION" in
+  detach)
+    if [[ "$(jq --arg arn "$TOPIC_ARN" 'any(. == $arn)' <<<"$CURRENT_TOPICS_JSON")" != "true" ]]; then
+      echo "Topic ARN not present on Chatbot config; nothing to detach."
+      exit 0
+    fi
+    update_topics "$WITHOUT_TOPIC_JSON"
+    echo "Detached ${TOPIC_ARN} from ${CONFIGURATION_NAME}"
+    ;;
+  attach)
+    # Always remove-then-add so a previously listed-but-unsubscribed ARN is repaired.
+    if [[ "$(jq --arg arn "$TOPIC_ARN" 'any(. == $arn)' <<<"$CURRENT_TOPICS_JSON")" == "true" ]]; then
+      echo "Topic ARN already listed; removing first to force subscription refresh."
+      update_topics "$WITHOUT_TOPIC_JSON"
+      CONFIG_JSON="$(load_config)"
+      CURRENT_TOPICS_JSON="$(jq -c '.SnsTopicArns // []' <<<"$CONFIG_JSON")"
+    fi
+    WITH_TOPIC_JSON="$(
+      jq -c --arg arn "$TOPIC_ARN" '
+          (map(select(. != $arn))) + [$arn]
+        ' <<<"$CURRENT_TOPICS_JSON"
+    )"
+    update_topics "$WITH_TOPIC_JSON"
+    echo "Attached ${TOPIC_ARN} to ${CONFIGURATION_NAME}"
+    ;;
+esac

--- a/deployment/sync_chatbot_sns_topic
+++ b/deployment/sync_chatbot_sns_topic
@@ -58,8 +58,6 @@ if [[ "$ACTION" != "attach" && "$ACTION" != "detach" ]]; then
 fi
 
 echo "Action: ${ACTION}"
-echo "Chatbot configuration: ${CONFIGURATION_NAME}"
-echo "SNS topic ARN: ${TOPIC_ARN}"
 
 function load_config() {
   aws chatbot describe-slack-channel-configurations \
@@ -75,7 +73,7 @@ function load_config() {
 CONFIG_JSON="$(load_config)"
 
 if [[ -z "$CONFIG_JSON" || "$CONFIG_JSON" == "null" ]]; then
-  echo "Chatbot Slack channel configuration '${CONFIGURATION_NAME}' not found in ${REGION}" >&2
+  echo "Chatbot Slack channel configuration not found" >&2
   exit 1
 fi
 
@@ -85,9 +83,6 @@ IAM_ROLE_ARN="$(jq -r '.IamRoleArn' <<<"$CONFIG_JSON")"
 LOGGING_LEVEL="$(jq -r '.LoggingLevel // "ERROR"' <<<"$CONFIG_JSON")"
 CURRENT_TOPICS_JSON="$(jq -c '.SnsTopicArns // []' <<<"$CONFIG_JSON")"
 GUARDRAIL_JSON="$(jq -c '.GuardrailPolicyArns // []' <<<"$CONFIG_JSON")"
-
-echo "ChatConfigurationArn: ${CHAT_CONFIGURATION_ARN}"
-echo "Current SNS topics: ${CURRENT_TOPICS_JSON}"
 
 function update_topics() {
   local topics_json="$1"
@@ -110,10 +105,11 @@ function update_topics() {
       + (if ($guardrails | length) > 0 then {GuardrailPolicyArns: $guardrails} else {} end)'
   )"
 
-  echo "Updating Chatbot SNS topics to: ${topics_json}"
+  # Silence CLI output.
   aws chatbot update-slack-channel-configuration \
     --region "$REGION" \
-    --cli-input-json "$payload"
+    --cli-input-json "$payload" \
+    >/dev/null 2>&1
 }
 
 WITHOUT_TOPIC_JSON="$(
@@ -123,16 +119,16 @@ WITHOUT_TOPIC_JSON="$(
 case "$ACTION" in
   detach)
     if [[ "$(jq --arg arn "$TOPIC_ARN" 'any(. == $arn)' <<<"$CURRENT_TOPICS_JSON")" != "true" ]]; then
-      echo "Topic ARN not present on Chatbot config; nothing to detach."
+      echo "nothing to detach"
       exit 0
     fi
     update_topics "$WITHOUT_TOPIC_JSON"
-    echo "Detached ${TOPIC_ARN} from ${CONFIGURATION_NAME}"
+    echo "Detached"
     ;;
   attach)
     # Always remove-then-add so a previously listed-but-unsubscribed ARN is repaired.
     if [[ "$(jq --arg arn "$TOPIC_ARN" 'any(. == $arn)' <<<"$CURRENT_TOPICS_JSON")" == "true" ]]; then
-      echo "Topic ARN already listed; removing first to force subscription refresh."
+      echo "Topic already listed; refreshing subscription"
       update_topics "$WITHOUT_TOPIC_JSON"
       CONFIG_JSON="$(load_config)"
       CURRENT_TOPICS_JSON="$(jq -c '.SnsTopicArns // []' <<<"$CONFIG_JSON")"
@@ -143,6 +139,6 @@ case "$ACTION" in
         ' <<<"$CURRENT_TOPICS_JSON"
     )"
     update_topics "$WITH_TOPIC_JSON"
-    echo "Attached ${TOPIC_ARN} to ${CONFIGURATION_NAME}"
+    echo "Attached"
     ;;
 esac

--- a/doc/ops/monitoring.md
+++ b/doc/ops/monitoring.md
@@ -76,7 +76,16 @@ AWS allows **only one** Chatbot Slack channel configuration per Slack channel **
 | Production | `true` (owner) | Creates the channel config; `sns_topic_arns` = Prod SNS + optional sibling ARNs |
 | Staging / RBA | `false` | Own SNS topic only; no Chatbot resources |
 
-Owner optional list `aws_chatbot_additional_sns_topic_arns` defaults to `[]` (safe for a new account / first env). After sibling SNS topics exist, add their ARNs in private `ci-deployment` tfvars for the owner env and re-apply.
+Owner optional list `aws_chatbot_additional_sns_topic_arns` defaults to `[]` (safe for a new account / first env). After **stable** sibling SNS topics exist, add their ARNs in private `ci-deployment` tfvars for the owner env and re-apply.
+
+Do **not** put ephemeral Preprod in that Terraform list. Chatbot accepts an SNS ARN even when the topic does not exist yet and does **not** create a subscription later when the topic appears. Preprod attach/detach is CI-owned:
+
+| When | Workflow | Script |
+| --- | --- | --- |
+| After Preprod terraform apply | `deploy_to_aws.yml` | `./deployment/sync_chatbot_sns_topic attach` → Test Chatbot config `chatbotOpenSupplyHubTestGlobalAlarms` |
+| Before Preprod terraform destroy | `destroy.yml` | `./deployment/sync_chatbot_sns_topic detach` |
+
+`attach` remove-then-re-adds the ARN so a previously listed-but-unsubscribed topic is repaired. After a **Test** apply while Preprod is live, Terraform may drop the CI-attached Preprod ARN (desired state is Test + Dev only); re-run Preprod deploy (or the attach script) to restore Slack paging.
 
 New AWS account, first env: leave manage `true` and additional ARNs empty — only that env’s SNS is attached. If ownership later moves between envs in the same account, apply the previous owner with manage `false` first (destroys its Chatbot resources), then apply the new owner.
 


### PR DESCRIPTION
## Summary

Follow-up to [#1169](https://github.com/opensupplyhub/open-supply-hub/pull/1169) / [OSDEV-2867](https://opensupplyhub.atlassian.net/browse/OSDEV-2867): ephemeral **Preprod** must not be owned by Test Terraform's `aws_chatbot_additional_sns_topic_arns`.

- Chatbot accepts an SNS ARN even when the topic does not exist yet and does **not** create a subscription later when the topic appears (no backfill).
- After Preprod terraform apply, `deploy_to_aws.yml` runs `./deployment/sync_chatbot_sns_topic attach` against Test Chatbot config `chatbotOpenSupplyHubTestGlobalAlarms`.
- Before Preprod terraform destroy, `destroy.yml` runs `detach` (hard failure — no `continue-on-error`).
- Documented in `doc/ops/monitoring.md`.
- Companion: [ci-deployment#69](https://github.com/opensupplyhub/ci-deployment/pull/69) removes Preprod ARN from Test additional SNS list (Dev remains).

**Caveat:** a Test apply while Preprod is live may drop the CI-attached Preprod ARN (desired Terraform state is Test + Dev only). Re-run Preprod deploy or the attach script to restore Slack paging.

## Test plan

- [ ] Deploy Preprod — confirm attach step succeeds and Test Chatbot lists Preprod SNS ARN with an active subscription
- [ ] Trigger a Preprod CloudWatch alarm → Slack via shared Test Chatbot channel
- [ ] Destroy Preprod — confirm detach runs before terraform destroy and Preprod ARN is removed from Chatbot
- [ ] Confirm Test tfvars (ci-deployment companion) no longer list Preprod; Dev remains
- [ ] Optional: apply Test while Preprod is up — confirm Preprod ARN may disappear; re-attach via Preprod deploy or script

[OSDEV-2867]: https://opensupplyhub.atlassian.net/browse/OSDEV-2867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ