### PR TITLE
OSDEV-3228: [Data Centers] Open the contributions drawer when a field has a single contribution

### DIFF
--- a/src/react/src/__tests__/components/ContributionsDrawer.test.jsx
+++ b/src/react/src/__tests__/components/ContributionsDrawer.test.jsx
@@ -247,6 +247,35 @@ describe('ContributionsDrawer', () => {
         expect(screen.getByText('Operator website')).toBeInTheDocument();
     });
 
+    test('omits the other-sources section when there is a single contribution', () => {
+        renderContributionsDrawer({
+            open: true,
+            onClose: () => {},
+            fieldName: 'Operator',
+            promotedContribution: {
+                value: 'Equinix',
+                sourceName: 'Source A',
+                date: '2023-01-01',
+                userId: 10,
+            },
+            contributions: [],
+        });
+
+        // The promoted contribution is shown on its own.
+        expect(
+            screen.getByTestId('contribution-card-promoted'),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByTestId('contributions-drawer-list'),
+        ).not.toBeInTheDocument();
+        // No empty "Other Data Sources" section or multi-organization copy.
+        expect(screen.queryByText('Other Data Sources')).not.toBeInTheDocument();
+        // The subtitle reads in the singular.
+        expect(
+            screen.getByTestId('contributions-drawer-subtitle'),
+        ).toHaveTextContent('1 organization has contributed data for Operator');
+    });
+
     test('provenance accordion toggles open and closed', () => {
         renderContributionsDrawer({
             open: true,

--- a/src/react/src/__tests__/components/DataPoint.test.jsx
+++ b/src/react/src/__tests__/components/DataPoint.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 
@@ -89,5 +89,65 @@ describe('DataPoint', () => {
         });
 
         expect(screen.queryByTestId('data-point-sources-button')).not.toBeInTheDocument();
+    });
+
+    test('renders sources button when the field has only a promoted contribution', () => {
+        renderDataPoint({
+            label: 'Name',
+            value: 'Value',
+            drawerData: {
+                promotedContribution: {
+                    value: 'Value',
+                    sourceName: 'Source A',
+                    date: '2022-01-01',
+                },
+                contributions: [],
+            },
+            onOpenDrawer: jest.fn(),
+        });
+
+        const button = screen.getByTestId('data-point-sources-button');
+        expect(button).toBeInTheDocument();
+        expect(button).toHaveTextContent('1 data source');
+    });
+
+    test('sources button counts the promoted contribution in the total', () => {
+        renderDataPoint({
+            label: 'Name',
+            value: 'Value',
+            drawerData: {
+                promotedContribution: {
+                    value: 'Value',
+                    sourceName: 'Source A',
+                    date: '2022-01-01',
+                },
+                contributions: [
+                    { value: 'Other', sourceName: 'Source B' },
+                    { value: 'Another', sourceName: 'Source C' },
+                ],
+            },
+            onOpenDrawer: jest.fn(),
+        });
+
+        expect(
+            screen.getByTestId('data-point-sources-button'),
+        ).toHaveTextContent('3 data sources');
+    });
+
+    test('opens the drawer from a single-contribution field', () => {
+        const onOpenDrawer = jest.fn();
+        renderDataPoint({
+            label: 'Name',
+            value: 'Value',
+            drawerData: {
+                promotedContribution: { value: 'Value', sourceName: 'Source' },
+                contributions: [],
+            },
+            onOpenDrawer,
+        });
+
+        fireEvent.click(screen.getByTestId('data-point-sources-button'));
+
+        expect(onOpenDrawer).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/react/src/components/ProductionLocation/ContributionsDrawer/ContributionsDrawer.jsx
+++ b/src/react/src/components/ProductionLocation/ContributionsDrawer/ContributionsDrawer.jsx
@@ -105,39 +105,48 @@ const ContributionsDrawer = ({
                     </>
                 ) : null}
 
-                <Typography
-                    className={classes.sectionLabel}
-                    component="p"
-                    variant="body1"
-                >
-                    {sectionLabel}
-                </Typography>
-                <InfoBox
-                    title={null}
-                    variant="contributions"
-                    learnMoreUrl={LEARN_MORE_OPEN_DATA_MODEL_URL}
-                    learnMoreLabel={LEARN_MORE_LABEL}
-                >
-                    {INFO_CONTRIBUTIONS_TEXT}
-                </InfoBox>
+                {/*
+                Only shown when there are other contributions: a field with a
+                single contribution would otherwise render an empty section
+                with copy about multiple organizations (OSDEV-3228).
+                */}
                 {contributionsCount > 0 ? (
-                    <div data-testid="contributions-drawer-list">
-                        {contributions.map((item, index) => (
-                            <ContributionCard
-                                key={
-                                    item.id ||
-                                    `${item.value}-${item.sourceName}-${index}`
-                                }
-                                value={item.value}
-                                sourceName={item.sourceName}
-                                date={item.date}
-                                userId={item.userId}
-                                provenance={item.provenance}
-                                data-testid="contribution-card"
-                                spotlightGaProfileBase={spotlightGaProfileBase}
-                            />
-                        ))}
-                    </div>
+                    <>
+                        <Typography
+                            className={classes.sectionLabel}
+                            component="p"
+                            variant="body1"
+                        >
+                            {sectionLabel}
+                        </Typography>
+                        <InfoBox
+                            title={null}
+                            variant="contributions"
+                            learnMoreUrl={LEARN_MORE_OPEN_DATA_MODEL_URL}
+                            learnMoreLabel={LEARN_MORE_LABEL}
+                        >
+                            {INFO_CONTRIBUTIONS_TEXT}
+                        </InfoBox>
+                        <div data-testid="contributions-drawer-list">
+                            {contributions.map((item, index) => (
+                                <ContributionCard
+                                    key={
+                                        item.id ||
+                                        `${item.value}-${item.sourceName}-${index}`
+                                    }
+                                    value={item.value}
+                                    sourceName={item.sourceName}
+                                    date={item.date}
+                                    userId={item.userId}
+                                    provenance={item.provenance}
+                                    data-testid="contribution-card"
+                                    spotlightGaProfileBase={
+                                        spotlightGaProfileBase
+                                    }
+                                />
+                            ))}
+                        </div>
+                    </>
                 ) : null}
             </div>
         </Drawer>

--- a/src/react/src/components/ProductionLocation/ContributionsDrawer/utils.js
+++ b/src/react/src/components/ProductionLocation/ContributionsDrawer/utils.js
@@ -3,6 +3,16 @@ import { CONTRIBUTIONS_SECTION_LABEL } from './constants';
 export const getContributionsCount = contributions =>
     Array.isArray(contributions) ? contributions.length : 0;
 
+/**
+ * Total number of contributions the drawer will display for a field: the
+ * promoted contribution plus the other contributions (OSDEV-3228). Used to
+ * decide whether the drawer is reachable, so a field with a single
+ * contribution can still be opened.
+ */
+export const getTotalContributionsCount = drawerData =>
+    getContributionsCount(drawerData?.contributions) +
+    (drawerData?.promotedContribution ? 1 : 0);
+
 export const getContributionsSectionLabel = contributionsCount =>
     contributionsCount > 0
         ? `${CONTRIBUTIONS_SECTION_LABEL} (${contributionsCount})`

--- a/src/react/src/components/ProductionLocation/DataPoint/DataPoint.jsx
+++ b/src/react/src/components/ProductionLocation/DataPoint/DataPoint.jsx
@@ -16,7 +16,7 @@ import Grid from '@material-ui/core/Grid';
 import { withStyles } from '@material-ui/core/styles';
 
 import IconComponent from '../../Shared/IconComponent/IconComponent';
-import { getContributionsCount } from '../ContributionsDrawer/utils';
+import { getTotalContributionsCount } from '../ContributionsDrawer/utils';
 import SourcesButton from './SourcesButton/SourcesButton';
 import MetaContributor from './MetaContributor/MetaContributor';
 import MetaDate from './MetaDate/MetaDate';
@@ -38,7 +38,9 @@ const DataPoint = ({
     onOpenDrawer,
     multiline,
 }) => {
-    const sourcesCount = getContributionsCount(drawerData?.contributions);
+    // Counts the promoted contribution as well, so a field with a single
+    // contribution can still open the drawer (OSDEV-3228).
+    const sourcesCount = getTotalContributionsCount(drawerData);
     const showSourcesButton = sourcesCount > 0 && onOpenDrawer;
     const statusChipClass = getStatusChipClass(statusLabel, classes);
 

--- a/src/react/src/components/ProductionLocation/DataPoint/SourcesButton/utils.js
+++ b/src/react/src/components/ProductionLocation/DataPoint/SourcesButton/utils.js
@@ -1,6 +1,12 @@
+/*
+`sourcesCount` is the total number of contributions the drawer will show for
+the field, including the promoted one (OSDEV-3228). The label therefore states
+the total rather than a "+N more" delta, so it matches the drawer contents and
+reads correctly when a field has a single contribution.
+*/
 const getSourcesButtonLabel = sourcesCount => {
     const sourceWord = sourcesCount === 1 ? 'source' : 'sources';
-    return `+${sourcesCount} data ${sourceWord}`;
+    return `${sourcesCount} data ${sourceWord}`;
 };
 
 export default getSourcesButtonLabel;


### PR DESCRIPTION
## Jira Ticket
[OSDEV-3228](https://opensupplyhub.atlassian.net/browse/OSDEV-3228)

---
## Summary of Changes
Makes the contributions drawer reachable for a field that has only one contribution, so the source of every data point can always be inspected.

**Root cause:** in `ProductionLocation/DataPoint/DataPoint.jsx` the sources button was gated on `getContributionsCount(drawerData?.contributions) > 0`. The `contributions` array **excludes** the promoted contribution, so a field with a single contribution had `contributions: []` → count 0 → the button was hidden and the drawer could not be opened at all.

**Changes:**
- `ContributionsDrawer/utils.js`: new `getTotalContributionsCount(drawerData)` — `contributions.length + (promotedContribution ? 1 : 0)`.
- `DataPoint.jsx`: gates the sources button on that total, so single-contribution fields now open the drawer.
- `DataPoint/SourcesButton/utils.js`: **copy change.** The count is now a total, so the label can no longer read as a "+N more" delta (`+1 data source` would be misleading and `+0 data sources` nonsense). It now states the total — `1 data source` / `3 data sources` — which matches what the drawer lists. A field that previously read "+2 data sources" now reads "3 data sources".
- `ContributionsDrawer.jsx`: the "Other Data Sources" heading, its info box ("Multiple organizations may have shared information…") and the list are only rendered when there *are* other contributions. Without this, a single-contribution drawer showed an empty section with copy about multiple organizations. The subtitle already read correctly in the singular, since `getContributorCount` includes the promoted contribution.

This also makes per-field provenance (OSDEV-3073) reachable for data-center fields contributed by a single source, which was the motivation for the ticket.

---
## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Backend change (API, database, business logic)
- [x] UI / frontend change
- [ ] Architectural change (affects structure, contracts, or shared modules)
- [ ] Refactor (no functional change)
- [ ] Breaking change (existing functionality may not work as before)
- [ ] Documentation / tooling only

---
## Testing
`__tests__/components/DataPoint.test.jsx` (+3 tests):
- A field with only a promoted contribution renders the sources button, labelled "1 data source".
- Promoted + 2 others renders "3 data sources" (total includes the promoted one).
- Clicking the button on a single-contribution field calls `onOpenDrawer`.
- The existing "no contributions at all → no button" test still passes (total is 0).

`__tests__/components/ContributionsDrawer.test.jsx` (+1 test):
- A single contribution shows the promoted card, no contributions list, no "Other Data Sources" section, and a singular subtitle ("1 organization has contributed data for Operator").

Manual: open a field with a single contribution and confirm the drawer opens and (for data-center fields) the provenance accordion is available.

---
## Known TODO Items
- **Provenance is not shown for `name`, `address` and `sector`** — by design for now (agreed: no change). Those entries are not serialized extended fields: they are synthesized from the separate `FacilityIndex` arrays (`facility_names` / `facility_addresses` / `sector`) and appended after the extended-field serializer runs, so they carry no `facility_list_item_id` to resolve provenance from. The index SQL (`index_facility_names.sql` / addresses) does not emit that id either, so enabling it would need new versioned SQL plus a reindex. Documented here rather than fixed.
- Provenance for other extended fields (e.g. `processing_type`) resolves only when the originating `FacilityListItem` actually has provenance values — older contributions and claim-derived fields (no list item) will show none. Expected behaviour, not a bug.
- The label copy change ("+2 data sources" → "3 data sources") is a visible product change and worth a quick product sign-off.
- The legacy details page has an equivalent gate in `FacilityDetailsItem` (`hasAdditionalContent`); aligning it was left out of scope.
- Screenshots to be attached after a local run.

---
## Checklist
### Implementation
- [x] My code follows the project's style guidelines and naming conventions.
- [x] I have removed debug logs, commented-out code, and unused imports.
- [x] Any AI-assisted code (e.g., Claude) has been reviewed, understood, and adapted to fit our codebase.
- [x] I have considered backward compatibility and migrations where applicable.
### Testing & Validation
- [ ] I have manually tested the change in a local/dev environment.
- [x] I have added or updated unit tests for the new/changed behavior.
- [ ] All existing tests pass locally.
- [ ] For UI changes: I have included screenshots or a recording, and verified responsive/cross-browser behavior.
- [ ] For backend changes: I have validated API contracts, error handling, and edge cases.
- [ ] For architectural changes: I have documented the design decision and notified affected teams.
### Documentation & Communication
- [x] I have updated relevant documentation (README, ADRs, inline comments, API docs).
- [ ] I have updated the Jira ticket status and added any relevant notes.
### Final Review
- [x] I have performed a self-review on my PR and I am presenting my best work for my peers to review.

[OSDEV-3228]: https://opensupplyhub.atlassian.net/browse/OSDEV-3228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ