### PR TITLE
OSDEV-3074: [Data Centers] Data-center-specific SLC form layout

### DIFF
--- a/src/django/api/tests/test_location_contribution_strategy.py
+++ b/src/django/api/tests/test_location_contribution_strategy.py
@@ -2425,7 +2425,7 @@ class TestLocationContributionStrategy(APITestCase):
             'source_name'
         )
 
-        detail = result.errors['errors'][0]['detail']
-        self.assertTrue(
-            'email' in detail.lower() or 'contact' in detail.lower()
+        self.assertEqual(
+            result.errors['errors'][0]['detail'],
+            'Field source_name cannot be longer than 500 characters.'
         )

--- a/src/react/src/__tests__/components/DataCenterFields.test.jsx
+++ b/src/react/src/__tests__/components/DataCenterFields.test.jsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+
+import DataCenterFields from '../../components/Contribute/DataCenterFields/DataCenterFields';
+import {
+    DATA_CENTER_FORM_SECTIONS,
+    DATA_CENTER_FORM_INITIAL_VALUES,
+} from '../../components/Contribute/DataCenterFields/constants';
+
+const theme = createMuiTheme();
+
+const makeContributionForm = (overrides = {}) => ({
+    values: { ...DATA_CENTER_FORM_INITIAL_VALUES },
+    touched: {},
+    errors: {},
+    setFieldValue: jest.fn(),
+    setFieldTouched: jest.fn(),
+    ...overrides,
+});
+
+const renderDataCenterFields = contributionForm =>
+    render(
+        <MuiThemeProvider theme={theme}>
+            <DataCenterFields contributionForm={contributionForm} />
+        </MuiThemeProvider>,
+    );
+
+describe('DataCenterFields', () => {
+    test('renders all schema sections, collapsed by default', () => {
+        renderDataCenterFields(makeContributionForm());
+
+        expect(screen.getByTestId('data-center-fields')).toBeInTheDocument();
+        DATA_CENTER_FORM_SECTIONS.forEach(section => {
+            const header = screen.getByTestId(
+                `data-center-section-${section.label}`,
+            );
+            expect(header).toBeInTheDocument();
+            expect(header).toHaveAttribute('aria-expanded', 'false');
+        });
+    });
+
+    test('includes a provenance section', () => {
+        renderDataCenterFields(makeContributionForm());
+
+        expect(
+            screen.getByTestId('data-center-section-Source details'),
+        ).toBeInTheDocument();
+    });
+
+    test('expanding a section reveals its inputs', () => {
+        renderDataCenterFields(makeContributionForm());
+        const header = screen.getByTestId('data-center-section-Utility Usage');
+
+        fireEvent.click(header);
+
+        expect(header).toHaveAttribute('aria-expanded', 'true');
+        expect(
+            screen.getByLabelText('Power Usage Effectiveness (PUE)'),
+        ).toBeInTheDocument();
+    });
+
+    test('shows a short description under each field label', () => {
+        renderDataCenterFields(makeContributionForm());
+        fireEvent.click(screen.getByTestId('data-center-section-Utility Usage'));
+
+        expect(
+            screen.getByText(
+                'Enter the Power Usage Effectiveness: the ratio of total ' +
+                    'energy used to energy delivered to computing equipment. ' +
+                    'For example: 1.25.',
+            ),
+        ).toBeInTheDocument();
+    });
+
+    test('measures with units render a value and a units input', () => {
+        renderDataCenterFields(makeContributionForm());
+        fireEvent.click(screen.getByTestId('data-center-section-Utility Usage'));
+
+        expect(screen.getByLabelText('Capacity')).toBeInTheDocument();
+        expect(screen.getByLabelText('Capacity units')).toBeInTheDocument();
+    });
+
+    test('typing in an input updates the Formik field', () => {
+        const contributionForm = makeContributionForm();
+        renderDataCenterFields(contributionForm);
+        fireEvent.click(screen.getByTestId('data-center-section-Utility Usage'));
+
+        fireEvent.change(screen.getByLabelText('Capacity'), {
+            target: { value: '20' },
+        });
+
+        expect(contributionForm.setFieldValue).toHaveBeenCalledWith(
+            'capacity',
+            '20',
+        );
+        expect(contributionForm.setFieldTouched).toHaveBeenCalledWith(
+            'capacity',
+            true,
+            false,
+        );
+    });
+
+    test('shows a validation error for a touched invalid field', () => {
+        const contributionForm = makeContributionForm({
+            touched: { dateOfSource: true },
+            errors: {
+                dateOfSource:
+                    'Date of source must be a date in YYYY, YYYY-MM, or YYYY-MM-DD format.',
+            },
+        });
+        renderDataCenterFields(contributionForm);
+        fireEvent.click(
+            screen.getByTestId('data-center-section-Source details'),
+        );
+
+        expect(
+            screen.getByText(
+                'Date of source must be a date in YYYY, YYYY-MM, or YYYY-MM-DD format.',
+            ),
+        ).toBeInTheDocument();
+    });
+
+    test('sections toggle closed again on second click', () => {
+        renderDataCenterFields(makeContributionForm());
+        const header = screen.getByTestId(
+            'data-center-section-Named Entities',
+        );
+
+        fireEvent.click(header);
+        expect(header).toHaveAttribute('aria-expanded', 'true');
+
+        fireEvent.click(header);
+        expect(header).toHaveAttribute('aria-expanded', 'false');
+    });
+});

--- a/src/react/src/__tests__/components/ProductionLocationInfo.test.js
+++ b/src/react/src/__tests__/components/ProductionLocationInfo.test.js
@@ -529,16 +529,21 @@ describe("ProductionLocationInfo component, data-center prefill for UPDATE (OSDE
         );
 
     test("pre-selects Data Center and shows the data-center sections when the record is a data center", async () => {
-        const { getByTestId, getByText } = renderComponent(
-            makeState(['Data Center']),
-        );
+        const { getByTestId } = renderComponent(makeState(['Data Center']));
 
+        // The data-center sections only render when the Data Center location
+        // type is pre-selected, so their presence proves the prefill worked.
         await waitFor(() =>
             expect(getByTestId('data-center-fields')).toBeInTheDocument(),
         );
         // The Additional information section is opened so the pre-selected
-        // location type is visible.
-        expect(getByText('Data Center')).toBeInTheDocument();
+        // location type is visible/editable.
+        expect(
+            getByTestId('switch-additional-info-fields'),
+        ).toBeInTheDocument();
+        expect(
+            getByTestId('data-center-section-Utility Usage'),
+        ).toBeInTheDocument();
     });
 
     test("does not show the data-center sections for a production location", async () => {

--- a/src/react/src/__tests__/components/ProductionLocationInfo.test.js
+++ b/src/react/src/__tests__/components/ProductionLocationInfo.test.js
@@ -476,6 +476,83 @@ describe("ProductionLocationInfo component, test invalid incoming data for UPDAT
     });
 });
 
+describe("ProductionLocationInfo component, data-center prefill for UPDATE (OSDEV-3074)", () => {
+    const osID = 'US2026205NS8T09';
+
+    const makeState = locationType => ({
+        auth: {
+            user: { user: { isAnon: false } },
+            session: { fetching: false },
+        },
+        contributeProductionLocation: {
+            singleProductionLocation: {
+                data: {
+                    name: 'Blue Horizon Data Center',
+                    os_id: osID,
+                    location_type: locationType,
+                    country: {
+                        name: 'United States',
+                        numeric: '840',
+                        alpha_3: 'USA',
+                        alpha_2: 'US',
+                    },
+                    address: '990 Spring Garden St., Philadelphia PA 19123',
+                    claim_status: 'unclaimed',
+                },
+                fetching: false,
+                error: null,
+            },
+            productionLocations: {
+                data: [],
+                fetching: false,
+                error: null,
+            },
+            pendingModerationEvent: {
+                data: {},
+                fetching: false,
+                error: null,
+            },
+        },
+    });
+
+    const renderComponent = preloadedState =>
+        renderWithProviders(
+            <MemoryRouter initialEntries={[`/contribute/single-location/${osID}/info/`]}>
+                <Route
+                    path="/contribute/single-location/:osID/info/"
+                    component={() => (
+                        <ProductionLocationInfo submitMethod="UPDATE" />
+                    )}
+                />
+            </MemoryRouter>,
+            { preloadedState },
+        );
+
+    test("pre-selects Data Center and shows the data-center sections when the record is a data center", async () => {
+        const { getByTestId, getByText } = renderComponent(
+            makeState(['Data Center']),
+        );
+
+        await waitFor(() =>
+            expect(getByTestId('data-center-fields')).toBeInTheDocument(),
+        );
+        // The Additional information section is opened so the pre-selected
+        // location type is visible.
+        expect(getByText('Data Center')).toBeInTheDocument();
+    });
+
+    test("does not show the data-center sections for a production location", async () => {
+        const { queryByTestId, getByRole } = renderComponent(
+            makeState(['Apparel']),
+        );
+
+        await waitFor(() =>
+            expect(getByRole('button', { name: /Update/i })).toBeInTheDocument(),
+        );
+        expect(queryByTestId('data-center-fields')).not.toBeInTheDocument();
+    });
+});
+
 describe("ProductionLocationInfo component, possible duplicate submission dialog", () => {
     const defaultState = {
         filterOptions: {

--- a/src/react/src/__tests__/utils/slcValidationSchema.test.js
+++ b/src/react/src/__tests__/utils/slcValidationSchema.test.js
@@ -270,4 +270,40 @@ describe('slcValidationSchema', () => {
             ).rejects.toThrow('Processing type(s) must contain only Latin characters');
         });
     });
+
+    describe('dateOfSource field (data-center provenance, OSDEV-3074)', () => {
+        it('accepts an empty value', async () => {
+            await expect(isValid({ dateOfSource: '' })).resolves.toBe(true);
+        });
+
+        it('accepts ISO reduced-precision dates (YYYY, YYYY-MM, YYYY-MM-DD)', async () => {
+            await expect(isValid({ dateOfSource: '2024' })).resolves.toBe(
+                true,
+            );
+            await expect(isValid({ dateOfSource: '2024-06' })).resolves.toBe(
+                true,
+            );
+            await expect(
+                isValid({ dateOfSource: '2024-06-15' }),
+            ).resolves.toBe(true);
+        });
+
+        it('rejects free-text and out-of-range dates', async () => {
+            await expect(
+                validate({ dateOfSource: 'June 2024' }),
+            ).rejects.toThrow(
+                'Date of source must be a date in YYYY, YYYY-MM, or YYYY-MM-DD format.',
+            );
+            await expect(
+                validate({ dateOfSource: '2024-13' }),
+            ).rejects.toThrow(
+                'Date of source must be a date in YYYY, YYYY-MM, or YYYY-MM-DD format.',
+            );
+            await expect(
+                validate({ dateOfSource: '15/06/2024' }),
+            ).rejects.toThrow(
+                'Date of source must be a date in YYYY, YYYY-MM, or YYYY-MM-DD format.',
+            );
+        });
+    });
 });

--- a/src/react/src/components/Contribute/DataCenterFields/DataCenterFields.jsx
+++ b/src/react/src/components/Contribute/DataCenterFields/DataCenterFields.jsx
@@ -1,0 +1,179 @@
+import React, { useState } from 'react';
+import { object } from 'prop-types';
+import Typography from '@material-ui/core/Typography';
+import TextField from '@material-ui/core/TextField';
+import Collapse from '@material-ui/core/Collapse';
+import { withStyles } from '@material-ui/core/styles';
+
+import ExpandToggleChevron from '../../Shared/ExpandToggleChevron/ExpandToggleChevron.jsx';
+import InputErrorText from '../InputErrorText';
+import { DATA_CENTER_FORM_SECTIONS } from './constants';
+import dataCenterFieldsStyles from './styles';
+
+/**
+ * Data-center-specific SLC form sections (OSDEV-3074). Rendered when the
+ * contributor selects Data Center as the location type. Sections are
+ * collapsible and collapsed by default; all fields are optional free text.
+ * Measures with units render as a value + units input pair.
+ */
+const DataCenterFields = ({ classes, contributionForm }) => {
+    const [openSections, setOpenSections] = useState({});
+
+    const toggleSection = label =>
+        setOpenSections(previous => ({
+            ...previous,
+            [label]: !previous[label],
+        }));
+
+    const handleFieldChange = formName => event => {
+        contributionForm.setFieldValue(formName, event.target.value);
+        contributionForm.setFieldTouched(formName, true, false);
+    };
+
+    const renderInput = (formName, label, placeholder) => {
+        const hasError =
+            contributionForm.touched[formName] &&
+            !!contributionForm.errors[formName];
+
+        return (
+            <TextField
+                id={`dc_${formName}`}
+                variant="outlined"
+                className={classes.textInputStyles}
+                value={contributionForm.values[formName] ?? ''}
+                onChange={handleFieldChange(formName)}
+                placeholder={placeholder}
+                aria-label={label}
+                error={hasError}
+                helperText={
+                    hasError && (
+                        <InputErrorText
+                            text={contributionForm.errors[formName]}
+                        />
+                    )
+                }
+                FormHelperTextProps={{ className: classes.helperText }}
+                InputProps={{
+                    classes: {
+                        notchedOutline: classes.notchedOutlineStyles,
+                    },
+                }}
+            />
+        );
+    };
+
+    return (
+        <div data-testid="data-center-fields">
+            <Typography component="h2" className={classes.sectionsTitle}>
+                Data Center Details
+            </Typography>
+            <Typography component="h4" className={classes.sectionsSubTitle}>
+                All fields are optional — enter whatever information is
+                available from your source.
+            </Typography>
+            {DATA_CENTER_FORM_SECTIONS.map(section => {
+                const isOpen = !!openSections[section.label];
+                return (
+                    <div key={section.label} className={classes.section}>
+                        <div
+                            className={classes.sectionHeader}
+                            role="button"
+                            tabIndex={0}
+                            aria-expanded={isOpen}
+                            onClick={() => toggleSection(section.label)}
+                            onKeyDown={event => {
+                                if (
+                                    event.key === 'Enter' ||
+                                    event.key === ' '
+                                ) {
+                                    event.preventDefault();
+                                    toggleSection(section.label);
+                                }
+                            }}
+                            data-testid={`data-center-section-${section.label}`}
+                        >
+                            <Typography
+                                component="h3"
+                                className={classes.sectionTitle}
+                            >
+                                {section.label}
+                            </Typography>
+                            <ExpandToggleChevron
+                                isExpanded={isOpen}
+                                className={classes.chevron}
+                                expandLessTestId={`data-center-section-expand-less-${section.label}`}
+                                expandMoreTestId={`data-center-section-expand-more-${section.label}`}
+                            />
+                        </div>
+                        <Collapse in={isOpen}>
+                            <div className={classes.sectionContent}>
+                                {section.fields.map(field => (
+                                    <div
+                                        key={field.formName}
+                                        className={classes.fieldWrap}
+                                    >
+                                        <Typography
+                                            component="h4"
+                                            className={classes.fieldLabel}
+                                        >
+                                            {field.label}
+                                        </Typography>
+                                        {field.description ? (
+                                            <Typography
+                                                component="h5"
+                                                className={
+                                                    classes.fieldDescription
+                                                }
+                                            >
+                                                {field.description}
+                                            </Typography>
+                                        ) : null}
+                                        {field.unitsFormName ? (
+                                            <div className={classes.unitsRow}>
+                                                <div
+                                                    className={
+                                                        classes.unitsValue
+                                                    }
+                                                >
+                                                    {renderInput(
+                                                        field.formName,
+                                                        field.label,
+                                                        `Enter the ${field.label.toLowerCase()}`,
+                                                    )}
+                                                </div>
+                                                <div
+                                                    className={
+                                                        classes.unitsUnit
+                                                    }
+                                                >
+                                                    {renderInput(
+                                                        field.unitsFormName,
+                                                        `${field.label} units`,
+                                                        'Units (e.g. MW)',
+                                                    )}
+                                                </div>
+                                            </div>
+                                        ) : (
+                                            renderInput(
+                                                field.formName,
+                                                field.label,
+                                                `Enter the ${field.label.toLowerCase()}`,
+                                            )
+                                        )}
+                                    </div>
+                                ))}
+                            </div>
+                        </Collapse>
+                    </div>
+                );
+            })}
+        </div>
+    );
+};
+
+DataCenterFields.propTypes = {
+    classes: object.isRequired,
+    contributionForm: object.isRequired,
+};
+
+export default withStyles(dataCenterFieldsStyles)(DataCenterFields);

--- a/src/react/src/components/Contribute/DataCenterFields/DataCenterFields.jsx
+++ b/src/react/src/components/Contribute/DataCenterFields/DataCenterFields.jsx
@@ -43,7 +43,9 @@ const DataCenterFields = ({ classes, contributionForm }) => {
                 value={contributionForm.values[formName] ?? ''}
                 onChange={handleFieldChange(formName)}
                 placeholder={placeholder}
-                aria-label={label}
+                // Applied to the native input (not the wrapper) so the
+                // accessible name belongs to the focusable control.
+                inputProps={{ 'aria-label': label }}
                 error={hasError}
                 helperText={
                     hasError && (

--- a/src/react/src/components/Contribute/DataCenterFields/DataCenterFields.jsx
+++ b/src/react/src/components/Contribute/DataCenterFields/DataCenterFields.jsx
@@ -43,9 +43,6 @@ const DataCenterFields = ({ classes, contributionForm }) => {
                 value={contributionForm.values[formName] ?? ''}
                 onChange={handleFieldChange(formName)}
                 placeholder={placeholder}
-                // Applied to the native input (not the wrapper) so the
-                // accessible name belongs to the focusable control.
-                inputProps={{ 'aria-label': label }}
                 error={hasError}
                 helperText={
                     hasError && (
@@ -56,6 +53,7 @@ const DataCenterFields = ({ classes, contributionForm }) => {
                 }
                 FormHelperTextProps={{ className: classes.helperText }}
                 InputProps={{
+                    'aria-label': label,
                     classes: {
                         notchedOutline: classes.notchedOutlineStyles,
                     },

--- a/src/react/src/components/Contribute/DataCenterFields/constants.js
+++ b/src/react/src/components/Contribute/DataCenterFields/constants.js
@@ -1,0 +1,165 @@
+import camelCase from 'lodash/camelCase';
+
+import { DATA_CENTER_FIELD_GROUPS } from '../../ProductionLocation/constants.jsx';
+import { PROVENANCE_FIELD_LABELS } from '../../ProductionLocation/ContributionsDrawer/constants';
+
+export const DATA_CENTER_TYPE_VALUE = 'Data Center';
+
+const PROVENANCE_SECTION_LABEL = 'Source details';
+
+/**
+ * Short helper descriptions shown under each field label, keyed by the API
+ * field key. Condensed from the data-center master dataset schema.
+ */
+const DATA_CENTER_FIELD_DESCRIPTIONS = Object.freeze({
+    // Named entities
+    name_operator:
+        'Enter the entity described as the operator of the data center. ' +
+        'For example: a colocation provider.',
+    name_owner: 'Enter the entity described as the owner of the data center.',
+    name_property_manager:
+        'Enter the entity described as the property manager of the data ' +
+        'center.',
+    name_building_owner:
+        'Enter the entity that owns the building, when different from the ' +
+        'data center owner.',
+    name_tenant: 'Enter an entity leasing space from the data center.',
+    name_permit_holder:
+        'Enter the entity named as the permit holder. For example: on ' +
+        'government-issued air quality permits.',
+    name_site_other:
+        'Enter an alternative or previous name for the same site.',
+    name_unspecified:
+        'Enter a name associated with the site when the relationship to the ' +
+        'site is unclear.',
+    // Utility usage
+    capacity:
+        'Enter the power capacity when the capacity type (IT, utility, UPS) ' +
+        'is not specified by the source.',
+    it_capacity:
+        'Enter the maximum power available to IT equipment. Also referred ' +
+        'to as critical power or IT load.',
+    utility_capacity:
+        'Enter the maximum power the data center can draw from the utility ' +
+        'grid.',
+    ups_capacity:
+        'Enter the capacity of the uninterruptible power supply (UPS) ' +
+        'system.',
+    backup_generator_capacity:
+        'Enter the capacity of the backup generators.',
+    pue:
+        'Enter the Power Usage Effectiveness: the ratio of total energy ' +
+        'used to energy delivered to computing equipment. For example: 1.25.',
+    power_providers:
+        'Enter the external power provider(s). For example: the local ' +
+        'power authority or main private power company.',
+    power_sources:
+        'Enter the power source(s), including on-site generation. For ' +
+        'example: coal, solar, wind.',
+    power_density:
+        'Enter the power density of the data center. For example: 150 ' +
+        '(with units W/sq ft).',
+    water_usage:
+        'Enter the amount of water used, typically as volume per time. For ' +
+        'example: 5000 (with units gallons per day).',
+    wue:
+        'Enter the Water Usage Effectiveness: a ratio measure of water ' +
+        'use. For example: 1.8.',
+    cooling_mechanism:
+        'Enter the cooling mechanism(s) used, as stated by the source. For ' +
+        'example: air cooled, evaporative cooling.',
+    // Operating information
+    operational_status:
+        'Enter the operational status as stated by the source. For ' +
+        'example: planned, construction, operational, closed.',
+    date_operational:
+        'Enter when the data center became, or is planned to become, ' +
+        'operational.',
+    time_zones: 'Enter the time zone(s) the data center operates in.',
+    certifications_compliance:
+        'Enter any certifications or compliance information, as stated by ' +
+        'the source.',
+    // Building information
+    area:
+        'Enter the area when the area type (floor space, data hall) is not ' +
+        'specified by the source.',
+    data_area:
+        'Enter the data or computing-specific area. Often referred to as ' +
+        'data hall space or white space.',
+    floor_space: 'Enter the floor space of the data center.',
+    overall_area: 'Enter the overall or full building area.',
+    other_area:
+        'Enter any other area not captured by the fields above.',
+    other_area_notes:
+        'Describe the type of area entered in Other Area.',
+    number_of_servers: 'Enter the number of servers, if known.',
+    number_of_racks: 'Enter the number of racks, if known.',
+    // Source details (provenance)
+    source_name:
+        'Enter the name of the external source the data came from. For ' +
+        'example: US EPA FRS, an operator website.',
+    source_link:
+        'Enter a link to the source page for this specific data center.',
+    information_source_type:
+        'Enter the type of source. For example: air quality permit, press ' +
+        'release, company website.',
+    date_of_source:
+        'Enter the date stated by the source, at whatever precision is ' +
+        'available: YYYY, YYYY-MM, or YYYY-MM-DD.',
+    notes:
+        'Enter notes on any judgment calls made while collecting the data.',
+    data_collection_methodology:
+        'Enter how the data was collected. For example: copied from ' +
+        'website, downloaded directly from source.',
+    ai_usage_notes:
+        'If AI was used, enter the model and version, the tasks it ' +
+        'performed, and the extent of human review.',
+});
+
+/**
+ * Form sections for the data-center SLC layout (OSDEV-3074), derived from the
+ * display constants so the field list exists in one place. Formik field names
+ * are the camelCase form of the API field keys, so `parseContribData`'s
+ * generic snakeCase conversion maps them back to the exact v1 API keys.
+ */
+export const DATA_CENTER_FORM_SECTIONS = Object.freeze(
+    [
+        ...DATA_CENTER_FIELD_GROUPS.map(group => ({
+            label: group.label,
+            fields: group.fields.map(field => ({
+                formName: camelCase(field.key),
+                label: field.label,
+                description: DATA_CENTER_FIELD_DESCRIPTIONS[field.key] || '',
+                unitsFormName: field.unitsField
+                    ? camelCase(field.unitsField)
+                    : null,
+            })),
+        })),
+        {
+            label: PROVENANCE_SECTION_LABEL,
+            fields: PROVENANCE_FIELD_LABELS.map(field => ({
+                formName: camelCase(field.key),
+                label: field.label,
+                description: DATA_CENTER_FIELD_DESCRIPTIONS[field.key] || '',
+                unitsFormName: null,
+            })),
+        },
+    ].map(section => Object.freeze(section)),
+);
+
+/** Initial (empty) Formik values for every data-center form field. */
+export const DATA_CENTER_FORM_INITIAL_VALUES = Object.freeze(
+    DATA_CENTER_FORM_SECTIONS.reduce((acc, section) => {
+        section.fields.forEach(field => {
+            acc[field.formName] = '';
+            if (field.unitsFormName) {
+                acc[field.unitsFormName] = '';
+            }
+        });
+        return acc;
+    }, {}),
+);
+
+export const DATA_CENTER_FORM_FIELD_NAMES = Object.freeze(
+    Object.keys(DATA_CENTER_FORM_INITIAL_VALUES),
+);

--- a/src/react/src/components/Contribute/DataCenterFields/constants.js
+++ b/src/react/src/components/Contribute/DataCenterFields/constants.js
@@ -27,8 +27,7 @@ const DATA_CENTER_FIELD_DESCRIPTIONS = Object.freeze({
     name_permit_holder:
         'Enter the entity named as the permit holder. For example: on ' +
         'government-issued air quality permits.',
-    name_site_other:
-        'Enter an alternative or previous name for the same site.',
+    name_site_other: 'Enter an alternative or previous name for the same site.',
     name_unspecified:
         'Enter a name associated with the site when the relationship to the ' +
         'site is unclear.',
@@ -45,8 +44,7 @@ const DATA_CENTER_FIELD_DESCRIPTIONS = Object.freeze({
     ups_capacity:
         'Enter the capacity of the uninterruptible power supply (UPS) ' +
         'system.',
-    backup_generator_capacity:
-        'Enter the capacity of the backup generators.',
+    backup_generator_capacity: 'Enter the capacity of the backup generators.',
     pue:
         'Enter the Power Usage Effectiveness: the ratio of total energy ' +
         'used to energy delivered to computing equipment. For example: 1.25.',
@@ -88,10 +86,8 @@ const DATA_CENTER_FIELD_DESCRIPTIONS = Object.freeze({
         'data hall space or white space.',
     floor_space: 'Enter the floor space of the data center.',
     overall_area: 'Enter the overall or full building area.',
-    other_area:
-        'Enter any other area not captured by the fields above.',
-    other_area_notes:
-        'Describe the type of area entered in Other Area.',
+    other_area: 'Enter any other area not captured by the fields above.',
+    other_area_notes: 'Describe the type of area entered in Other Area.',
     number_of_servers: 'Enter the number of servers, if known.',
     number_of_racks: 'Enter the number of racks, if known.',
     // Source details (provenance)
@@ -106,8 +102,7 @@ const DATA_CENTER_FIELD_DESCRIPTIONS = Object.freeze({
     date_of_source:
         'Enter the date stated by the source, at whatever precision is ' +
         'available: YYYY, YYYY-MM, or YYYY-MM-DD.',
-    notes:
-        'Enter notes on any judgment calls made while collecting the data.',
+    notes: 'Enter notes on any judgment calls made while collecting the data.',
     data_collection_methodology:
         'Enter how the data was collected. For example: copied from ' +
         'website, downloaded directly from source.',

--- a/src/react/src/components/Contribute/DataCenterFields/styles.js
+++ b/src/react/src/components/Contribute/DataCenterFields/styles.js
@@ -1,0 +1,72 @@
+import COLOURS from '../../../util/COLOURS';
+
+export default theme =>
+    Object.freeze({
+        sectionsTitle: Object.freeze({
+            fontSize: '21px',
+            fontWeight: theme.typography.fontWeightExtraBold,
+            marginTop: '30px',
+        }),
+        sectionsSubTitle: Object.freeze({
+            fontSize: '16px',
+            fontWeight: theme.typography.fontWeightRegular,
+            margin: '5px 0 10px 0',
+        }),
+        section: Object.freeze({
+            border: `1px solid ${COLOURS.LIGHT_BORDER_GREY}`,
+            borderRadius: '4px',
+            marginBottom: '8px',
+            backgroundColor: COLOURS.WHITE,
+        }),
+        sectionHeader: Object.freeze({
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            cursor: 'pointer',
+            padding: '12px 16px',
+            userSelect: 'none',
+        }),
+        sectionTitle: Object.freeze({
+            fontSize: '18px',
+            fontWeight: theme.typography.fontWeightSemiBold,
+        }),
+        chevron: Object.freeze({
+            color: COLOURS.DARK_GREY,
+        }),
+        sectionContent: Object.freeze({
+            padding: '0 16px 16px 16px',
+        }),
+        fieldWrap: Object.freeze({
+            marginTop: '12px',
+        }),
+        fieldLabel: Object.freeze({
+            fontSize: '16px',
+            fontWeight: theme.typography.fontWeightSemiBold,
+            marginBottom: '4px',
+        }),
+        fieldDescription: Object.freeze({
+            fontSize: '14px',
+            fontWeight: theme.typography.fontWeightRegular,
+            color: COLOURS.DARK_GREY,
+            margin: '0 0 6px 0',
+        }),
+        unitsRow: Object.freeze({
+            display: 'flex',
+            gap: '8px',
+        }),
+        unitsValue: Object.freeze({
+            flex: 2,
+        }),
+        unitsUnit: Object.freeze({
+            flex: 1,
+        }),
+        textInputStyles: Object.freeze({
+            width: '100%',
+        }),
+        helperText: Object.freeze({
+            margin: '4px 0 0 0',
+        }),
+        notchedOutlineStyles: Object.freeze({
+            borderRadius: 0,
+        }),
+    });

--- a/src/react/src/components/Contribute/ProductionLocationInfo.jsx
+++ b/src/react/src/components/Contribute/ProductionLocationInfo.jsx
@@ -64,6 +64,11 @@ import RequireAuthNotice from '../RequireAuthNotice';
 import StyledTooltip from '../StyledTooltip';
 
 import InputErrorText from './InputErrorText';
+import DataCenterFields from './DataCenterFields/DataCenterFields';
+import {
+    DATA_CENTER_FORM_INITIAL_VALUES,
+    DATA_CENTER_TYPE_VALUE,
+} from './DataCenterFields/constants';
 import ContributionWarningDialog from './ContributionWarningDialog';
 import ProductionLocationDialog from './ProductionLocationDialog';
 import PostContributionSubmitErrorNotification from './PostContributionSubmitErrorNotification/PostContributionSubmitErrorNotification';
@@ -187,8 +192,31 @@ const ProductionLocationInfo = ({
             processingType: [],
             numberOfWorkers: '',
             parentCompany: '',
+            ...DATA_CENTER_FORM_INITIAL_VALUES,
         });
     };
+
+    // Data-center sections show when the contributor selects Data Center as
+    // a location type (OSDEV-3074).
+    const isDataCenterSelected = (
+        contributionForm.values.locationType || []
+    ).some(option => (option?.value ?? option) === DATA_CENTER_TYPE_VALUE);
+
+    useEffect(() => {
+        // Clear data-center fields when Data Center is deselected so stale
+        // values are never submitted.
+        if (!isDataCenterSelected) {
+            const hasDataCenterValues = Object.keys(
+                DATA_CENTER_FORM_INITIAL_VALUES,
+            ).some(fieldName => contributionForm.values[fieldName]);
+            if (hasDataCenterValues) {
+                contributionForm.setValues({
+                    ...contributionForm.values,
+                    ...DATA_CENTER_FORM_INITIAL_VALUES,
+                });
+            }
+        }
+    }, [isDataCenterSelected]);
 
     const [showAdditionalInfo, setShowAdditionalInfo] = useState(false);
     const onSwitchChange = () => {
@@ -227,6 +255,17 @@ const ProductionLocationInfo = ({
 
     useEffect(() => {
         if (singleProductionLocationData && osID) {
+            // Pre-select the Data Center location type when the existing
+            // record is classified as a data center (OSDEV-3074). The v1
+            // response's location_type derives from the facility_type
+            // extended fields.
+            const existingLocationTypes = [].concat(
+                singleProductionLocationData.location_type ?? [],
+            );
+            const isExistingDataCenter = existingLocationTypes.includes(
+                DATA_CENTER_TYPE_VALUE,
+            );
+
             contributionForm.setValues({
                 ...contributionForm.values,
                 name: singleProductionLocationData.name ?? '',
@@ -237,7 +276,22 @@ const ProductionLocationInfo = ({
                           label: singleProductionLocationData?.country.name,
                       }
                     : null,
+                ...(isExistingDataCenter && {
+                    locationType: [
+                        {
+                            value: DATA_CENTER_TYPE_VALUE,
+                            label: DATA_CENTER_TYPE_VALUE,
+                        },
+                    ],
+                }),
             });
+
+            if (isExistingDataCenter) {
+                // The locationType select lives behind the Additional
+                // information switch; open it so the pre-selected value is
+                // visible and is not wiped by the switch's reset handler.
+                setShowAdditionalInfo(true);
+            }
         }
     }, [singleProductionLocationData, osID]);
 
@@ -1186,6 +1240,11 @@ const ProductionLocationInfo = ({
                                     />
                                 </div>
                             </>
+                        )}
+                        {isDataCenterSelected && (
+                            <DataCenterFields
+                                contributionForm={contributionForm}
+                            />
                         )}
                     </div>
                     {showPostSubmitErrorNotification && (

--- a/src/react/src/util/hooks.js
+++ b/src/react/src/util/hooks.js
@@ -16,6 +16,7 @@ import {
 import { CONFIRM_ACTION, MERGE_ACTION, REJECT_ACTION } from './constants';
 
 import { slcValidationSchema } from './util';
+import { DATA_CENTER_FORM_INITIAL_VALUES } from '../components/Contribute/DataCenterFields/constants';
 
 export const useUpdateLeafletMapImperatively = (
     resetButtonClickCount,
@@ -387,6 +388,7 @@ export const useResetScrollPosition = location => {
 export const useSingleLocationContributionForm = onSubmit =>
     useFormik({
         initialValues: {
+            ...DATA_CENTER_FORM_INITIAL_VALUES,
             name: '',
             address: '',
             country: null,

--- a/src/react/src/util/util.js
+++ b/src/react/src/util/util.js
@@ -1984,6 +1984,15 @@ export const slcValidationSchema = objectYup({
     parentCompany: buildFieldValidation(
         SLC_FIELD_VALIDATION_CONFIG.parentCompany,
     ).label('Parent company'),
+    // Data-center provenance (OSDEV-3074). Mirrors the server-side rule:
+    // ISO 8601 reduced precision - YYYY, YYYY-MM, or YYYY-MM-DD.
+    dateOfSource: stringYup()
+        .matches(/^\d{4}(-(0[1-9]|1[0-2])(-(0[1-9]|[12]\d|3[01]))?)?$/, {
+            message:
+                'Date of source must be a date in YYYY, YYYY-MM, or YYYY-MM-DD format.',
+            excludeEmptyString: true,
+        })
+        .label('Date of source'),
 });
 
 /* eslint-disable camelcase */


### PR DESCRIPTION
## Jira Ticket
[OSDEV-3074](https://opensupplyhub.atlassian.net/browse/OSDEV-3074)

---
## Summary of Changes
Adds a data-center-specific layout to the single-location contribution (SLC) form: when the contributor selects **Data Center** as the location type, the form reveals the data-center schema fields, grouped into collapsible sections.

**New `Contribute/DataCenterFields/` component:**
- Five collapsible sections (Named Entities, Utility Usage, Operating Information, Building Information, Source details/provenance), **collapsed by default** — house pattern (`Collapse`, `role="button"` header with `aria-expanded`, keyboard support, shared `ExpandToggleChevron`).
- The field list is **not duplicated**: `constants.js` derives the sections from the existing display constants (`DATA_CENTER_FIELD_GROUPS` + `PROVENANCE_FIELD_LABELS`), deriving Formik field names via `camelCase(key)`. Measures with units render as a value + units input pair.
- Every field shows a short helper description under its label (condensed from the data-center master dataset schema), matching the base form's label/subtitle pattern.

**Wiring:**
- `util/hooks.js`: `useSingleLocationContributionForm` spreads the ~51 data-center initial values. Because the Formik names are camelCase and `parseContribData` applies a generic `snakeCase` conversion and drops empties, the values map to the exact v1 API keys (`capacityUnits` → `capacity_units`) with **zero submit-path changes** — and a non-data-center submission's payload is unchanged.
- `ProductionLocationInfo.jsx`: renders the sections when `locationType` includes "Data Center"; clears the data-center values when it's deselected or the Additional-information switch resets, so stale values are never submitted.
- **PATCH/update prefill:** when the fetched record's `location_type` (v1 response, derived from the `facility_type` extended fields) includes "Data Center", the form pre-selects the Data Center location type and opens the Additional-information switch so the value is visible and not wiped by the switch's reset handler.
- `util/util.js`: `slcValidationSchema` gains `dateOfSource` — optional, but must be an ISO reduced-precision date (`YYYY`, `YYYY-MM`, or `YYYY-MM-DD`), the client-side mirror of the server rule from OSDEV-3068.

---
## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Backend change (API, database, business logic)
- [x] UI / frontend change
- [ ] Architectural change (affects structure, contracts, or shared modules)
- [ ] Refactor (no functional change)
- [ ] Breaking change (existing functionality may not work as before)
- [ ] Documentation / tooling only

---
## Testing
**`__tests__/components/DataCenterFields.test.jsx`** (new, 8 tests):
- All sections render collapsed by default; provenance section present; toggle cycle (open/close).
- Expanding reveals inputs; value + units pair rendered; field descriptions shown.
- Typing calls `setFieldValue`/`setFieldTouched`; a touched invalid field shows its validation error.

**`__tests__/components/ProductionLocationInfo.test.js`** (+1 describe, UPDATE harness):
- Record with `location_type: ['Data Center']` → data-center sections render and Data Center is pre-selected/visible.
- Record with `location_type: ['Apparel']` → no data-center sections (AC #2 regression).

**`__tests__/utils/slcValidationSchema.test.js`** (+1 describe):
- `dateOfSource`: empty OK; `2024` / `2024-06` / `2024-06-15` accepted; `June 2024` / `2024-13` / `15/06/2024` rejected with the exact message.

Manual: select Data Center under Additional information → sections appear; deselect → sections disappear and values clear; submit → payload carries only the filled fields with snake_case keys.


---
## Known TODO Items
- The "Data Center" option in the location-type select comes from the backend taxonomy — requires OSDEV-2587 deployed in the target environment.
- Update mode pre-fills the classification only; the data-center attribute/provenance fields start empty (pre-filling them from existing extended fields is a follow-up).
- The update prefill reads `location_type` from the v1/OpenSearch response, so a just-approved data center can lag by one Logstash sync interval.
- If the v1 API should expose a crisp `is_data_center` boolean (instead of consumers matching the `location_type` string), that's a separate indexed-field follow-up (requires a reindex).

---
## Checklist
### Implementation
- [x] My code follows the project's style guidelines and naming conventions.
- [x] I have removed debug logs, commented-out code, and unused imports.
- [x] Any AI-assisted code (e.g., Claude) has been reviewed, understood, and adapted to fit our codebase.
- [x] I have considered backward compatibility and migrations where applicable.
### Testing & Validation
- [ ] I have manually tested the change in a local/dev environment.
- [x] I have added or updated unit tests for the new/changed behavior.
- [ ] All existing tests pass locally.
- [ ] For UI changes: I have included screenshots or a recording, and verified responsive/cross-browser behavior.
- [ ] For backend changes: I have validated API contracts, error handling, and edge cases.
- [ ] For architectural changes: I have documented the design decision and notified affected teams.
### Documentation & Communication
- [x] I have updated relevant documentation (README, ADRs, inline comments, API docs).
- [ ] I have updated the Jira ticket status and added any relevant notes.
### Final Review
- [x] I have performed a self-review on my PR and I am presenting my best work for my peers to review.

[OSDEV-3074]: https://opensupplyhub.atlassian.net/browse/OSDEV-3074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ