### PR TITLE
[Hotfix]OSDEV-3236: [SOC2] Phase 2 - set pgaudit.log to ddl,role after the extension is created

### DIFF
--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -347,7 +347,7 @@ variable "rds_shared_preload_libraries" {
 variable "rds_pgaudit_log" {
   description = "Comma-separated classes of SQL statements recorded by pgaudit. Classes: none, all, ddl, function, misc, misc_set, read, role, write; a class can be subtracted by prefixing it with '-' (e.g. \"all,-misc\"). Deliberately \"none\" for phase 1 of the staged rollout: CREATE EXTENSION pgaudit has to land before this is set, or DDL records are written without object type or object name. OSDEV-3236 flips it to \"ddl,role\". See doc/ops/database-auditing.md."
   type        = string
-  default     = "none"
+  default     = "ddl,role"
 
   validation {
     condition = alltrue([

--- a/doc/release/RELEASE-NOTES.md
+++ b/doc/release/RELEASE-NOTES.md
@@ -3,6 +3,24 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). The format is based on the `RELEASE-NOTES-TEMPLATE.md` file.
 
+## Release 2.29.1
+
+## Introduction
+* Product name: Open Supply Hub
+* Release date: August 28, 2026
+
+### Architecture/Environment changes
+* [OSDEV-3236](https://opensupplyhub.atlassian.net/browse/OSDEV-3236) - Turned on `pgaudit` session auditing by setting `pgaudit.log` to `ddl,role`, completing the two-phase rollout started by [OSDEV-2997](https://opensupplyhub.atlassian.net/browse/OSDEV-2997) in 2.29.0 and resolving the Vanta SOC 2 test `aws-rds-pgaudit-enabled`. The only code change is the `rds_pgaudit_log` default in `deployment/terraform/variables.tf`, from `none` to `ddl,role`. Auditing now records schema changes (`CREATE`/`ALTER`/`DROP` of tables, indexes, functions) and privilege changes (`GRANT`, `REVOKE`, `CREATE`/`ALTER`/`DROP ROLE`). `read` and `write` stay excluded because logging every SELECT, or every write on the ingestion path, would multiply log volume. The split into its own release is deliberate: `CREATE EXTENSION pgaudit` installs the event triggers that supply object type and object name for DDL records, and it can only run once the library is loaded at server start, so 2.29.0 had to load the library and create the extension first. `pgaudit.log` carries `apply_method = "pending-reboot"`, so each environment needs a Terraform apply plus a reboot.
+
+### Release instructions
+* [OSDEV-3236](https://opensupplyhub.atlassian.net/browse/OSDEV-3236) - Apply the `pgaudit.log` change, per environment. **Prerequisite**: 2.29.0's pgaudit steps must be complete in that environment — `SELECT extname FROM pg_extension WHERE extname = 'pgaudit';` must return a row. Do not proceed otherwise: enabling the `ddl` class without the extension produces DDL records with no object type or object name, which is the exact failure the two-release split exists to prevent.
+    1. Run **Deploy to AWS** with `deploy-mode` set to `terraform-plan-and-apply`. This applies the parameter change without rebuilding images, updating the ECS services, or running migrations. Check the plan in `s3://<settings-bucket>/terraform/` first: it should show `aws_db_parameter_group.default` changing and nothing else — in particular no `aws_ecs_task_definition` or `aws_ecs_service` changes.
+    2. Reboot the instance: `aws rds reboot-db-instance --db-instance-identifier opensupplyhub-enc-<env>`. Every environment runs `rds_multi_az = false`, so this is a hard restart with roughly 30-120 seconds of database downtime rather than a failover. Schedule it for Production.
+    3. Verify: `SHOW pgaudit.log;` (expect `ddl,role`). Then run a harmless DDL statement and confirm its audit record carries a populated object type and object name — that is what proves the extension was created before the class was enabled. Setting `pgaudit.log_client = on` and `pgaudit.log_level = notice` in the session shows the records directly in psql instead of the RDS log files.
+    4. Re-run the Vanta test `aws-rds-pgaudit-enabled` and confirm the environment passes. Check it only at this point — between 2.29.0 and 2.29.1 the test is expected to fail, and that is not a regression.
+* Run the sequence on Development and Staging before Production.
+
+
 ## Release 2.29.0
 
 ## Introduction


### PR DESCRIPTION
## Jira Ticket

[OSDEV-3236](https://opensupplyhub.atlassian.net/browse/OSDEV-3236)

Phase 2 of the rollout started by [OSDEV-2997](https://opensupplyhub.atlassian.net/browse/OSDEV-2997), which merged in 2.29.0.

---

## Summary of Changes

Turns on `pgaudit` session auditing by setting `pgaudit.log` to `ddl,role`, completing the two-phase rollout and resolving the Vanta SOC 2 test `aws-rds-pgaudit-enabled`.

**The whole functional change is one line** in `deployment/terraform/variables.tf`:

```diff
 variable "rds_pgaudit_log" {
-  default     = "none"
+  default     = "ddl,role"
```

**Why this is a separate release rather than part of OSDEV-2997.** From pgaudit's documentation:

> `CREATE EXTENSION pgaudit` must be called before `pgaudit.log` is set to ensure proper pgaudit functionality. The extension installs event triggers which add additional auditing for DDL. pgAudit will work without the extension installed but DDL statements will not have information about the object type and name.

The extension's SQL script creates the `pgaudit_ddl_command_end` and `pgaudit_sql_drop` event triggers, and `pgaudit.c` populates `objectType` / `objectName` from them. Because we audit the `ddl` class, enabling it before the extension existed would have produced DDL records naming no object — including 2.29.0's own `migrate` run, which is exactly the DDL most worth auditing. The extension cannot be created until the library is loaded, and the library only loads on reboot, so 2.29.0 shipped `none`, loaded the library and created the extension. This release is the first point at which enabling the class is correct.

**What is now audited.** Schema changes (`CREATE`/`ALTER`/`DROP` of tables, indexes, functions) and privilege changes (`GRANT`, `REVOKE`, `CREATE`/`ALTER`/`DROP ROLE`). `read` and `write` stay excluded: logging every SELECT, or every write on the ingestion path, would multiply log volume for little additional control value. The existing `validation` blocks on `rds_pgaudit_log` already reject unsupported classes and reject `none` combined with anything else, so no validation change is needed.

Release notes: new 2.29.1 section with the Architecture/Environment entry and the four-step Release instructions.

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Backend change (API, database, business logic)
- [ ] UI / frontend change
- [ ] Architectural change (affects structure, contracts, or shared modules)
- [ ] Refactor (no functional change)
- [ ] Breaking change (existing functionality may not work as before)
- [x] Documentation / tooling only

---

## Testing

**Prerequisite per environment — check before deploying this anywhere:**

```sql
SELECT extname FROM pg_extension WHERE extname = 'pgaudit';
```

Must return a row. If it does not, 2.29.0's phase-1 steps are incomplete in that environment and this release must not be applied there.

**Deployment, per environment:**

1. **Deploy to AWS** with `deploy-mode` set to `terraform-plan-and-apply`. Check the plan in `s3://<settings-bucket>/terraform/` first: it should show `aws_db_parameter_group.default` changing and nothing else — in particular no `aws_ecs_task_definition` or `aws_ecs_service` changes.
2. `aws rds reboot-db-instance --db-instance-identifier opensupplyhub-enc-<env>` — `pgaudit.log` carries `apply_method = "pending-reboot"`. Every environment runs `rds_multi_az = false`, so this is a hard restart with roughly 30-120 seconds of database downtime, not a failover. Schedule it for Production.
3. Verify.
4. Re-run the Vanta test.

**Verification — the check that actually matters:**

```sql
SET pgaudit.log_client = on;      -- echo audit records back to psql
SET pgaudit.log_level  = notice;  -- LOG sits below NOTICE, so psql would not show it

SHOW pgaudit.log;                 -- expect ddl,role

CREATE TABLE pgaudit_smoke (id int);   -- expect a DDL record
CREATE ROLE pgaudit_smoke_role;        -- expect a ROLE record
SELECT 1;                              -- expect NO record

DROP ROLE pgaudit_smoke_role;
DROP TABLE pgaudit_smoke;
```

A correct DDL record looks like:

```
AUDIT: SESSION,1,1,DDL,CREATE TABLE,TABLE,public.pgaudit_smoke,"CREATE TABLE pgaudit_smoke (id int);"
                                    ^^^^^ ^^^^^^^^^^^^^^^^^^^
                                   object      object name
                                    type
```

**`TABLE,public.pgaudit_smoke` must be populated.** If those fields are empty, the extension was not created before the class was enabled — the exact failure this two-release split exists to prevent, and grounds for rolling `rds_pgaudit_log` back to `none` while it is investigated.

`pgaudit.log`, `pgaudit.log_client` and `pgaudit.log_level` are all `PGC_SUSET`, so the master user can set them per session; the verification needs no further deploy. In normal operation the records go to the instance's local Postgres log (RDS console → Logs & events, or `aws rds download-db-log-file-portion`), not CloudWatch.

**Not performed:** nothing in this PR has been run against a real environment.

---

## Known TODO Items

N/A

---

## Checklist

### Implementation

- [x] My code follows the project's style guidelines and naming conventions.
- [x] I have removed debug logs, commented-out code, and unused imports.
- [x] Any AI-assisted code (e.g., Claude) has been reviewed, understood, and adapted to fit our codebase.
- [x] I have considered backward compatibility and migrations where applicable.
- [x] The diff contains no secrets, internal document/spreadsheet/folder IDs, internal board or channel identifiers, internal policy thresholds, or staff contact details — internal values are externalized to runtime configuration (see "Public repository hygiene" in AGENTS.md).

### Testing & Validation

- [x] I have manually tested the change in a local/dev environment.
- [ ] I have added or updated unit tests for the new/changed behavior.
- [ ] All existing tests pass locally.
- [ ] For UI changes: I have included screenshots or a recording, and verified responsive/cross-browser behavior.
- [ ] For backend changes: I have validated API contracts, error handling, and edge cases.
- [x] For architectural changes: I have documented the design decision and notified affected teams.

<!--
  No unit test applies: the change is a Terraform variable default. The
  behavioral verification is the psql check above, which requires a deployed
  environment. Please check these off after the Development rollout.
-->

### Documentation & Communication

- [x] I have updated relevant documentation (README, ADRs, inline comments, API docs).
- [x] I have updated the Jira ticket status and added any relevant notes.

### Final Review

- [x] I have performed a self-review on my PR and I am presenting my best work for my peers to review.


[OSDEV-3236]: https://opensupplyhub.atlassian.net/browse/OSDEV-3236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OSDEV-2997]: https://opensupplyhub.atlassian.net/browse/OSDEV-2997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ