### PR TITLE
Add a CODEOWNERS approver allowlist to support a single-approval merge rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Approver allowlist for the single-approval merge rule.
+#
+# Every PR requires one approving review, and it must come from a user
+# listed here (enforced via the "Require review from Code Owners" setting
+# in the Protected branches ruleset). Anyone with write access can still
+# review and comment; only approvals from the users below satisfy the rule.
+#
+# To change the allowlist, edit this file in a PR like any other change.
+
+* @daniellekain @vlad-shapik @valencia-max @ColumbusLeonardOSHub @VadimKovalenkoSNF @protsack-stephan

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@
 #
 # To change the allowlist, edit this file in a PR like any other change.
 
-* @daniellekain @vlad-shapik @valencia-max @ColumbusLeonardOSHub @VadimKovalenkoSNF @protsack-stephan
+* @ColumbusLeonardOSHub @daniellekain @protsack-stephan @VadimKovalenkoSNF @valencia-max @vlad-shapik


### PR DESCRIPTION
We're moving from requiring 2 approvals on every PR to requiring 1, but with the constraint that the approving review must come from a designated reviewer. GitHub can't restrict *who* counts toward the required approval count natively, so this uses CODEOWNERS: the `*` rule makes the listed users code owners of every path, and turning on "Require review from Code Owners" in the Protected branches ruleset enforces that the one approval comes from this list.

Anyone with write access can still review and comment as before — only the *required* approval is restricted. The allowlist is changed by editing this file in a normal PR.

This PR only adds the file; the ruleset change (2 → 1 required approvals + require code-owner review) happens in repo settings after this merges, so there's no window where one approval from anyone suffices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)