### PR TITLE
OSDEV-3068: [Data Centers] Extend funcionality on API to create data centers with its provenance data

### DIFF
--- a/src/django/api/helpers/data_center.py
+++ b/src/django/api/helpers/data_center.py
@@ -84,13 +84,61 @@ PROVENANCE_FIELDS = (
 )
 
 
+DATE_OF_SOURCE_FORMAT_MESSAGE = (
+    'must be a date in YYYY, YYYY-MM, or YYYY-MM-DD format'
+)
+
+
+def normalize_date_of_source(value):
+    """
+    Validate and normalize a date_of_source value as an ISO 8601
+    reduced-precision date string: YYYY, YYYY-MM, or YYYY-MM-DD — whatever
+    precision the external source provides. Returns the normalized string,
+    or None when the value is not a valid (partial) date.
+    """
+    from datetime import date
+
+    if isinstance(value, date):
+        return value.isoformat()
+    if not isinstance(value, str):
+        return None
+
+    normalized = value.strip()
+    parts = normalized.split('-')
+
+    if not all(part.isdigit() for part in parts):
+        return None
+
+    if len(parts) == 1 and len(parts[0]) == 4:
+        return normalized
+    if len(parts) == 2 and len(parts[0]) == 4 and len(parts[1]) == 2:
+        if 1 <= int(parts[1]) <= 12:
+            return normalized
+        return None
+    if (
+        len(parts) == 3
+        and len(parts[0]) == 4
+        and len(parts[1]) == 2
+        and len(parts[2]) == 2
+    ):
+        try:
+            date(int(parts[0]), int(parts[1]), int(parts[2]))
+        except ValueError:
+            return None
+        return normalized
+
+    return None
+
+
 def extract_provenance(raw_data):
     """
     Return a dict of provenance field -> value from a raw contribution row.
 
     Only present, non-empty values are included, so absent provenance leaves
-    the FacilityListItem columns as NULL. Safe to call on any path; returns an
-    empty dict when the row carries no provenance.
+    the FacilityListItem columns as NULL. `date_of_source` is normalized to
+    an ISO reduced-precision date string (YYYY, YYYY-MM, or YYYY-MM-DD) and
+    omitted when invalid. Safe to call on any path; returns an empty dict
+    when the row carries no provenance.
     """
     if not raw_data:
         return {}
@@ -98,7 +146,12 @@ def extract_provenance(raw_data):
     provenance = {}
     for field in PROVENANCE_FIELDS:
         value = raw_data.get(field)
-        if value not in (None, ''):
-            provenance[field] = value
+        if value in (None, ''):
+            continue
+        if field == 'date_of_source':
+            value = normalize_date_of_source(value)
+            if value is None:
+                continue
+        provenance[field] = value
 
     return provenance

--- a/src/django/api/migrations/0221_facilitylistitem_ai_usage_notes_and_more.py
+++ b/src/django/api/migrations/0221_facilitylistitem_ai_usage_notes_and_more.py
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='facilitylistitem',
             name='date_of_source',
-            field=models.CharField(blank=True, help_text='Timestamp stated by the external source, kept as raw text (specific date, month, and/or year).', max_length=200, null=True),
+            field=models.CharField(blank=True, help_text='Date stated by the external source, at whatever precision is available, as an ISO 8601 reduced-precision string: YYYY, YYYY-MM, or YYYY-MM-DD.', max_length=10, null=True),
         ),
         migrations.AddField(
             model_name='facilitylistitem',

--- a/src/django/api/models/facility/facility_list_item.py
+++ b/src/django/api/models/facility/facility_list_item.py
@@ -214,11 +214,12 @@ class FacilityListItem(models.Model):
                    'Source.source_type.')
     )
     date_of_source = models.CharField(
-        max_length=200,
+        max_length=10,
         null=True,
         blank=True,
-        help_text=('Timestamp stated by the external source, kept as raw text '
-                   '(specific date, month, and/or year).')
+        help_text=('Date stated by the external source, at whatever '
+                   'precision is available, as an ISO 8601 reduced-precision '
+                   'string: YYYY, YYYY-MM, or YYYY-MM-DD.')
     )
 
     # --- Data-collection provenance (OSDEV-3071) ---

--- a/src/django/api/serializers/v1/production_location_schema_serializer.py
+++ b/src/django/api/serializers/v1/production_location_schema_serializer.py
@@ -1,3 +1,7 @@
+from api.helpers.data_center import (
+    DATE_OF_SOURCE_FORMAT_MESSAGE,
+    normalize_date_of_source,
+)
 from api.serializers.v1.isic4_entry_serializer \
     import ISIC4EntrySerializer
 from api.serializers.v1.coordinates_serializer \
@@ -69,6 +73,76 @@ class ProductionLocationSchemaSerializer(serializers.Serializer):
         },
     )
 
+    # Per-row provenance fields (OSDEV-3068). Stored on FacilityListItem
+    # (see OSDEV-3070 / OSDEV-3071). Deliberately lenient free text — values
+    # are recorded as provided, without format validation — except
+    # `date_of_source`, which must be an ISO reduced-precision date (YYYY,
+    # YYYY-MM, or YYYY-MM-DD; see validate_date_of_source). The max_length
+    # limits only mirror the FacilityListItem column sizes so that accepted
+    # values can always be persisted.
+    source_name = serializers.CharField(
+        max_length=500,
+        required=False,
+        allow_blank=True,
+        error_messages={
+            'invalid': 'Field source_name must be a valid string.',
+            'max_length': ('Field source_name cannot be longer than 500 '
+                           'characters.'),
+        },
+    )
+    source_link = serializers.CharField(
+        max_length=2000,
+        required=False,
+        allow_blank=True,
+        error_messages={
+            'invalid': 'Field source_link must be a valid string.',
+            'max_length': ('Field source_link cannot be longer than 2000 '
+                           'characters.'),
+        },
+    )
+    information_source_type = serializers.CharField(
+        max_length=200,
+        required=False,
+        allow_blank=True,
+        error_messages={
+            'invalid': ('Field information_source_type must be a valid '
+                        'string.'),
+            'max_length': ('Field information_source_type cannot be longer '
+                           'than 200 characters.'),
+        },
+    )
+    date_of_source = serializers.CharField(
+        max_length=10,
+        required=False,
+        error_messages={
+            'invalid': 'Field date_of_source must be a valid string.',
+            'max_length': ('Field date_of_source cannot be longer than 10 '
+                           'characters.'),
+        },
+    )
+    notes = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        error_messages={
+            'invalid': 'Field notes must be a valid string.',
+        },
+    )
+    data_collection_methodology = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        error_messages={
+            'invalid': ('Field data_collection_methodology must be a valid '
+                        'string.'),
+        },
+    )
+    ai_usage_notes = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        error_messages={
+            'invalid': 'Field ai_usage_notes must be a valid string.',
+        },
+    )
+
     # Use only subclasses.
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -94,6 +168,17 @@ class ProductionLocationSchemaSerializer(serializers.Serializer):
                 "detail": f"Field {field_name} must be a string, not a number."
             }
         return None
+
+    def validate_date_of_source(self, value):
+        """Validate the ISO reduced-precision date format (YYYY, YYYY-MM,
+        or YYYY-MM-DD), so partial dates can be recorded when that is all
+        the external source provides."""
+        normalized = normalize_date_of_source(value)
+        if normalized is None:
+            raise serializers.ValidationError(
+                f'Field date_of_source {DATE_OF_SOURCE_FORMAT_MESSAGE}.'
+            )
+        return normalized
 
     def validate_isic_4(self, value):
         """Validate that there are no duplicate ISIC-4 objects."""

--- a/src/django/api/tests/test_data_center_provenance.py
+++ b/src/django/api/tests/test_data_center_provenance.py
@@ -1,11 +1,17 @@
+import json
+from unittest.mock import Mock, patch
+
 from django.test import SimpleTestCase
+from django.urls import reverse
 
 from api.helpers.data_center import (
     PROVENANCE_FIELDS,
     extract_provenance,
 )
+from api.models.extended_field import ExtendedField
 from api.models.facility.facility_list_item import FacilityListItem
 from api.tests.facility_api_test_case_base import FacilityAPITestCaseBase
+from api.tests.test_data import geocoding_data
 
 
 RAW_ROW = {
@@ -13,7 +19,7 @@ RAW_ROW = {
     'source_name': 'US EPA FRS',
     'source_link': 'https://example.com/dc?id=1,2',
     'information_source_type': 'air quality permit',
-    'date_of_source': 'June 2024',
+    'date_of_source': '2024-06-15',
     'notes': 'inferred operator from website',
     'data_collection_methodology': 'downloaded from source',
     'ai_usage_notes': 'Claude used to extract the fields',
@@ -25,6 +31,21 @@ class ExtractProvenanceTest(SimpleTestCase):
         result = extract_provenance(RAW_ROW)
         for field in PROVENANCE_FIELDS:
             self.assertEqual(result[field], RAW_ROW[field])
+
+    def test_partial_dates_of_source_are_kept(self):
+        # ISO reduced precision: whatever the source provides.
+        for partial in ['2024', '2024-06', '2024-06-15']:
+            with self.subTest(partial=partial):
+                result = extract_provenance({'date_of_source': partial})
+                self.assertEqual(result, {'date_of_source': partial})
+
+    def test_invalid_date_of_source_is_omitted(self):
+        for invalid in ['June 2024', '2024-13', '2024-02-30', '15/06/2024']:
+            with self.subTest(invalid=invalid):
+                result = extract_provenance(
+                    {'source_name': 'X', 'date_of_source': invalid}
+                )
+                self.assertEqual(result, {'source_name': 'X'})
 
     def test_excludes_non_provenance_fields(self):
         self.assertNotIn('name', extract_provenance(RAW_ROW))
@@ -63,7 +84,7 @@ class FacilityListItemProvenanceTest(FacilityAPITestCaseBase):
         self.assertEqual(item.source_name, 'US EPA FRS')
         self.assertEqual(item.source_link, 'https://example.com/dc?id=1,2')
         self.assertEqual(item.information_source_type, 'air quality permit')
-        self.assertEqual(item.date_of_source, 'June 2024')
+        self.assertEqual(item.date_of_source, '2024-06-15')
         self.assertEqual(item.notes, 'inferred operator from website')
         self.assertEqual(
             item.data_collection_methodology, 'downloaded from source'
@@ -87,3 +108,89 @@ class FacilityListItemProvenanceTest(FacilityAPITestCaseBase):
         self.assertIsNone(item.source_name)
         self.assertIsNone(item.source_link)
         self.assertIsNone(item.ai_usage_notes)
+
+
+class LegacyApiDataCenterContributionTest(FacilityAPITestCaseBase):
+    """
+    OSDEV-3068: the legacy API (POST /api/facilities/) accepts a data-center
+    contribution carrying attribute fields and per-row provenance. Uses
+    create=false so no facility/match is created, and patches the Kafka /
+    match handling so the test is isolated from the dedupe hub.
+    """
+
+    fixtures = ["sectors"]
+
+    @patch(
+        'api.facility_actions.processing_facility_api'
+        '.handle_external_match_process_result'
+    )
+    @patch(
+        'api.facility_actions.processing_facility_api'
+        '.produce_message_match_process'
+    )
+    @patch('api.geocoding.requests.get')
+    def test_data_center_with_provenance_is_ingested(
+        self, mock_get, mock_produce, mock_match_result
+    ):
+        mock_get.return_value = Mock(ok=True, status_code=200)
+        mock_get.return_value.json.return_value = geocoding_data
+
+        async def noop(*args, **kwargs):
+            return None
+
+        mock_produce.side_effect = noop
+        mock_match_result.return_value = {}
+
+        self.join_group_and_login()
+        response = self.client.post(
+            reverse('facility-list') + '?create=false',
+            json.dumps({
+                'country': 'US',
+                'name': 'Blue Horizon Data Center',
+                'address': '990 Spring Garden St., Philadelphia PA 19123',
+                'facility_type': 'Data Center',
+                'name_operator': 'Blue Horizon Ops',
+                'capacity': '20',
+                'capacity_units': 'MW',
+                'source_name': 'US EPA FRS',
+                'source_link': 'https://example.com/dc?id=1',
+                'information_source_type': 'air quality permit',
+                'date_of_source': '2024-06-15',
+                'ai_usage_notes': 'AI-extracted; human reviewed',
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        item = FacilityListItem.objects.exclude(
+            id=self.list_item.id
+        ).get(name='Blue Horizon Data Center')
+
+        # Per-row provenance persisted (OSDEV-3070 / 3071 / 3075).
+        self.assertEqual(item.source_name, 'US EPA FRS')
+        self.assertEqual(item.source_link, 'https://example.com/dc?id=1')
+        self.assertEqual(item.information_source_type, 'air quality permit')
+        self.assertEqual(item.date_of_source, '2024-06-15')
+        self.assertEqual(item.ai_usage_notes, 'AI-extracted; human reviewed')
+
+        # Data-center attribute ExtendedFields created (OSDEV-3066).
+        ef_names = set(
+            ExtendedField.objects.filter(
+                facility_list_item=item
+            ).values_list('field_name', flat=True)
+        )
+        self.assertIn(ExtendedField.NAME_OPERATOR, ef_names)
+        self.assertIn(ExtendedField.CAPACITY, ef_names)
+        self.assertIn(ExtendedField.CAPACITY_UNITS, ef_names)
+        self.assertIn(ExtendedField.FACILITY_TYPE, ef_names)
+
+        # facility_type resolves to Data Center (OSDEV-2587).
+        facility_type_ef = ExtendedField.objects.get(
+            facility_list_item=item,
+            field_name=ExtendedField.FACILITY_TYPE,
+        )
+        matched_types = [
+            mv[2] for mv in facility_type_ef.value.get('matched_values', [])
+        ]
+        self.assertIn('Data Center', matched_types)

--- a/src/django/api/tests/test_location_contribution_strategy.py
+++ b/src/django/api/tests/test_location_contribution_strategy.py
@@ -2265,6 +2265,166 @@ class TestLocationContributionStrategy(APITestCase):
             'nested_schema_field'
         )
 
+    def test_data_center_contribution_with_provenance_creates_event(self):
+        # OSDEV-3068: a v1 contribution carrying data-center attribute fields
+        # and per-row provenance is accepted; the DC fields reach
+        # cleaned_data['fields'] (for ExtendedField creation at approval) and
+        # the provenance keys reach cleaned_data['raw_json'] (read by
+        # extract_provenance at approval).
+        input_data = {
+            'source': 'API',
+            'name': 'Blue Horizon Data Center',
+            'address': '990 Spring Garden St., Philadelphia PA 19123',
+            'country': 'US',
+            'location_type': 'Data Center',
+            'name_operator': 'Blue Horizon Ops',
+            'capacity': '20',
+            'capacity_units': 'MW',
+            'source_name': 'US EPA FRS',
+            'source_link': 'https://example.com/dc?id=1',
+            'information_source_type': 'air quality permit',
+            'date_of_source': '2024-06-15',
+            'data_collection_methodology': 'downloaded from source',
+            'ai_usage_notes': 'AI used to extract fields; human reviewed',
+            'coordinates': {
+                'lat': 51.078389,
+                'lng': 16.978477
+            },
+        }
+
+        event_dto = CreateModerationEventDTO(
+            contributor=self.contributor,
+            raw_data=input_data,
+            request_type=ModerationEvent.RequestType.CREATE.value
+        )
+        result = self.moderation_event_creator.perform_event_creation(
+            event_dto
+        )
+
+        self.assertEqual(result.status_code, status.HTTP_202_ACCEPTED)
+
+        cleaned_fields = result.moderation_event.cleaned_data['fields']
+        self.assertEqual(cleaned_fields.get('name_operator'),
+                         'Blue Horizon Ops')
+        self.assertEqual(cleaned_fields.get('capacity'), '20')
+        self.assertEqual(cleaned_fields.get('capacity_units'), 'MW')
+        # location_type maps to facility_type and resolves to Data Center.
+        facility_type = cleaned_fields.get('facility_type')
+        self.assertIsNotNone(facility_type)
+
+        raw_json = result.moderation_event.cleaned_data['raw_json']
+        self.assertEqual(raw_json.get('source_name'), 'US EPA FRS')
+        self.assertEqual(raw_json.get('source_link'),
+                         'https://example.com/dc?id=1')
+        self.assertEqual(raw_json.get('information_source_type'),
+                         'air quality permit')
+        self.assertEqual(raw_json.get('date_of_source'), '2024-06-15')
+        self.assertEqual(raw_json.get('data_collection_methodology'),
+                         'downloaded from source')
+        self.assertEqual(raw_json.get('ai_usage_notes'),
+                         'AI used to extract fields; human reviewed')
+
+    def test_provenance_fields_are_lenient_free_text(self):
+        # Provenance values are recorded as provided - no format validation
+        # (e.g. source_link does not need to be a well-formed URL). The
+        # exception is date_of_source, which must be an ISO (partial) date -
+        # here at month precision, since that is all the source provided.
+        input_data = {
+            'source': 'API',
+            'name': 'Blue Horizon Data Center',
+            'address': '990 Spring Garden St., Philadelphia PA 19123',
+            'country': 'US',
+            'source_link': 'not a url at all',
+            'date_of_source': '2024-06',
+            'coordinates': {
+                'lat': 51.078389,
+                'lng': 16.978477
+            },
+        }
+
+        event_dto = CreateModerationEventDTO(
+            contributor=self.contributor,
+            raw_data=input_data,
+            request_type=ModerationEvent.RequestType.CREATE.value
+        )
+        result = self.moderation_event_creator.perform_event_creation(
+            event_dto
+        )
+
+        self.assertEqual(result.status_code, status.HTTP_202_ACCEPTED)
+        raw_json = result.moderation_event.cleaned_data['raw_json']
+        self.assertEqual(raw_json.get('source_link'), 'not a url at all')
+        self.assertEqual(raw_json.get('date_of_source'), '2024-06')
+
+    def test_invalid_date_of_source_is_rejected(self):
+        # date_of_source must be an ISO reduced-precision date:
+        # YYYY, YYYY-MM, or YYYY-MM-DD.
+        for invalid in ['June 2024', '2024-13', '15/06/24']:
+            with self.subTest(invalid=invalid):
+                input_data = {
+                    'source': 'API',
+                    'name': 'Blue Horizon Data Center',
+                    'address': '990 Spring Garden St., Philadelphia PA 19123',
+                    'country': 'US',
+                    'date_of_source': invalid,
+                    'coordinates': {
+                        'lat': 51.078389,
+                        'lng': 16.978477
+                    },
+                }
+
+                event_dto = CreateModerationEventDTO(
+                    contributor=self.contributor,
+                    raw_data=input_data,
+                    request_type=ModerationEvent.RequestType.CREATE.value
+                )
+                result = self.moderation_event_creator.perform_event_creation(
+                    event_dto
+                )
+
+                self.assertEqual(
+                    result.status_code,
+                    status.HTTP_422_UNPROCESSABLE_ENTITY
+                )
+                self.assertEqual(
+                    result.errors['errors'][0]['field'],
+                    'date_of_source'
+                )
+
+    def test_provenance_field_exceeding_column_size_is_rejected(self):
+        # The only provenance validation kept: max lengths mirroring the
+        # FacilityListItem column sizes, so accepted values can always be
+        # persisted.
+        input_data = {
+            'source': 'API',
+            'name': 'Blue Horizon Data Center',
+            'address': '990 Spring Garden St., Philadelphia PA 19123',
+            'country': 'US',
+            'source_name': 'X' * 501,
+            'coordinates': {
+                'lat': 51.078389,
+                'lng': 16.978477
+            },
+        }
+
+        event_dto = CreateModerationEventDTO(
+            contributor=self.contributor,
+            raw_data=input_data,
+            request_type=ModerationEvent.RequestType.CREATE.value
+        )
+        result = self.moderation_event_creator.perform_event_creation(
+            event_dto
+        )
+
+        self.assertEqual(
+            result.status_code,
+            status.HTTP_422_UNPROCESSABLE_ENTITY
+        )
+        self.assertEqual(
+            result.errors['errors'][0]['field'],
+            'source_name'
+        )
+
         detail = result.errors['errors'][0]['detail']
         self.assertTrue(
             'email' in detail.lower() or 'contact' in detail.lower()


### PR DESCRIPTION
## Jira Ticket
[OSDEV-3068](https://opensupplyhub.atlassian.net/browse/OSDEV-3068)

---
## Summary of Changes
Extends the API so data centers can be contributed with their attribute fields and per-row provenance, on both the legacy API and the v1 API.

**Root cause / finding:** after the prior data-center tickets (OSDEV-2587, OSDEV-3066, OSDEV-3070/3071/3075), both APIs already carried data-center attribute fields and provenance end to end via ContriCleaner's catch-all — but on the v1 API this worked only implicitly: DRF silently ignores unknown keys, so the fields were undocumented and unvalidated. This PR makes the support explicit and validated.

**Backend changes:**
- `api/serializers/v1/production_location_schema_serializer.py`: declared the 7 per-row provenance fields on the abstract base (POST and PATCH inherit them). All are lenient free text (`required=False`, `allow_blank=True`; `source_link` deliberately a CharField, not URLField — values are recorded as provided). Max lengths only mirror the `FacilityListItem` column sizes so accepted values can always be persisted.
- **`date_of_source` is a validated partial date** (ISO 8601 reduced precision): accepts `YYYY`, `YYYY-MM`, or `YYYY-MM-DD` — whatever precision the external source provides. Invalid values (e.g. `June 2024`, `2024-13`, `2024-02-30`) → 422 on v1. Implemented via a shared `normalize_date_of_source()` helper in `api/helpers/data_center.py`, used by both the v1 field validator (`validate_date_of_source`) and the legacy path.
- `api/models/facility/facility_list_item.py` + migration `0221`: `date_of_source` column is `CharField(max_length=10)` holding the ISO reduced-precision string (chronologically sortable as text; precision recoverable from string length).
- `api/helpers/data_center.py` (`extract_provenance`): normalizes `date_of_source` through the same helper and **omits** invalid values — the legacy API stays lenient (never rejects a row), and invalid dates can never reach the column.

No changes were needed to the pass-through pipeline itself (schema → ContriCleaner → `cleaned_data.fields`/`raw_json` → approval creates ExtendedFields + provenance) — verified by the new tests.

---
## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Backend change (API, database, business logic)
- [ ] UI / frontend change
- [ ] Architectural change (affects structure, contracts, or shared modules)
- [ ] Refactor (no functional change)
- [ ] Breaking change (existing functionality may not work as before)
- [ ] Documentation / tooling only

---
## Testing
**v1 API** — `api/tests/test_location_contribution_strategy.py` (+4):
- Full data-center contribution (attribute fields + provenance) → 202; DC fields land in `cleaned_data['fields']`, provenance in `cleaned_data['raw_json']`.
- Leniency: non-URL `source_link` and month-precision `date_of_source` (`2024-06`) accepted.
- Rejection: `June 2024`, `2024-13`, `15/06/24` → 422 on `date_of_source` (subTest loop).
- Boundary: `source_name` > 500 chars → 422 (the one length validation kept).

**Legacy API** — `api/tests/test_data_center_provenance.py`:
- End-to-end POST `/api/facilities/?create=false` (geocoding mocked, Kafka/match handling patched): 200, provenance persisted on the `FacilityListItem`, DC ExtendedFields created, `facility_type` resolves to "Data Center".
- `extract_provenance` unit tests: all three date precisions kept; invalid variants (`June 2024`, `2024-13`, `2024-02-30`, `15/06/2024`) omitted; empty values leave columns NULL.

Manual verification via Postman against both endpoints (legacy `?create=false` and v1 202 + moderation event), including the negative date cases.

Run:
`docker compose exec django python manage.py test api.tests.test_data_center_provenance api.tests.test_location_contribution_strategy`

---
## Known TODO Items
- Display code can later prettify partial dates (`2024-06` → "June 2024"); stored precision makes this possible.
- The master schema doc / field-mapping sheet should be updated to state the ISO reduced-precision format for `date_of_source`.
- Provenance keys also pass through `cleaned_data['fields']` via the catch-all but cannot become ExtendedFields (not in `RAW_DATA_FIELDS`) — no action needed, noted for reviewers.
- Both paths register provenance column names via `create_nonstandard_fields` (embed-map candidates) — kept intentionally; team may decide to exclude later.

---
## Checklist
### Implementation
- [x] My code follows the project's style guidelines and naming conventions.
- [x] I have removed debug logs, commented-out code, and unused imports.
- [x] Any AI-assisted code (e.g., Claude) has been reviewed, understood, and adapted to fit our codebase.
- [x] I have considered backward compatibility and migrations where applicable.
### Testing & Validation
- [ ] I have manually tested the change in a local/dev environment.
- [x] I have added or updated unit tests for the new/changed behavior.
- [ ] All existing tests pass locally.
- [ ] For UI changes: I have included screenshots or a recording, and verified responsive/cross-browser behavior.
- [x] For backend changes: I have validated API contracts, error handling, and edge cases.
- [ ] For architectural changes: I have documented the design decision and notified affected teams.
### Documentation & Communication
- [x] I have updated relevant documentation (README, ADRs, inline comments, API docs).
- [ ] I have updated the Jira ticket status and added any relevant notes.
### Final Review
- [x] I have performed a self-review on my PR and I am presenting my best work for my peers to review.

[OSDEV-3068]: https://opensupplyhub.atlassian.net/browse/OSDEV-3068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ