### PR TITLE
OSDEV-3227: [Data Centers] Show data-center fields on the legacy faci…

### DIFF
--- a/src/react/src/__tests__/components/FacilityDetailsGeneralFields.test.js
+++ b/src/react/src/__tests__/components/FacilityDetailsGeneralFields.test.js
@@ -642,4 +642,95 @@ describe('FacilityDetailsGeneralFields component', () => {
 
         expect(queryByText('Facility Type')).not.toBeInTheDocument();
     });
+
+    describe('data center fields (OSDEV-3227)', () => {
+        const dataCenterExtendedField = (rawValue, fieldName) => [
+            {
+                id: 1,
+                is_verified: false,
+                value: { raw_value: rawValue },
+                created_at: '2025-01-01T00:00:00.000Z',
+                updated_at: '2025-01-01T00:00:00.000Z',
+                contributor_name: 'Test Contributor',
+                contributor_id: 1,
+                value_count: 1,
+                is_from_claim: false,
+                field_name: fieldName,
+                verified_count: 0,
+                source_by: null,
+                unit: null,
+                label: null,
+                base_url: null,
+                display_text: null,
+                json_schema: null,
+            },
+        ];
+
+        const dataCenterData = {
+            ...mockData,
+            properties: {
+                ...mockData.properties,
+                is_data_center: true,
+                extended_fields: {
+                    ...mockData.properties.extended_fields,
+                    name_operator: dataCenterExtendedField(
+                        'Equinix',
+                        'name_operator',
+                    ),
+                    capacity: dataCenterExtendedField('20', 'capacity'),
+                    capacity_units: dataCenterExtendedField(
+                        'MW',
+                        'capacity_units',
+                    ),
+                    operational_status: dataCenterExtendedField(
+                        'operational',
+                        'operational_status',
+                    ),
+                },
+            },
+        };
+
+        test('renders grouped data center fields when is_data_center is true', () => {
+            const { getByText } = renderComponent({ data: dataCenterData });
+
+            expect(getByText('Named Entities')).toBeInTheDocument();
+            expect(getByText('Utility Usage')).toBeInTheDocument();
+            expect(getByText('Operating Information')).toBeInTheDocument();
+            expect(getByText('Operator')).toBeInTheDocument();
+            expect(getByText('Equinix')).toBeInTheDocument();
+        });
+
+        test('combines a measure with its units into one value', () => {
+            const { getByText, queryByText } = renderComponent({
+                data: dataCenterData,
+            });
+
+            expect(getByText('20 MW')).toBeInTheDocument();
+            // The units field is merged, not rendered on its own.
+            expect(queryByText('Capacity units')).not.toBeInTheDocument();
+        });
+
+        test('omits groups with no contributed values', () => {
+            const { queryByText } = renderComponent({ data: dataCenterData });
+
+            expect(queryByText('Building Information')).not.toBeInTheDocument();
+        });
+
+        test('does not render data center groups for a production location', () => {
+            const { queryByText } = renderComponent();
+
+            expect(queryByText('Named Entities')).not.toBeInTheDocument();
+            expect(queryByText('Utility Usage')).not.toBeInTheDocument();
+        });
+
+        test('does not render data center groups in embed mode', () => {
+            const { queryByText } = renderComponent({
+                data: dataCenterData,
+                embed: true,
+                embedConfig: { embed_fields: [] },
+            });
+
+            expect(queryByText('Named Entities')).not.toBeInTheDocument();
+        });
+    });
 });

--- a/src/react/src/components/Contribute/DataCenterFields/DataCenterFields.jsx
+++ b/src/react/src/components/Contribute/DataCenterFields/DataCenterFields.jsx
@@ -52,8 +52,17 @@ const DataCenterFields = ({ classes, contributionForm }) => {
                     )
                 }
                 FormHelperTextProps={{ className: classes.helperText }}
+                /*
+                `inputProps` (lowercase) targets the native <input>, so the
+                accessible name belongs to the focusable control, while
+                `InputProps` (capital) targets the Input wrapper and is used
+                only for styling. They are separate MUI APIs, but
+                react/jsx-no-duplicate-props is configured with ignoreCase and
+                reports them as duplicates.
+                */
+                // eslint-disable-next-line react/jsx-no-duplicate-props
+                inputProps={{ 'aria-label': label }}
                 InputProps={{
-                    'aria-label': label,
                     classes: {
                         notchedOutline: classes.notchedOutlineStyles,
                     },

--- a/src/react/src/components/Contribute/DataCenterFields/DataCenterFields.jsx
+++ b/src/react/src/components/Contribute/DataCenterFields/DataCenterFields.jsx
@@ -60,8 +60,8 @@ const DataCenterFields = ({ classes, contributionForm }) => {
                 react/jsx-no-duplicate-props is configured with ignoreCase and
                 reports them as duplicates.
                 */
-                // eslint-disable-next-line react/jsx-no-duplicate-props
                 inputProps={{ 'aria-label': label }}
+                // eslint-disable-next-line react/jsx-no-duplicate-props
                 InputProps={{
                     classes: {
                         notchedOutline: classes.notchedOutlineStyles,

--- a/src/react/src/components/FacilityDetailsGeneralFields.jsx
+++ b/src/react/src/components/FacilityDetailsGeneralFields.jsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
 import get from 'lodash/get';
 import isNil from 'lodash/isNil';
 import filter from 'lodash/filter';
@@ -10,6 +11,7 @@ import FacilityDetailsClaimedInfo from './FacilityDetailsClaimedInfo/FacilityDet
 import ShowOnly from './ShowOnly';
 import FeatureFlag from './FeatureFlag';
 import { formatAttribution, formatExtendedField } from '../util/util';
+import { DATA_CENTER_FIELD_GROUPS } from './ProductionLocation/constants.jsx';
 
 import {
     EXTENDED_FIELD_TYPES,
@@ -33,6 +35,11 @@ const locationFieldsStyles = theme =>
             maxWidth: '1072px',
             paddingLeft: theme.spacing.unit * 3,
             paddingBottom: theme.spacing.unit * 3,
+        },
+        dataCenterGroupTitle: {
+            fontSize: '18px',
+            fontWeight: theme.typography.fontWeightSemiBold,
+            marginTop: theme.spacing.unit * 2,
         },
     });
 
@@ -258,9 +265,10 @@ const FacilityDetailsGeneralFields = ({
     );
 
     const renderExtendedFields = () => {
-        const extendedFieldsWithoutAdditionalIdentifiers = EXTENDED_FIELD_TYPES.filter(
-            field => !ADDITIONAL_IDENTIFIERS.includes(field.fieldName),
-        );
+        const extendedFieldsWithoutAdditionalIdentifiers =
+            EXTENDED_FIELD_TYPES.filter(
+                field => !ADDITIONAL_IDENTIFIERS.includes(field.fieldName),
+            );
 
         return (
             <FeatureFlag
@@ -273,6 +281,67 @@ const FacilityDetailsGeneralFields = ({
             </FeatureFlag>
         );
     };
+
+    /*
+    Reuses DATA_CENTER_FIELD_GROUPS as the single source of truth for the
+    field list, labels and units pairing (the same config the new details
+    page uses), and renders each field through renderExtendedField so
+    multi-contributor values and attribution behave exactly like the other
+    extended fields on this page. Units fields are merged into their measure
+    rather than rendered on their own.
+    */
+    const isDataCenter = !!get(data, 'properties.is_data_center', false);
+
+    const renderDataCenterField = ({ key, label, unitsField }) => {
+        let unit = null;
+        if (unitsField) {
+            const unitValues = get(
+                data,
+                `properties.extended_fields.${unitsField}`,
+                [],
+            );
+            unit = unitValues.length
+                ? get(unitValues[0], 'value.raw_value', null)
+                : null;
+        }
+
+        return renderExtendedField({
+            label,
+            fieldName: key,
+            formatValue: value => {
+                const rawValue = get(value, 'raw_value', null);
+                if (isNil(rawValue) || rawValue === '') {
+                    return rawValue;
+                }
+                return unit ? `${rawValue} ${unit}` : rawValue;
+            },
+        });
+    };
+
+    const renderDataCenterGroups = () =>
+        DATA_CENTER_FIELD_GROUPS.map(group => {
+            const renderedFields = group.fields
+                .map(field => renderDataCenterField(field))
+                .filter(Boolean);
+
+            if (!renderedFields.length) {
+                return null;
+            }
+
+            return (
+                <React.Fragment key={group.label}>
+                    <Grid item xs={12}>
+                        <Typography
+                            component="h3"
+                            className={classes.dataCenterGroupTitle}
+                        >
+                            {group.label}
+                        </Typography>
+                    </Grid>
+                    {renderedFields}
+                </React.Fragment>
+            );
+        }).filter(Boolean);
 
     return (
         <div className={classes.root}>
@@ -297,6 +366,7 @@ const FacilityDetailsGeneralFields = ({
                         </Grid>
                     )}
                     {embed ? renderEmbedFields() : renderExtendedFields()}
+                    {!embed && isDataCenter ? renderDataCenterGroups() : null}
                     <FeatureFlag flag={REPORT_A_FACILITY}>
                         <ShowOnly when={!!activityReport}>
                             <FacilityDetailsItem

--- a/src/react/src/components/FacilityDetailsGeneralFields.jsx
+++ b/src/react/src/components/FacilityDetailsGeneralFields.jsx
@@ -265,10 +265,9 @@ const FacilityDetailsGeneralFields = ({
     );
 
     const renderExtendedFields = () => {
-        const extendedFieldsWithoutAdditionalIdentifiers =
-            EXTENDED_FIELD_TYPES.filter(
-                field => !ADDITIONAL_IDENTIFIERS.includes(field.fieldName),
-            );
+        const extendedFieldsWithoutAdditionalIdentifiers = EXTENDED_FIELD_TYPES.filter(
+            field => !ADDITIONAL_IDENTIFIERS.includes(field.fieldName),
+        );
 
         return (
             <FeatureFlag


### PR DESCRIPTION
## Jira Ticket
[OSDEV-3227](https://opensupplyhub.atlassian.net/browse/OSDEV-3227)

---
## Summary of Changes
Adds the data-center fields to the **legacy** facility details page, so data centers display their data regardless of which details page the environment serves.

**Root cause / finding:** the data-center fields were added to the new ProductionLocation details page only (OSDEV-3076 / OSDEV-3077). The legacy page renders its own component, `src/react/src/components/FacilityDetailsGeneralFields.jsx`, driven by the shared `EXTENDED_FIELD_TYPES` list — which deliberately excludes the data-center fields (they live in `DATA_CENTER_FIELD_GROUPS` to keep them off the legacy page). Since which page is served depends on the `enable_production_location_page` waffle switch, a data center currently shows no data-center fields wherever that switch is off.

**Changes in `FacilityDetailsGeneralFields.jsx`:**
- Gate on `properties.is_data_center` (already returned by `/api/facilities/{os_id}`), so production locations are untouched.
- Reuse `DATA_CENTER_FIELD_GROUPS` as the single source of truth for the field list, labels and units pairing — the same config the new details page uses — rather than extending the shared `EXTENDED_FIELD_TYPES` list (which would leak the fields into other consumers).
- Each field renders through the component's **existing `renderExtendedField`**, so multi-contributor values, attribution and the standard drawer behave exactly like every other extended field on this page. No formatting logic was duplicated.
- Measures are combined with their units into one displayed value ("20 MW") via a closure passed as `formatValue`; the units field is never rendered on its own.
- Groups are rendered with a full-width heading followed by the page's existing two-column layout; **groups with no contributed values are omitted entirely**.
- Data-center groups are **excluded in embed mode**: embedded maps render only the contributor's configured `embed_fields`, so injecting the groups there would override an embedding partner's explicit field configuration.
- Provenance fields are out of scope (they are per-row and shown in the contributions drawer, OSDEV-3073).

---
## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Backend change (API, database, business logic)
- [x] UI / frontend change
- [ ] Architectural change (affects structure, contracts, or shared modules)
- [ ] Refactor (no functional change)
- [ ] Breaking change (existing functionality may not work as before)
- [ ] Documentation / tooling only

---
## Testing
`__tests__/components/FacilityDetailsGeneralFields.test.js` (+1 describe, 5 tests), using the file's existing render harness:
- Grouped data-center fields render when `is_data_center` is true (group headings, field labels and values).
- A measure is combined with its units into one value ("20 MW"), and the units field is not rendered standalone.
- Groups with no contributed values are omitted (Building Information absent when unpopulated).
- A production location renders unchanged — no data-center groups.
- Embed mode renders no data-center groups.

Manual: with the `enable_production_location_page` switch **off**, open a data center and confirm the grouped fields appear; open a production location and confirm the page is unchanged.

<img width="1172" height="748" alt="image" src="https://github.com/user-attachments/assets/e11504c4-1dc1-49ed-9b3f-548d741f310a" />


---
## Known TODO Items
- Per-field provenance is not shown on this page. `FacilityDetailsItem` supports a `customDrawer` mode that renders the new `ContributionsDrawer` (with the provenance accordion), so this is a small follow-up if wanted — deliberately left out of this PR to keep the scope to field display.
- A field with a single contribution shows no drawer on this page (`FacilityDetailsItem` gates the drawer on `hasAdditionalContent`) — the same limitation covered by OSDEV-3228, whose fix would benefit both pages.
- **Open question from the ticket:** if the legacy page is due to be retired once the production-location-page switch is fully enabled, this work may be short-lived — worth confirming before merge.
- Screenshots to be attached after a local run.

---
## Checklist
### Implementation
- [x] My code follows the project's style guidelines and naming conventions.
- [x] I have removed debug logs, commented-out code, and unused imports.
- [x] Any AI-assisted code (e.g., Claude) has been reviewed, understood, and adapted to fit our codebase.
- [x] I have considered backward compatibility and migrations where applicable.
### Testing & Validation
- [ ] I have manually tested the change in a local/dev environment.
- [x] I have added or updated unit tests for the new/changed behavior.
- [ ] All existing tests pass locally.
- [ ] For UI changes: I have included screenshots or a recording, and verified responsive/cross-browser behavior.
- [ ] For backend changes: I have validated API contracts, error handling, and edge cases.
- [ ] For architectural changes: I have documented the design decision and notified affected teams.
### Documentation & Communication
- [x] I have updated relevant documentation (README, ADRs, inline comments, API docs).
- [ ] I have updated the Jira ticket status and added any relevant notes.
### Final Review
- [x] I have performed a self-review on my PR and I am presenting my best work for my peers to review.

[OSDEV-3227]: https://opensupplyhub.atlassian.net/browse/OSDEV-3227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ