### PR TITLE
OSDEV-3073: [Data Centers] Show per-field provenance in the contributions drawer

### DIFF
--- a/src/django/api/migrations/0224_facilitylistitem_ai_usage_notes_and_more.py
+++ b/src/django/api/migrations/0224_facilitylistitem_ai_usage_notes_and_more.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('api', '0220_fix_processing_type_search_index'),
+        ('api', '0223_fix_sector_search_index'),
     ]
 
     operations = [

--- a/src/django/api/serializers/facility/facility_index_details_serializer.py
+++ b/src/django/api/serializers/facility/facility_index_details_serializer.py
@@ -43,6 +43,10 @@ from api.helpers.data_center import is_data_center
 
 
 class FacilityIndexDetailsSerializer(FacilityIndexSerializer):
+    # Extended-field entries on the details endpoint carry the per-row
+    # provenance of the FacilityListItem they came from (OSDEV-3073).
+    include_extended_field_provenance = True
+
     other_names = SerializerMethodField()
     other_addresses = SerializerMethodField()
     other_locations = SerializerMethodField()

--- a/src/django/api/serializers/facility/facility_index_extended_field_list_serializer.py
+++ b/src/django/api/serializers/facility/facility_index_extended_field_list_serializer.py
@@ -25,7 +25,7 @@ class FacilityIndexExtendedFieldListSerializer:
                              'contributor_id', 'value_count', 'is_from_claim',
                              'field_name', 'verified_count', 'source_by',
                              'unit', 'label', 'base_url', 'display_text',
-                             'json_schema']
+                             'json_schema', 'provenance']
         self.data: list = []
 
         if exclude_fields:
@@ -42,6 +42,7 @@ class FacilityIndexExtendedFieldListSerializer:
             'contributor_id': self._get_contributor_id,
             'is_from_claim': self._get_is_from_claim,
             'verified_count': self._get_verified_count,
+            'provenance': self._get_provenance,
         }
         context_overrides = {
             'source_by',
@@ -116,6 +117,17 @@ class FacilityIndexExtendedFieldListSerializer:
         if is_contribution_masked(contributor, self.masked_contributors):
             return False
         return contributor.get('id') == claimant_contributor_id
+
+    def _get_provenance(self, extended_field: dict) -> Union[None, dict]:
+        """Per-row provenance of the FacilityListItem this field came from.
+        None when the row carries no provenance data or the
+        field has no list item (e.g. claim-born fields)."""
+        list_item_id = extended_field.get('facility_list_item_id')
+        if list_item_id is None:
+            return None
+        return self.context.get(
+            'provenance_by_list_item_id', {}
+        ).get(list_item_id)
 
     def _get_verified_count(self, extended_field: dict) -> int:
         count = 0

--- a/src/django/api/serializers/facility/facility_index_serializer.py
+++ b/src/django/api/serializers/facility/facility_index_serializer.py
@@ -12,8 +12,10 @@ from rest_framework.serializers import (
 
 from countries.lib.countries import COUNTRY_NAMES
 from ...constants import MASKED_CONTRIBUTOR_LABEL
+from ...helpers.data_center import PROVENANCE_FIELDS
 from ...models import Contributor
 from ...models.facility.facility_index import FacilityIndex
+from ...models.facility.facility_list_item import FacilityListItem
 from ...models.embed_config import EmbedConfig
 from ...models.embed_field import EmbedField
 from ...models.extended_field import ExtendedField
@@ -71,6 +73,11 @@ class FacilityIndexSerializer(GeoFeatureModelSerializer):
     address = SerializerMethodField()
     has_approved_claim = SerializerMethodField()
     sector = SerializerMethodField()
+    # Whether extended-field entries should carry the per-row provenance of
+    # the FacilityListItem they came from. Enabled only on the
+    # single-facility details serializer to avoid extra queries on list
+    # endpoints.
+    include_extended_field_provenance = False
 
     class Meta:
         model = FacilityIndex
@@ -229,6 +236,37 @@ class FacilityIndexSerializer(GeoFeatureModelSerializer):
             except EmbedConfig.DoesNotExist:
                 return fields
 
+    @staticmethod
+    def _build_extended_field_provenance_map(fields):
+        """
+        Bulk-load per-row provenance (see PROVENANCE_FIELDS) for the
+        FacilityListItems referenced by the given extended-field entries.
+        Returns {facility_list_item_id: {field: value}} containing only
+        items that carry at least one non-empty provenance value.
+        """
+        list_item_ids = {
+            field.get('facility_list_item_id')
+            for field in fields
+            if field.get('facility_list_item_id') is not None
+        }
+        if not list_item_ids:
+            return {}
+
+        provenance_map = {}
+        rows = FacilityListItem.objects.filter(
+            id__in=list_item_ids
+        ).values('id', *PROVENANCE_FIELDS)
+        for row in rows:
+            provenance = {
+                field: row[field]
+                for field in PROVENANCE_FIELDS
+                if row[field] not in (None, '')
+            }
+            if provenance:
+                provenance_map[row['id']] = provenance
+
+        return provenance_map
+
     @with_masked_contributors
     def get_extended_fields(self, facility, masked):
         request = self._get_request()
@@ -248,6 +286,10 @@ class FacilityIndexSerializer(GeoFeatureModelSerializer):
         claimant_contributor_id = (
             (facility.approved_claim or {}).get('contributor_id')
         )
+        provenance_by_list_item_id = (
+            self._build_extended_field_provenance_map(fields)
+            if self.include_extended_field_provenance else {}
+        )
 
         grouped_data = defaultdict(list)
 
@@ -260,7 +302,9 @@ class FacilityIndexSerializer(GeoFeatureModelSerializer):
                 context={'user_can_see_detail': user_can_see_detail,
                          'embed_mode_active': embed_mode_active,
                          'claimant_contributor_id': claimant_contributor_id,
-                         'masked_contributor_ids': masked},
+                         'masked_contributor_ids': masked,
+                         'provenance_by_list_item_id':
+                             provenance_by_list_item_id},
                 exclude_fields=(
                     ['created_at'] if not use_main_created_at else []
                 )

--- a/src/django/api/tests/test_facility_index_details_serializer.py
+++ b/src/django/api/tests/test_facility_index_details_serializer.py
@@ -206,6 +206,54 @@ class FacilityIndexDetailsSerializerTest(TestCase):
         self.assertIn("values", data["properties"]["sector"][0])
         self.assertIn("updated_at", data["properties"]["sector"][0])
 
+    def test_extended_field_carries_list_item_provenance(self):
+        # Extended-field entries on the details endpoint carry
+        # the per-row provenance of the FacilityListItem they came from.
+        self.list_item_one.source_name = 'US EPA FRS'
+        self.list_item_one.source_link = 'https://example.com/dc?id=1'
+        self.list_item_one.information_source_type = 'air quality permit'
+        self.list_item_one.date_of_source = '2024-06'
+        self.list_item_one.ai_usage_notes = 'AI-extracted; human reviewed'
+        self.list_item_one.save()
+
+        ExtendedField.objects.create(
+            contributor=self.contrib_one,
+            facility=self.facility,
+            facility_list_item=self.list_item_one,
+            field_name=ExtendedField.NAME_OPERATOR,
+            value={'raw_value': 'Blue Horizon Ops'},
+        )
+
+        facility_index = FacilityIndex.objects.get(id=self.facility.id)
+        data = FacilityIndexDetailsSerializer(facility_index).data
+
+        entries = data['properties']['extended_fields']['name_operator']
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]['provenance'], {
+            'source_name': 'US EPA FRS',
+            'source_link': 'https://example.com/dc?id=1',
+            'information_source_type': 'air quality permit',
+            'date_of_source': '2024-06',
+            'ai_usage_notes': 'AI-extracted; human reviewed',
+        })
+
+    def test_extended_field_without_provenance_has_none(self):
+        # list_item_two carries no provenance data.
+        ExtendedField.objects.create(
+            contributor=self.contrib_two,
+            facility=self.facility,
+            facility_list_item=self.list_item_two,
+            field_name=ExtendedField.NAME_OPERATOR,
+            value={'raw_value': 'Other Ops'},
+        )
+
+        facility_index = FacilityIndex.objects.get(id=self.facility.id)
+        data = FacilityIndexDetailsSerializer(facility_index).data
+
+        entries = data['properties']['extended_fields']['name_operator']
+        self.assertEqual(len(entries), 1)
+        self.assertIsNone(entries[0]['provenance'])
+
     def test_is_data_center_false_by_default(self):
         facility_index = FacilityIndex.objects.get(id=self.facility.id)
         data = FacilityIndexDetailsSerializer(facility_index).data

--- a/src/react/src/__tests__/components/ContributionsDrawer.test.jsx
+++ b/src/react/src/__tests__/components/ContributionsDrawer.test.jsx
@@ -153,4 +153,128 @@ describe('ContributionsDrawer', () => {
             screen.getByTestId('contribution-card-promoted'),
         ).toBeInTheDocument();
     });
+
+    test('renders provenance block only for contributions that carry it', () => {
+        renderContributionsDrawer({
+            open: true,
+            onClose: () => {},
+            contributions: [
+                {
+                    value: 'Value A',
+                    sourceName: 'Source A',
+                    date: '2022-01-01',
+                    userId: 1,
+                    provenance: {
+                        source_name: 'US EPA FRS',
+                        source_link: 'https://example.com/dc?id=1',
+                        information_source_type: 'air quality permit',
+                        date_of_source: '2024-06',
+                        ai_usage_notes: 'AI-extracted; human reviewed',
+                    },
+                },
+                {
+                    value: 'Value B',
+                    sourceName: 'Source B',
+                    date: '2022-02-01',
+                    userId: 2,
+                },
+            ],
+        });
+
+        // Only the first contribution carries provenance.
+        expect(
+            screen.getAllByTestId('contribution-card-provenance'),
+        ).toHaveLength(1);
+
+        // Collapsed by default; expand the accordion to reveal the details.
+        const toggle = screen.getByTestId('provenance-accordion-toggle');
+        expect(toggle).toHaveAttribute('aria-expanded', 'false');
+        fireEvent.click(toggle);
+        expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+        expect(screen.getByText('US EPA FRS')).toBeInTheDocument();
+        expect(screen.getByText('air quality permit')).toBeInTheDocument();
+        expect(
+            screen.getByText('AI-extracted; human reviewed'),
+        ).toBeInTheDocument();
+        const link = screen.getByText('https://example.com/dc?id=1');
+        expect(link).toHaveAttribute('href', 'https://example.com/dc?id=1');
+        expect(link).toHaveAttribute('target', '_blank');
+    });
+
+    test('does not render provenance block when no contribution carries it', () => {
+        renderContributionsDrawer({
+            open: true,
+            onClose: () => {},
+            promotedContribution: {
+                value: 'Promoted Value',
+                sourceName: 'Promoted Source',
+                date: '2023-01-01',
+                userId: 10,
+            },
+            contributions: [
+                {
+                    value: 'Value A',
+                    sourceName: 'Source A',
+                    date: '2022-01-01',
+                    userId: 1,
+                },
+            ],
+        });
+
+        expect(
+            screen.queryByTestId('contribution-card-provenance'),
+        ).not.toBeInTheDocument();
+    });
+
+    test('renders provenance on the promoted card when present', () => {
+        renderContributionsDrawer({
+            open: true,
+            onClose: () => {},
+            promotedContribution: {
+                value: 'Promoted Value',
+                sourceName: 'Promoted Source',
+                date: '2023-01-01',
+                userId: 10,
+                provenance: { source_name: 'Operator website' },
+            },
+        });
+
+        expect(
+            screen.getByTestId('contribution-card-provenance'),
+        ).toBeInTheDocument();
+        fireEvent.click(screen.getByTestId('provenance-accordion-toggle'));
+        expect(screen.getByText('Operator website')).toBeInTheDocument();
+    });
+
+    test('provenance accordion toggles open and closed', () => {
+        renderContributionsDrawer({
+            open: true,
+            onClose: () => {},
+            contributions: [
+                {
+                    value: 'Value A',
+                    sourceName: 'Source A',
+                    date: '2022-01-01',
+                    userId: 1,
+                    provenance: { source_name: 'US EPA FRS' },
+                },
+            ],
+        });
+
+        const toggle = screen.getByTestId('provenance-accordion-toggle');
+        expect(toggle).toHaveAttribute('aria-expanded', 'false');
+        expect(
+            screen.getByTestId('provenance-accordion-expand-more'),
+        ).toBeInTheDocument();
+
+        fireEvent.click(toggle);
+        expect(toggle).toHaveAttribute('aria-expanded', 'true');
+        expect(
+            screen.getByTestId('provenance-accordion-expand-less'),
+        ).toBeInTheDocument();
+
+        fireEvent.click(toggle);
+        expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    });
 });

--- a/src/react/src/__tests__/components/ProvenanceAccordion.test.jsx
+++ b/src/react/src/__tests__/components/ProvenanceAccordion.test.jsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+
+import ProvenanceAccordion from '../../components/ProductionLocation/ContributionsDrawer/ProvenanceAccordion/ProvenanceAccordion';
+
+const theme = createMuiTheme();
+
+const fullProvenance = {
+    source_name: 'US EPA FRS',
+    source_link: 'https://example.com/dc?id=1',
+    information_source_type: 'air quality permit',
+    date_of_source: '2024-06',
+    notes: 'inferred operator from website',
+    data_collection_methodology: 'downloaded from source',
+    ai_usage_notes: 'AI-extracted; human reviewed',
+};
+
+const renderProvenanceAccordion = (props = {}) =>
+    render(
+        <MuiThemeProvider theme={theme}>
+            <ProvenanceAccordion
+                data-testid="provenance-accordion"
+                {...props}
+            />
+        </MuiThemeProvider>,
+    );
+
+describe('ProvenanceAccordion', () => {
+    test('renders nothing when provenance is null', () => {
+        renderProvenanceAccordion({ provenance: null });
+
+        expect(
+            screen.queryByTestId('provenance-accordion'),
+        ).not.toBeInTheDocument();
+    });
+
+    test('renders nothing when provenance has no known non-empty fields', () => {
+        renderProvenanceAccordion({
+            provenance: { unknown_key: 'x', source_name: '' },
+        });
+
+        expect(
+            screen.queryByTestId('provenance-accordion'),
+        ).not.toBeInTheDocument();
+    });
+
+    test('renders the toggle with the container testid passed through', () => {
+        renderProvenanceAccordion({ provenance: fullProvenance });
+
+        expect(
+            screen.getByTestId('provenance-accordion'),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByTestId('provenance-accordion-toggle'),
+        ).toHaveTextContent('Source details');
+    });
+
+    test('is collapsed by default', () => {
+        renderProvenanceAccordion({ provenance: fullProvenance });
+
+        expect(
+            screen.getByTestId('provenance-accordion-toggle'),
+        ).toHaveAttribute('aria-expanded', 'false');
+        expect(
+            screen.getByTestId('provenance-accordion-expand-more'),
+        ).toBeInTheDocument();
+    });
+
+    test('toggles open and closed on click', () => {
+        renderProvenanceAccordion({ provenance: fullProvenance });
+        const toggle = screen.getByTestId('provenance-accordion-toggle');
+
+        fireEvent.click(toggle);
+        expect(toggle).toHaveAttribute('aria-expanded', 'true');
+        expect(
+            screen.getByTestId('provenance-accordion-expand-less'),
+        ).toBeInTheDocument();
+
+        fireEvent.click(toggle);
+        expect(toggle).toHaveAttribute('aria-expanded', 'false');
+        expect(
+            screen.getByTestId('provenance-accordion-expand-more'),
+        ).toBeInTheDocument();
+    });
+
+    test('toggles with keyboard (Enter and Space)', () => {
+        renderProvenanceAccordion({ provenance: fullProvenance });
+        const toggle = screen.getByTestId('provenance-accordion-toggle');
+
+        fireEvent.keyDown(toggle, { key: 'Enter' });
+        expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+        fireEvent.keyDown(toggle, { key: ' ' });
+        expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    test('shows all provided provenance fields with their labels when expanded', () => {
+        renderProvenanceAccordion({ provenance: fullProvenance });
+        fireEvent.click(screen.getByTestId('provenance-accordion-toggle'));
+
+        expect(screen.getByText('Source:')).toBeInTheDocument();
+        expect(screen.getByText('US EPA FRS')).toBeInTheDocument();
+        expect(screen.getByText('Source type:')).toBeInTheDocument();
+        expect(screen.getByText('air quality permit')).toBeInTheDocument();
+        expect(screen.getByText('Date of source:')).toBeInTheDocument();
+        expect(screen.getByText('2024-06')).toBeInTheDocument();
+        expect(screen.getByText('Notes:')).toBeInTheDocument();
+        expect(
+            screen.getByText('Data collection methodology:'),
+        ).toBeInTheDocument();
+        expect(screen.getByText('AI usage notes:')).toBeInTheDocument();
+        expect(
+            screen.getByText('AI-extracted; human reviewed'),
+        ).toBeInTheDocument();
+    });
+
+    test('omits fields that are not present', () => {
+        renderProvenanceAccordion({
+            provenance: { source_name: 'US EPA FRS' },
+        });
+        fireEvent.click(screen.getByTestId('provenance-accordion-toggle'));
+
+        expect(screen.getByText('Source:')).toBeInTheDocument();
+        expect(screen.queryByText('Notes:')).not.toBeInTheDocument();
+        expect(screen.queryByText('Source link:')).not.toBeInTheDocument();
+        expect(screen.queryByText('AI usage notes:')).not.toBeInTheDocument();
+    });
+
+    test('renders source_link as a safe external link', () => {
+        renderProvenanceAccordion({ provenance: fullProvenance });
+        fireEvent.click(screen.getByTestId('provenance-accordion-toggle'));
+
+        const link = screen.getByText('https://example.com/dc?id=1');
+        expect(link.tagName).toBe('A');
+        expect(link).toHaveAttribute('href', 'https://example.com/dc?id=1');
+        expect(link).toHaveAttribute('target', '_blank');
+        expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+});

--- a/src/react/src/__tests__/utils/ProductionLocationDetailsGeneralFieldsUtils.test.js
+++ b/src/react/src/__tests__/utils/ProductionLocationDetailsGeneralFieldsUtils.test.js
@@ -166,6 +166,7 @@ describe('getVisibleFields', () => {
                         sourceName: 'Source',
                         date: '2020-06-15T12:00:00.000Z',
                         userId: undefined,
+                        provenance: null,
                     },
                     contributions: [],
                 },
@@ -210,6 +211,7 @@ describe('getVisibleFields', () => {
                     sourceName: null,
                     date: null,
                     userId: undefined,
+                    provenance: null,
                 },
                 contributions: [],
             });
@@ -223,6 +225,7 @@ describe('getVisibleFields', () => {
                     sourceName: 'Org',
                     date: '2021-01-01T00:00:00.000Z',
                     userId: 10,
+                    provenance: null,
                 },
                 contributions: [],
             });

--- a/src/react/src/__tests__/utils/ProductionLocationDetailsGeneralFieldsUtils.test.js
+++ b/src/react/src/__tests__/utils/ProductionLocationDetailsGeneralFieldsUtils.test.js
@@ -525,6 +525,38 @@ describe('getDataCenterFieldGroups', () => {
         expect(findField(utility, 'capacity_units')).toBeUndefined();
     });
 
+    it('passes provenance through to drawer contributions', () => {
+        const provenance = {
+            source_name: 'US EPA FRS',
+            source_link: 'https://example.com/dc?id=1',
+        };
+        const fixture = {
+            type: 'Feature',
+            properties: {
+                is_data_center: true,
+                extended_fields: {
+                    name_operator: [
+                        {
+                            value: { raw_value: 'Equinix' },
+                            contributor_id: 1,
+                            contributor_name: 'Contributor A',
+                            created_at: '2020-01-01T00:00:00.000Z',
+                            provenance,
+                        },
+                    ],
+                },
+            },
+        };
+        const groups = getDataCenterFieldGroups(fixture);
+        const operator = findField(
+            findGroup(groups, 'Named Entities'),
+            'name_operator',
+        );
+        expect(operator.drawerData.promotedContribution.provenance).toEqual(
+            provenance,
+        );
+    });
+
     it('includes additional contributors in drawer contributions', () => {
         const fixture = {
             type: 'Feature',

--- a/src/react/src/components/ProductionLocation/ContributionsDrawer/ContributionCard/ContributionCard.jsx
+++ b/src/react/src/components/ProductionLocation/ContributionsDrawer/ContributionCard/ContributionCard.jsx
@@ -15,6 +15,7 @@ import ScheduleIcon from '@material-ui/icons/Schedule';
 
 import { makeProfileRouteLink, formatDate } from '../../../../util/util';
 import { DATE_FORMATS } from '../../../../util/constants';
+import ProvenanceAccordion from '../ProvenanceAccordion/ProvenanceAccordion.jsx';
 import {
     GA_LINK_PLACEMENT,
     sendLocationPartnerProfileLinkClick,
@@ -29,6 +30,7 @@ const ContributionCard = ({
     date,
     promoted,
     userId,
+    provenance,
     spotlightGaProfileBase,
     'data-testid': dataTestId,
 }) => {
@@ -125,6 +127,10 @@ const ContributionCard = ({
                     ) : null}
                 </div>
             </div>
+            <ProvenanceAccordion
+                provenance={provenance}
+                data-testid="contribution-card-provenance"
+            />
         </div>
     );
 };
@@ -136,6 +142,7 @@ ContributionCard.propTypes = {
     date: oneOfType([string, instanceOf(Date)]),
     promoted: bool,
     userId: oneOfType([string, number]),
+    provenance: object,
     'data-testid': string,
     spotlightGaProfileBase: object,
 };
@@ -145,6 +152,7 @@ ContributionCard.defaultProps = {
     date: null,
     promoted: false,
     userId: null,
+    provenance: null,
     'data-testid': undefined,
     spotlightGaProfileBase: null,
 };

--- a/src/react/src/components/ProductionLocation/ContributionsDrawer/ContributionsDrawer.jsx
+++ b/src/react/src/components/ProductionLocation/ContributionsDrawer/ContributionsDrawer.jsx
@@ -98,6 +98,7 @@ const ContributionsDrawer = ({
                             date={promotedContribution.date}
                             promoted
                             userId={promotedContribution.userId}
+                            provenance={promotedContribution.provenance}
                             data-testid="contribution-card-promoted"
                             spotlightGaProfileBase={spotlightGaProfileBase}
                         />
@@ -131,6 +132,7 @@ const ContributionsDrawer = ({
                                 sourceName={item.sourceName}
                                 date={item.date}
                                 userId={item.userId}
+                                provenance={item.provenance}
                                 data-testid="contribution-card"
                                 spotlightGaProfileBase={spotlightGaProfileBase}
                             />

--- a/src/react/src/components/ProductionLocation/ContributionsDrawer/ProvenanceAccordion/ProvenanceAccordion.jsx
+++ b/src/react/src/components/ProductionLocation/ContributionsDrawer/ProvenanceAccordion/ProvenanceAccordion.jsx
@@ -24,9 +24,7 @@ const ProvenanceAccordion = ({
 
     if (!provenance) return null;
 
-    const rows = PROVENANCE_FIELD_LABELS.filter(
-        ({ key }) => provenance[key],
-    );
+    const rows = PROVENANCE_FIELD_LABELS.filter(({ key }) => provenance[key]);
     if (!rows.length) return null;
 
     const handleToggle = () => setIsOpen(previous => !previous);

--- a/src/react/src/components/ProductionLocation/ContributionsDrawer/ProvenanceAccordion/ProvenanceAccordion.jsx
+++ b/src/react/src/components/ProductionLocation/ContributionsDrawer/ProvenanceAccordion/ProvenanceAccordion.jsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react';
+import { object, string } from 'prop-types';
+import Typography from '@material-ui/core/Typography';
+import Collapse from '@material-ui/core/Collapse';
+import { withStyles } from '@material-ui/core/styles';
+
+import ExpandToggleChevron from '../../../Shared/ExpandToggleChevron/ExpandToggleChevron.jsx';
+import { PROVENANCE_FIELD_LABELS } from '../constants';
+import provenanceAccordionStyles from './styles';
+
+const TOGGLE_LABEL = 'Source details';
+
+/**
+ * Collapsible accordion showing the per-row provenance of the
+ * FacilityListItem a contribution came from (OSDEV-3073). Renders nothing
+ * when the contribution carries no provenance. Collapsed by default.
+ */
+const ProvenanceAccordion = ({
+    classes,
+    provenance,
+    'data-testid': dataTestId,
+}) => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    if (!provenance) return null;
+
+    const rows = PROVENANCE_FIELD_LABELS.filter(
+        ({ key }) => provenance[key],
+    );
+    if (!rows.length) return null;
+
+    const handleToggle = () => setIsOpen(previous => !previous);
+    const handleKeyDown = event => {
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            handleToggle();
+        }
+    };
+
+    return (
+        <div className={classes.container} data-testid={dataTestId}>
+            <div
+                className={classes.header}
+                role="button"
+                tabIndex={0}
+                aria-expanded={isOpen}
+                onClick={handleToggle}
+                onKeyDown={handleKeyDown}
+                data-testid="provenance-accordion-toggle"
+            >
+                <Typography component="span" className={classes.toggleLabel}>
+                    {TOGGLE_LABEL}
+                </Typography>
+                <ExpandToggleChevron
+                    isExpanded={isOpen}
+                    className={classes.chevron}
+                    expandLessTestId="provenance-accordion-expand-less"
+                    expandMoreTestId="provenance-accordion-expand-more"
+                />
+            </div>
+            <Collapse in={isOpen}>
+                <div className={classes.contentArea}>
+                    {rows.map(({ key, label, isLink }) => (
+                        <Typography
+                            key={key}
+                            component="div"
+                            className={classes.provenanceRow}
+                        >
+                            <span className={classes.provenanceLabel}>
+                                {label}:
+                            </span>
+                            {isLink ? (
+                                <a
+                                    href={provenance[key]}
+                                    className={classes.provenanceLink}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    {provenance[key]}
+                                </a>
+                            ) : (
+                                provenance[key]
+                            )}
+                        </Typography>
+                    ))}
+                </div>
+            </Collapse>
+        </div>
+    );
+};
+
+ProvenanceAccordion.propTypes = {
+    classes: object.isRequired,
+    provenance: object,
+    'data-testid': string,
+};
+
+ProvenanceAccordion.defaultProps = {
+    provenance: null,
+    'data-testid': undefined,
+};
+
+export default withStyles(provenanceAccordionStyles)(ProvenanceAccordion);

--- a/src/react/src/components/ProductionLocation/ContributionsDrawer/ProvenanceAccordion/styles.js
+++ b/src/react/src/components/ProductionLocation/ContributionsDrawer/ProvenanceAccordion/styles.js
@@ -1,0 +1,45 @@
+import COLOURS from '../../../../util/COLOURS';
+
+export default () =>
+    Object.freeze({
+        container: Object.freeze({
+            borderTop: `1px solid ${COLOURS.LIGHT_BORDER_GREY}`,
+            marginTop: '12px',
+            paddingTop: '4px',
+        }),
+        header: Object.freeze({
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            cursor: 'pointer',
+            padding: '4px 0',
+            userSelect: 'none',
+        }),
+        toggleLabel: Object.freeze({
+            fontSize: '0.875rem',
+            fontWeight: 600,
+            color: COLOURS.DARK_GREY,
+        }),
+        chevron: Object.freeze({
+            color: COLOURS.DARK_GREY,
+        }),
+        contentArea: Object.freeze({
+            paddingBottom: '8px',
+        }),
+        provenanceRow: Object.freeze({
+            fontSize: '0.875rem',
+            lineHeight: 1.5,
+            color: COLOURS.DARK_GREY,
+        }),
+        provenanceLabel: Object.freeze({
+            fontWeight: 600,
+            marginRight: '4px',
+        }),
+        provenanceLink: Object.freeze({
+            color: COLOURS.PURPLE,
+            wordBreak: 'break-all',
+            '&:hover': Object.freeze({
+                textDecoration: 'underline',
+            }),
+        }),
+    });

--- a/src/react/src/components/ProductionLocation/ContributionsDrawer/constants.js
+++ b/src/react/src/components/ProductionLocation/ContributionsDrawer/constants.js
@@ -7,3 +7,21 @@ export const INFO_CONTRIBUTIONS_TEXT =
 export const LEARN_MORE_LABEL = 'Learn more about our open data model';
 export const LEARN_MORE_OPEN_DATA_MODEL_URL =
     'https://info.opensupplyhub.org/resources/an-open-data-model';
+
+/**
+ * Per-row provenance of the FacilityListItem a contribution came from
+ * (OSDEV-3073). Rendered in display order; only fields present on the
+ * contribution are shown.
+ */
+export const PROVENANCE_FIELD_LABELS = Object.freeze([
+    Object.freeze({ key: 'source_name', label: 'Source' }),
+    Object.freeze({ key: 'source_link', label: 'Source link', isLink: true }),
+    Object.freeze({ key: 'information_source_type', label: 'Source type' }),
+    Object.freeze({ key: 'date_of_source', label: 'Date of source' }),
+    Object.freeze({ key: 'notes', label: 'Notes' }),
+    Object.freeze({
+        key: 'data_collection_methodology',
+        label: 'Data collection methodology',
+    }),
+    Object.freeze({ key: 'ai_usage_notes', label: 'AI usage notes' }),
+]);

--- a/src/react/src/components/ProductionLocation/ProductionLocationDetailsGeneralFields/utils.js
+++ b/src/react/src/components/ProductionLocation/ProductionLocationDetailsGeneralFields/utils.js
@@ -19,6 +19,7 @@ const toDrawerContribution = (item, value) => ({
     sourceName: item.contributor_name || null,
     date: item.created_at || null,
     userId: item.contributor_id != null ? item.contributor_id : undefined,
+    provenance: item.provenance || null,
 });
 
 const getStatusLabel = isFromClaim =>
@@ -402,6 +403,7 @@ const buildDataCenterDataPoint = (data, field) => {
         sourceName: item.contributor_name || null,
         date: item.created_at || null,
         userId: item.contributor_id != null ? item.contributor_id : undefined,
+        provenance: item.provenance || null,
     });
 
     const promotedContribution = toContribution(values[0]);


### PR DESCRIPTION
## Jira Ticket
[OSDEV-3073](https://opensupplyhub.atlassian.net/browse/OSDEV-3073)

---
## Summary of Changes
Shows the per-row provenance of each extended-field contribution on the facility details page, so users can see where a specific data point came from.

**Root cause / finding:** the provenance columns exist on `FacilityListItem` (OSDEV-3070/3071) and every indexed extended-field entry already carries its `facility_list_item_id` in `FacilityIndex.extended_fields` — but that id was dropped by the output whitelist and never joined back to the provenance. This PR completes the link at the serializer level, with no `index_extended_fields()` SQL change and no reindex.

**Backend:**
- `facility_index_serializer.py`: new `include_extended_field_provenance` class flag (off by default) and a static `_build_extended_field_provenance_map()` — one bulk `FacilityListItem` query over the deduplicated `facility_list_item_id`s (set comprehension; one contributed row fans out to ~44 EFs, so dedup matters), keeping only rows with at least one non-empty provenance value.
- `facility_index_extended_field_list_serializer.py`: each entry now outputs `provenance` — the dict when present, `null` when the row carries no provenance or the field has no list item (claim-born fields).
- `facility_index_details_serializer.py`: flag enabled — **details endpoint only**, so list endpoints get no extra query.

**Frontend:**
- New `ProvenanceAccordion` component (`ContributionsDrawer/ProvenanceAccordion/`): a collapsible accordion (house pattern — `Collapse` + `role="button"` header with `aria-expanded`, keyboard support, shared `ExpandToggleChevron`), collapsed by default, labeled "Source details". Renders only the provenance fields present, with `source_link` as a safe external link; renders nothing when a contribution carries no provenance.
- `ContributionCard` renders the accordion under the card; `ContributionsDrawer` passes `provenance` to both the promoted and list cards.
- `…GeneralFields/utils.js`: both drawer builders (`toDrawerContribution` and the data-center `toContribution`) pass `provenance` through.
- Labels defined once in the drawer's `constants.js` (`PROVENANCE_FIELD_LABELS`).

Non-data-center facilities and contributions without provenance see zero visual change.

---
## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Backend change (API, database, business logic)
- [x] UI / frontend change
- [ ] Architectural change (affects structure, contracts, or shared modules)
- [ ] Refactor (no functional change)
- [ ] Breaking change (existing functionality may not work as before)
- [ ] Documentation / tooling only

---
## Testing
**Backend** — `api/tests/test_facility_index_details_serializer.py`:
- An extended field whose list item carries provenance → the serialized entry includes the `provenance` dict.
- An extended field whose list item has no provenance → `provenance` is `null`.

**Frontend** — `__tests__/components/ProvenanceAccordion.test.jsx` (new, 9 tests):
- Renders nothing for `null` provenance or provenance with no known non-empty fields.
- Collapsed by default; toggles via click and keyboard (Enter/Space) with correct `aria-expanded` and chevron state.
- Expanded content shows all present fields with labels; absent fields are omitted; `source_link` is an `<a>` with `href`, `target="_blank"`, `rel="noopener noreferrer"`.

**Frontend** — `__tests__/components/ContributionsDrawer.test.jsx`:
- Provenance block appears only on contributions that carry it (promoted and list cards); expand-then-assert flow; full toggle cycle; no block when absent.

**Frontend** — `__tests__/utils/ProductionLocationDetailsGeneralFieldsUtils.test.js`:
- `provenance` passes through to drawer contributions.

Manual verification: `GET /api/facilities/{os_id}` returns `provenance` on extended-field entries (regression: this request initially 500'd due to a misplaced decorator during development — fixed and covered by the serializer tests, which exercise the full `.data` path).


---
## Known TODO Items
- The shared list serializer emits `provenance: null` for non-details consumers (key present, harmless). If provenance is ever wanted on list-scale endpoints, revisit moving the join into the `index_extended_fields()` SQL instead of flipping the flag.
- One accordion per contribution card; an expand-all control or a different toggle label than "Source details" are one-line changes if product prefers.
- Screenshots of the accordion (collapsed/expanded) to be attached after a local run.

---
## Checklist
### Implementation
- [x] My code follows the project's style guidelines and naming conventions.
- [x] I have removed debug logs, commented-out code, and unused imports.
- [x] Any AI-assisted code (e.g., Claude) has been reviewed, understood, and adapted to fit our codebase.
- [x] I have considered backward compatibility and migrations where applicable.
### Testing & Validation
- [ ] I have manually tested the change in a local/dev environment.
- [x] I have added or updated unit tests for the new/changed behavior.
- [ ] All existing tests pass locally.
- [ ] For UI changes: I have included screenshots or a recording, and verified responsive/cross-browser behavior.
- [x] For backend changes: I have validated API contracts, error handling, and edge cases.
- [ ] For architectural changes: I have documented the design decision and notified affected teams.
### Documentation & Communication
- [x] I have updated relevant documentation (README, ADRs, inline comments, API docs).
- [x] I have updated the Jira ticket status and added any relevant notes.
### Final Review
- [x] I have performed a self-review on my PR and I am presenting my best work for my peers to review.

[OSDEV-3073]: https://opensupplyhub.atlassian.net/browse/OSDEV-3073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ