### PR TITLE
[OSDEV-3350] Prefix non-production ContriBot Slack notifications with the environment name

### DIFF
--- a/deployment/terraform/contribot_lambda.tf
+++ b/deployment/terraform/contribot_lambda.tf
@@ -21,6 +21,7 @@ locals {
 
   contribot_notify_environment = {
     CONTRIBOT_STATE_TABLE_NAME          = aws_dynamodb_table.contribot_state.name
+    ENVIRONMENT                         = var.environment
     OS_HUB_API_URL                      = local.contribot_os_hub_api_url
     MONDAY_API_URL                      = "https://api.monday.com/v2"
     MONDAY_BOARD_ID                     = var.contribot_monday_board_id

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * Product name: Open Supply Hub
 * Release date: *Provide release date*
 
+### Architecture/Environment changes
+* [OSDEV-3350](https://opensupplyhub.atlassian.net/browse/OSDEV-3350) - ContriBot Slack notifications from non-production environments are now prefixed with the environment name (e.g. `[TEST] New list …`), so test and production runs posting to the same Slack channels are distinguishable at a glance. Production messages are unchanged. The notify Lambda receives the new `ENVIRONMENT` Terraform variable; no tfvars changes are needed (`environment` is already set per env).
+
 ### Bugfix
 * [OSDEV-3349](https://opensupplyhub.atlassian.net/browse/OSDEV-3349) - **Deploy to AWS** now deletes the Terraform planfile from `s3://oshub-settings-<env>/terraform/` after a successful apply. The object is the handoff between `init-and-plan` and `apply`, so it cannot be removed after plan; it was previously left in the settings bucket indefinitely and can contain sensitive values from state. A failed apply still keeps the file so **Re-run failed jobs** can download it. `deploy-mode: terraform-plan` is unchanged — apply never runs, so the review copy stays in S3.
 

--- a/src/contribot/notify/handler.py
+++ b/src/contribot/notify/handler.py
@@ -47,6 +47,7 @@ def handler(event, context):
     notify_message = NotifyMessage(
         list_id=list_id,
         base_url=base_url,
+        environment=os.environ.get("ENVIRONMENT", ""),
         list_name=list_name,
         contributor_id=item.get("contributor_id"),
         contributor_name=item.get("contributor_name") or "",

--- a/src/contribot/notify/message.py
+++ b/src/contribot/notify/message.py
@@ -19,6 +19,7 @@ class NotifyMessage:
         *,
         list_id: str,
         base_url: str,
+        environment: str = "",
         list_name: str = "",
         contributor_id: Optional[str] = None,
         contributor_name: str = "",
@@ -32,6 +33,7 @@ class NotifyMessage:
     ) -> None:
         self._list_id = list_id
         self._base_url = base_url.rstrip("/")
+        self._environment = environment.strip()
         self._list_name = list_name
         self._contributor_id = contributor_id
         self._contributor_name = contributor_name
@@ -55,6 +57,7 @@ class NotifyMessage:
             if self._error
             else f"New list {list_link}"
         )
+        headline = f"{self._environment_prefix()}{headline}"
         lines = [
             headline,
             self._contributor_line(),
@@ -64,6 +67,13 @@ class NotifyMessage:
             self._error_line(),
         ]
         return "\n".join(line for line in lines if line)
+
+    def _environment_prefix(self) -> str:
+        """Tag non-production messages so test and prod runs posting to the
+        same Slack channels are distinguishable at a glance."""
+        if not self._environment or self._environment.lower() == "production":
+            return ""
+        return f"[{self._environment.upper()}] "
 
     def _contributor_line(self) -> str:
         if not (self._contributor_name or self._contributor_email):

--- a/src/contribot/notify/tests/test_notify_handler.py
+++ b/src/contribot/notify/tests/test_notify_handler.py
@@ -31,6 +31,7 @@ _SPEC.loader.exec_module(handler)
 @pytest.fixture
 def env(monkeypatch):
     monkeypatch.setenv("CONTRIBOT_STATE_TABLE_NAME", "contribot-state")
+    monkeypatch.setenv("ENVIRONMENT", "Test")
     monkeypatch.setenv("OS_HUB_API_URL", "https://example.com")
     monkeypatch.setenv("MONDAY_BOARD_ID", "3514246658")
     monkeypatch.setenv(
@@ -84,7 +85,9 @@ def test_handler_posts_success_message(repo_slack_monday):
         secret_arn="arn:aws:secretsmanager:us-east-1:123:secret:slack"
     )
     message = slack.post.call_args[0][0]
-    assert "New list <https://example.com/lists/101|#101 Spring Facilities>" in message
+    assert message.startswith(
+        "[TEST] New list <https://example.com/lists/101|#101 Spring Facilities>"
+    )
     assert (
         "<https://example.com/admin/api/contributor/5/change/"
         "|Contributor Example Brand> email brand@example.com" in message
@@ -116,7 +119,9 @@ def test_handler_skips_monday_on_failure(repo_slack_monday):
         secret_arn="arn:aws:secretsmanager:us-east-1:123:secret:slack-failures"
     )
     message = slack.post.call_args[0][0]
-    assert ":rotating_light: ContriBot failed to process list" in message
+    assert message.startswith(
+        "[TEST] :rotating_light: ContriBot failed to process list"
+    )
     assert "Error: boom" in message
     monday.create_item.assert_not_called()
     monday.cls.assert_not_called()
@@ -187,6 +192,36 @@ def test_error_ratio_emoji_thresholds(error_ratio, emoji):
         error_ratio=error_ratio,
     ).generate()
     assert emoji in message
+
+
+@pytest.mark.parametrize(
+    "environment,expected_prefix",
+    [
+        ("Test", "[TEST] "),
+        ("Staging", "[STAGING] "),
+        ("Production", ""),
+        ("", ""),
+    ],
+)
+def test_environment_prefix(environment, expected_prefix):
+    message = NotifyMessage(
+        list_id="101",
+        base_url="https://example.com",
+        environment=environment,
+    ).generate()
+    assert message.startswith(f"{expected_prefix}New list ")
+
+
+def test_handler_production_message_has_no_prefix(env, monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "Production")
+    repo, slack, monday = _mocks()
+    with patch.object(handler, "ListsRepository", return_value=repo), patch.object(
+        handler, "SlackWebhook", return_value=slack
+    ), patch.object(handler, "MondayBoard", return_value=monday):
+        handler.handler({"list_id": "101"}, None)
+
+    message = slack.post.call_args[0][0]
+    assert message.startswith("New list ")
 
 
 def test_handler_tolerates_missing_dynamodb_row(env):


### PR DESCRIPTION
## Jira Ticket

[OSDEV-3350](https://opensupplyhub.atlassian.net/browse/OSDEV-3350)

---

## Summary of Changes

Test and production ContriBot instances post their notifications to the same Slack channels, and the messages are indistinguishable without clicking through the list link and inspecting the hostname. This surfaced during the first end-to-end test-environment run (list 9528): the success message looked exactly like a production one.

The notify Lambda now receives an `ENVIRONMENT` variable from Terraform (`var.environment`, which every env already sets in its tfvars — no tfvars changes needed). `NotifyMessage` prepends `[TEST] ` / `[STAGING] ` etc. to both the success and failure headlines for any environment that is not `Production`. Production messages are byte-for-byte unchanged, and a missing/empty `ENVIRONMENT` (e.g. an older deploy) also leaves messages unchanged.

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Backend change (API, database, business logic)
- [ ] UI / frontend change
- [ ] Architectural change (affects structure, contracts, or shared modules)
- [ ] Refactor (no functional change)
- [ ] Breaking change (existing functionality may not work as before)
- [ ] Documentation / tooling only

---

## Testing

- Full ContriBot unit suites pass locally per-directory as CI runs them: notify 15 (5 new), fetch_lists 4, process_list 7, retry_failed_lists 2, lib 140.
- New tests cover: `[TEST]` prefix on success and failure headlines, `[STAGING]` casing, `Production` → no prefix, empty `ENVIRONMENT` → no prefix (backward compatibility with deploys that predate the variable).
- Not yet exercised on a live environment; the next test-env list run after deploy will show the prefixed message in Slack.

---

## Known TODO Items

None.

---

## Checklist

### Implementation

- [x] My code follows the project's style guidelines and naming conventions.
- [x] I have removed debug logs, commented-out code, and unused imports.
- [x] Any AI-assisted code (e.g., Claude) has been reviewed, understood, and adapted to fit our codebase.
- [x] I have considered backward compatibility and migrations where applicable.
- [x] The diff contains no secrets, internal document/spreadsheet/folder IDs, internal board or channel identifiers, internal policy thresholds, or staff contact details — internal values are externalized to runtime configuration (see "Public repository hygiene" in AGENTS.md).

### Testing & Validation

- [ ] I have manually tested the change in a local/dev environment.
- [x] I have added or updated unit tests for the new/changed behavior.
- [x] All existing tests pass locally.
- [ ] For UI changes: I have included screenshots or a recording, and verified responsive/cross-browser behavior. (N/A)
- [x] For backend changes: I have validated API contracts, error handling, and edge cases.
- [ ] For architectural changes: I have documented the design decision and notified affected teams. (N/A)

### Documentation & Communication

- [x] I have updated relevant documentation (README, ADRs, inline comments, API docs). (Release notes entry added under 2.30.0.)
- [ ] I have updated the Jira ticket status and added any relevant notes.

### Final Review

- [ ] I have performed a self-review on my PR and I am presenting my best work for my peers to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[OSDEV-3350]: https://opensupplyhub.atlassian.net/browse/OSDEV-3350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ