### PR TITLE
[OSDEV-3362] Pin BTrees to 6.4 to restore the dedupe-hub gazetteer build (main twin of #1235)

### DIFF
--- a/src/dedupe-hub/api/requirements.txt
+++ b/src/dedupe-hub/api/requirements.txt
@@ -5,6 +5,14 @@ fastapi[all]==0.75.0
 fastapi-utils==0.2.0
 Unidecode==1.3.6
 dedupe==1.9.4
+# Pinned transitive dependency of dedupe: BTrees 6.5 (released 2026-08-20)
+# removed the long-deprecated byValue() method that dedupe 1.9.4's canopy
+# index calls (dedupe/canopy_index.py) during the gazetteer build, so any
+# image built with an unpinned BTrees >= 6.5 fails every gazetteer build at
+# startup ("Attempting to block with an index predicate without indexing
+# records"). See https://github.com/zopefoundation/BTrees/issues/226.
+# Keep < 6.5 for as long as dedupe 1.9.4 is in use.
+BTrees==6.4
 numpy==1.22.4
 rollbar==0.16.3
 SQLAlchemy==1.4.49


### PR DESCRIPTION
Twin of #1235 for main, so every future image build (dev/test deploys, next releases) carries the pin. Identical one-line change + comment; root cause, evidence, and testing are documented on [#1235](https://github.com/opensupplyhub/open-supply-hub/pull/1235). Release-notes entry rides the 2.29 quickfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)