### PR TITLE
OSDEV-3218: [Quickfix][Infrastructure] terraform destroy fails — deployment/infra destroy branch does not build ContriBot Lambda zips

### DIFF
--- a/deployment/infra
+++ b/deployment/infra
@@ -116,6 +116,14 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 delete_contribot_lambda_zips
                 ;;
             destroy)
+                # Build the gitignored ContriBot Lambda archives. Terraform still
+                # evaluates the full configuration when planning a destroy, so
+                # filebase64sha256() fails if these zips are missing.
+                make -sC lambda-functions/contribot_fetch_lists
+                make -sC lambda-functions/contribot_process_list
+                make -sC lambda-functions/contribot_notify
+
+                echo "Terraform init"
                 terraform init \
                   -backend-config="bucket=${SETTINGS_BUCKET}" \
                   -backend-config="key=terraform/state"

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -56,6 +56,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   * `deployment/terraform/task-definitions/app_kafka.json` splits `entryPoint` into `/bin/bash` with `command` `./kafka.sh`, so ECS `run-task` can override the command (ECS cannot override `entryPoint`). The existing task's behavior is unchanged.
   * New `deployment/run_kafka_cmd` runs an arbitrary command in the `AppKafka` Fargate task, following the same pattern as `run_cli_task`, printing the CloudWatch log stream and propagating the container exit code.
 * [OSDEV-3215](https://opensupplyhub.atlassian.net/browse/OSDEV-3215) - Disabled the flags for redirecting to the new homepage across all environments. All environments now behave consistently, and the root page remains `/map`.
+* [OSDEV-3218](https://opensupplyhub.atlassian.net/browse/OSDEV-3218) - Fixed `terraform destroy` failing with `filebase64sha256(): no such file or directory` for the three ContriBot Lambda archives. The `destroy` branch of `deployment/infra` now builds them with `make -sC` before `terraform init`, mirroring `plan`. Previously only `plan` built the zips (and `apply` downloaded them from S3), and because `contribot_*/*.zip` is gitignored, a destroy never had them on disk — while Terraform still evaluates the full configuration when planning a destroy.
 
 
 ### Code/API changes


### PR DESCRIPTION
## OSDEV-3218 Build ContriBot Lambda zips before terraform destroy

### Summary

`terraform destroy` fails during plan evaluation with three
`filebase64sha256(): no such file or directory` errors, one per ContriBot
Lambda. This adds the missing archive build step to the `destroy` branch of
`deployment/infra`.

### Root cause

`deployment/infra` handles the ContriBot Lambda archives in two of its three
branches:

| Branch | Zip handling |
| --- | --- |
| `plan` | Builds all five archives via `make -sC`, then uploads the ContriBot zips to S3 |
| `apply` | `download_contribot_lambda_zips` pulls the exact bytes back from S3, deletes them after |
| `destroy` | **Nothing** — goes straight to `terraform init` |

Terraform evaluates the full configuration when planning a destroy, so
`filebase64sha256()` in `contribot_lambda.tf` runs and fails on the absent
files.

Only the three ContriBot functions are affected: `.gitignore` ignores
`deployment/terraform/lambda-functions/contribot_*/*.zip`, while the `alert_*`
and `add_security_headers` zips are committed and always on disk.

### Changes

- `deployment/infra` — the `destroy)` case now runs `make -sC` for
  `contribot_fetch_lists`, `contribot_process_list`, and `contribot_notify`
  before `terraform init`, mirroring `plan)`. Added an `echo "Terraform init"`
  line for parity with the other branches.
- `doc/release/RELEASE-NOTES.md` — entry under 2.28.0 →
  Architecture/Environment changes.

### Deliberately not changed

- The `alert_batch_failures` / `alert_sfn_failures` make targets are **not**
  added to `destroy)`. Their Makefiles run `git clean -qfdx src` and
  `pip3 install -t src`, which is meaningful work and failure surface to attach
  to a teardown, and their zips are tracked in git so they're present on any
  clean checkout. Happy to add them if reviewers prefer symmetry with `plan)`.
- `source_code_hash` in `contribot_lambda.tf` is untouched. Guarding it with
  `fileexists()` / `try()` would also work, but it would mask a genuinely
  missing build during `plan`/`apply`, where a missing zip *should* be loud.

### Testing

- [ ] `deployment/infra destroy` against Pre-prod completes past the
      `filebase64sha256` errors
- [ ] `deployment/infra plan` unchanged — still builds all five archives and
      uploads the ContriBot zips to S3
- [ ] `deployment/infra apply` unchanged — still downloads and then deletes them
- [x] `bash -n deployment/infra` passes

### Notes for reviewers

Running the `Destroy Environment` workflow from a feature branch is blocked by
the Pre-prod environment's deployment branch restriction, so end-to-end
verification needs either a merge or a branch pattern added under
Settings → Environments → Pre-prod.