### PR TITLE
OSDEV-3215: [Quickfix][Homepage] Deactive homepage redirection in all environments

### DIFF
--- a/deployment/environments/terraform-development.tfvars
+++ b/deployment/environments/terraform-development.tfvars
@@ -82,8 +82,8 @@ instance_source= "os_hub"
 
 vpn_ec2_ami = "ami-0940c95b23a1f7cac"
 
-enable_homepage_proxy   = true
-craft_cms_origin_domain = "open-supply.staging.servd.dev"
+enable_homepage_proxy   = false
+craft_cms_origin_domain = ""
 
 # Shares Chatbot channel config with Test (same AWS account / Slack channel).
 aws_chatbot_manage_channel_configuration = false

--- a/deployment/environments/terraform-preprod.tfvars
+++ b/deployment/environments/terraform-preprod.tfvars
@@ -83,8 +83,8 @@ instance_source= "os_hub"
 
 vpn_ec2_ami = "ami-0940c95b23a1f7cac"
 
-enable_homepage_proxy   = true
-craft_cms_origin_domain = "open-supply.production.servd.dev"
+enable_homepage_proxy   = false
+craft_cms_origin_domain = "
 
 # Shares Chatbot channel config with Test (same AWS account / Slack channel).
 aws_chatbot_manage_channel_configuration = false

--- a/deployment/environments/terraform-production.tfvars
+++ b/deployment/environments/terraform-production.tfvars
@@ -81,8 +81,8 @@ instance_source = "os_hub"
 
 vpn_ec2_ami = "ami-0940c95b23a1f7cac"
 
-enable_homepage_proxy   = true
-craft_cms_origin_domain = "open-supply.production.servd.dev"
+enable_homepage_proxy   = false
+craft_cms_origin_domain = ""
 
 is_database_private_link_provider = true
 

--- a/deployment/environments/terraform-staging.tfvars
+++ b/deployment/environments/terraform-staging.tfvars
@@ -79,8 +79,8 @@ instance_source= "os_hub"
 
 vpn_ec2_ami = "ami-0940c95b23a1f7cac"
 
-enable_homepage_proxy   = true
-craft_cms_origin_domain = "open-supply.staging.servd.dev"
+enable_homepage_proxy   = false
+craft_cms_origin_domain = ""
 
 # Shares Chatbot channel config with Production (same Slack channel / shared account).
 aws_chatbot_manage_channel_configuration = false

--- a/deployment/environments/terraform-test.tfvars
+++ b/deployment/environments/terraform-test.tfvars
@@ -95,8 +95,8 @@ instance_source= "os_hub"
 
 vpn_ec2_ami = "ami-0940c95b23a1f7cac"
 
-enable_homepage_proxy   = true
-craft_cms_origin_domain = "open-supply.staging.servd.dev"
+enable_homepage_proxy   = false
+craft_cms_origin_domain = ""
 
 # Owns the shared-account Chatbot Slack channel config (Dev/Test/Preprod).
 # Sibling SNS ARNs live in private ci-deployment Test tfvars (aws_chatbot_additional_sns_topic_arns).

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -55,6 +55,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   * New `src/kafka-tools/fix_replication.sh` performs the one-time remediation on existing topics: it builds a partition reassignment plan for topics below the target RF, repairs topic-level `min.insync.replicas` overrides (which the cluster default does not affect), and fails non-zero unless every topic ends at `min.insync.replicas <= replication factor - 1`. Dry run by default; `--execute` applies.
   * `deployment/terraform/task-definitions/app_kafka.json` splits `entryPoint` into `/bin/bash` with `command` `./kafka.sh`, so ECS `run-task` can override the command (ECS cannot override `entryPoint`). The existing task's behavior is unchanged.
   * New `deployment/run_kafka_cmd` runs an arbitrary command in the `AppKafka` Fargate task, following the same pattern as `run_cli_task`, printing the CloudWatch log stream and propagating the container exit code.
+* [OSDEV-3215](https://opensupplyhub.atlassian.net/browse/OSDEV-3215) - Disabled the flags for redirecting to the new homepage across all environments. All environments now behave consistently, and the root page remains `/map`.
+
 
 ### Code/API changes
 * [OSDEV-2652](https://opensupplyhub.atlassian.net/browse/OSDEV-2652) - Added `POST /api/facility-lists/{list_id}/deactivate/` so contributors can deactivate their own uploaded lists:


### PR DESCRIPTION
## Jira Ticket

[OSDEV-3215](https://opensupplyhub.atlassian.net/browse/OSDEV-3215)

---

## Summary of Changes

Prepares the platform for serving the new Craft CMS homepage at the root URL while keeping the React app fully functional, behind a feature flag that is **disabled in all environments** in this PR.

**Terraform / CloudFront:**
- `enable_homepage_proxy = false` and `craft_cms_origin_domain = ""` in **all** environments — this PR ships the plumbing only; no routing behavior changes until the flag is enabled per environment at launch.

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Backend change (API, database, business logic)
- [ ] UI / frontend change
- [x] Architectural change (affects structure, contracts, or shared modules)
- [ ] Refactor (no functional change)
- [ ] Breaking change (existing functionality may not work as before)
- [ ] Documentation / tooling only

---

## Testing

- Verified locally that `/` redirects to `/map` and that query params survive the redirect (e.g. `/?embed=1&contributor=100` → `/map?embed=1&contributor=100`), covering the paid embedded-map feature.
- With `enable_homepage_proxy = false` everywhere, `terraform plan` shows no behavioral change to current routing.

---

## Known TODO Items

- Confirm the exact Servd hostnames for preprod and production before enabling the flag there (TODO comments in tfvars).
- Update e2e tests that hit `/` expecting the map before enabling the proxy in test environments.
- Keep the CloudFront allowlist in sync with `createQueryStringFromSearchFilters` in `util/util.js` when filter params are added (cross-referenced comments in both files).

---

## Checklist

### Implementation
- [x] My code follows the project's style guidelines and naming conventions.
- [x] I have removed debug logs, commented-out code, and unused imports.
- [x] Any AI-assisted code (e.g., Claude) has been reviewed, understood, and adapted to fit our codebase.
- [x] I have considered backward compatibility and migrations where applicable.

### Testing & Validation
- [x] I have manually tested the change in a local/dev environment.
- [ ] I have added or updated unit tests for the new/changed behavior.
- [x] All existing tests pass locally.
- [ ] For UI changes: I have included screenshots or a recording, and verified responsive/cross-browser behavior.
- [ ] For backend changes: I have validated API contracts, error handling, and edge cases.
- [x] For architectural changes: I have documented the design decision and notified affected teams.

### Documentation & Communication
- [x] I have updated relevant documentation (README, ADRs, inline comments, API docs).
- [x] I have updated the Jira ticket status and added any relevant notes.

### Final Review
- [x] I have performed a self-review on my PR and I am presenting my best work for my peers to review.

[OSDEV-3215]: https://opensupplyhub.atlassian.net/browse/OSDEV-3215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ