### PR TITLE
OSDEV-3371: Platform UX Changes and Notification

### DIFF
--- a/src/django/api/mail.py
+++ b/src/django/api/mail.py
@@ -242,6 +242,41 @@ def send_claim_facility_revocation_email(request, facility_claim):
     )
 
 
+def send_claim_updated_by_claimant_notice(request, facility_claim, changes):
+    """
+    Internal notice to the Claims team when a claimant edits their own
+    pending claim (OSDEV-3371). `changes` is a list of human-readable
+    change descriptions (changed field names, attachment add/remove
+    events). The email deliberately carries only names and a dashboard
+    link — never document contents or download URLs.
+    """
+    subj_template = get_template('mail/claim_updated_by_claimant_subject.txt')
+    text_template = get_template('mail/claim_updated_by_claimant_body.txt')
+    html_template = get_template('mail/claim_updated_by_claimant_body.html')
+
+    facility = facility_claim.facility
+    notice_dictionary = {
+        'claim_id': facility_claim.id,
+        'facility_name': facility.name,
+        'facility_address': facility.address,
+        'facility_country': COUNTRY_NAMES.get(facility.country_code, ''),
+        'contributor_name': facility_claim.contributor.name,
+        'updated_at': facility_claim.claimant_updated_at,
+        'changes': changes,
+        'claim_dashboard_url': '{}/dashboard/claims/{}'.format(
+            make_oshub_url(request), facility_claim.id
+        ),
+    }
+
+    send_mail(
+        subj_template.render(notice_dictionary).rstrip(),
+        text_template.render(notice_dictionary),
+        settings.DEFAULT_FROM_EMAIL,
+        [settings.NOTIFICATION_EMAIL_TO],
+        html_message=html_template.render(notice_dictionary)
+    )
+
+
 def send_approved_claim_notice_to_one_contributor(request, claim, contributor):
     subj_template = get_template(
         'mail/approved_facility_claim_contributor_notice_subject.txt')

--- a/src/django/api/migrations/0235_add_claimant_updated_at.py
+++ b/src/django/api/migrations/0235_add_claimant_updated_at.py
@@ -1,0 +1,42 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """
+    OSDEV-3371. Adds FacilityClaim.claimant_updated_at, stamped only by
+    the claimant-facing pending-claim edit endpoints (field edits and
+    attachment changes), so the claims queue can show and sort by the
+    last claimant update without conflating moderator edits, which also
+    bump updated_at.
+    """
+
+    dependencies = [
+        ('api', '0234_claim_attachment_cascade_and_upload_prefix'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='facilityclaim',
+            name='claimant_updated_at',
+            field=models.DateTimeField(
+                blank=True,
+                help_text=(
+                    'When the claimant last updated this claim or its '
+                    'attachments through the pending-claim edit flow.'
+                ),
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name='historicalfacilityclaim',
+            name='claimant_updated_at',
+            field=models.DateTimeField(
+                blank=True,
+                help_text=(
+                    'When the claimant last updated this claim or its '
+                    'attachments through the pending-claim edit flow.'
+                ),
+                null=True,
+            ),
+        ),
+    ]

--- a/src/django/api/migrations/0235_add_claimant_updated_at.py
+++ b/src/django/api/migrations/0235_add_claimant_updated_at.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
     """
 
     dependencies = [
-        ('api', '0234_claim_attachment_cascade_and_upload_prefix'),
+        ('api', '0234_add_note_type_to_facility_claim_review_note'),
     ]
 
     operations = [

--- a/src/django/api/migrations/0236_claim_attachment_cascade_and_upload_prefix.py
+++ b/src/django/api/migrations/0236_claim_attachment_cascade_and_upload_prefix.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
     """
 
     dependencies = [
-        ('api', '0234_add_note_type_to_facility_claim_review_note'),
+        ('api', '0235_add_claimant_updated_at'),
     ]
 
     operations = [

--- a/src/django/api/models/facility/facility_claim.py
+++ b/src/django/api/models/facility/facility_claim.py
@@ -508,6 +508,15 @@ class FacilityClaim(models.Model):
     )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
+    # Stamped only by the claimant-facing pending-claim endpoints (field
+    # edits, attachment add/remove) — never by moderator actions, which
+    # also bump updated_at. This is what lets the claims queue show and
+    # sort by "updated by claimant" without conflating moderator edits.
+    claimant_updated_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        help_text=('When the claimant last updated this claim or its '
+                   'attachments through the pending-claim edit flow.'))
 
     history = HistoricalRecords(
         excluded_fields=['uuid', 'origin_source']

--- a/src/django/api/serializers/facility/edit_pending_claim_serializer.py
+++ b/src/django/api/serializers/facility/edit_pending_claim_serializer.py
@@ -43,6 +43,32 @@ class EditPendingClaimSerializer(FacilityCreateClaimSerializer):
     # Attachment files are sub-resource operations on pending claims.
     files = None
 
+    # In a partial PATCH an omitted field means "unchanged", so the
+    # only way a claimant can clear one of these optional values is to
+    # send null. The create serializer's definitions stay strict (the
+    # create flow simply omits them); the corresponding model fields
+    # are all null=True.
+    NULLABLE_ON_EDIT = (
+        'opening_date',
+        'estimated_annual_throughput',
+        'energy_coal',
+        'energy_natural_gas',
+        'energy_diesel',
+        'energy_kerosene',
+        'energy_biomass',
+        'energy_charcoal',
+        'energy_animal_waste',
+        'energy_electricity',
+        'energy_other',
+        'number_of_workers',
+        'facility_female_workers_percentage',
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field_name in self.NULLABLE_ON_EDIT:
+            self.fields[field_name].allow_null = True
+
     def validate(self, data):
         # The parent validate() rejects facilities that already have a
         # PENDING or APPROVED claim — that is create-time protection

--- a/src/django/api/serializers/facility/facility_claim_serializer.py
+++ b/src/django/api/serializers/facility/facility_claim_serializer.py
@@ -17,7 +17,8 @@ class FacilityClaimSerializer(ModelSerializer):
 
     class Meta:
         model = FacilityClaim
-        fields = ('id', 'created_at', 'updated_at', 'contributor_id', 'os_id',
+        fields = ('id', 'created_at', 'updated_at', 'claimant_updated_at',
+                  'contributor_id', 'os_id',
                   'contributor_name', 'facility_name', 'facility_address',
                   'facility_country_name', 'status', 'claim_decision')
 

--- a/src/django/api/templates/mail/claim_updated_by_claimant_body.html
+++ b/src/django/api/templates/mail/claim_updated_by_claimant_body.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>A claimant updated their pending claim on OS Hub</title>
+    </head>
+    <body>
+        <p>Hello,</p>
+        <p>
+            The claimant has updated their pending facility claim on Open
+            Supply Hub.
+        </p>
+        <p>Claim Details:</p>
+        <ul>
+            <li>Claim ID: {{ claim_id }}</li>
+            <li>
+                Facility: {{ facility_name }}, {{ facility_address }},
+                {{ facility_country }}
+            </li>
+            <li>Contributor: {{ contributor_name }}</li>
+            <li>Updated: {{ updated_at }}</li>
+        </ul>
+        <p>Changes made by the claimant:</p>
+        <ul>
+            {% for change in changes %}
+            <li>{{ change }}</li>
+            {% endfor %}
+        </ul>
+        <p>
+            <a href="{{ claim_dashboard_url }}">Review the claim in the
+            dashboard</a>
+        </p>
+        <p>
+            This is an automated notification. Documents are never attached
+            to this email; view them through the claim&rsquo;s page in the
+            dashboard.
+        </p>
+    </body>
+</html>

--- a/src/django/api/templates/mail/claim_updated_by_claimant_body.txt
+++ b/src/django/api/templates/mail/claim_updated_by_claimant_body.txt
@@ -1,0 +1,21 @@
+{% block content %}
+Hello,
+
+The claimant has updated their pending facility claim on Open Supply Hub.
+
+Claim Details:
+
+- Claim ID: {{ claim_id }}
+- Facility: {{ facility_name }}, {{ facility_address }}, {{ facility_country }}
+- Contributor: {{ contributor_name }}
+- Updated: {{ updated_at }}
+
+Changes made by the claimant:
+{% for change in changes %}
+- {{ change }}{% endfor %}
+
+Review the claim in the dashboard: {{ claim_dashboard_url }}
+
+This is an automated notification. Documents are never attached to this
+email; view them through the claim's page in the dashboard.
+{% endblock content %}

--- a/src/django/api/templates/mail/claim_updated_by_claimant_subject.txt
+++ b/src/django/api/templates/mail/claim_updated_by_claimant_subject.txt
@@ -1,0 +1,1 @@
+A claimant updated pending claim #{{ claim_id }} ({{ facility_name }})

--- a/src/django/api/tests/test_facility_download.py
+++ b/src/django/api/tests/test_facility_download.py
@@ -296,18 +296,25 @@ class FacilityDownloadTest(FacilityAPITestCaseBase):
             "business_linkedin_profile": "https://example.com",
         }
 
+        # File contents must start with the real magic bytes for their
+        # extension — attachment uploads validate content, not just the
+        # file name (OSDEV-3370).
         file_data = {
             'test_attachment_1.jpg': (
-                b'claimant_attachment_content_jpg', 'image/jpg'
+                b'\xff\xd8\xff\xe0claimant_attachment_content_jpg',
+                'image/jpg'
             ),
             'test_attachment_2.jpeg': (
-                b'claimant_attachment_content_jpeg', 'image/jpeg'
+                b'\xff\xd8\xff\xe0claimant_attachment_content_jpeg',
+                'image/jpeg'
             ),
             'test_attachment_3.png': (
-                b'claimant_attachment_content_png', 'image/png'
+                b'\x89PNG\r\n\x1a\nclaimant_attachment_content_png',
+                'image/png'
             ),
             'test_attachment_4.pdf': (
-                b'claimant_attachment_content_pdf', 'application/pdf'
+                b'%PDF-1.4 claimant_attachment_content_pdf',
+                'application/pdf'
             )
         }
 

--- a/src/django/api/tests/test_pending_claim_edit.py
+++ b/src/django/api/tests/test_pending_claim_edit.py
@@ -1,4 +1,5 @@
 import json
+from datetime import date
 
 from api.constants import FacilityClaimStatuses
 from api.models import (
@@ -157,6 +158,52 @@ class PendingClaimEditTest(APITestCase):
         self.claim.refresh_from_db()
         self.assertEqual('Only Name', self.claim.contact_person)
         self.assertEqual('Original Title', self.claim.job_title)
+
+    @override_switch('claim_a_facility', active=True)
+    def test_null_clears_optional_numeric_and_date_fields(self):
+        # In a partial PATCH omitted means "unchanged", so null is the
+        # only way a claimant can clear these values (e.g. unchecking
+        # an emissions section in the edit UI).
+        self.claim.energy_coal = 1000
+        self.claim.opening_date = date(2020, 1, 1)
+        self.claim.estimated_annual_throughput = 5000
+        self.claim.facility_workers_count = '50'
+        self.claim.save()
+
+        self.login()
+        response = self.client.patch(
+            self.pending_url,
+            {
+                'energy_coal': None,
+                'opening_date': None,
+                'estimated_annual_throughput': None,
+                'number_of_workers': None,
+            },
+            format='json',
+        )
+        self.assertEqual(200, response.status_code)
+
+        self.claim.refresh_from_db()
+        self.assertIsNone(self.claim.energy_coal)
+        self.assertIsNone(self.claim.opening_date)
+        self.assertIsNone(self.claim.estimated_annual_throughput)
+        self.assertIsNone(self.claim.facility_workers_count)
+
+        self.assertIsNone(response.data['energy_coal'])
+        self.assertIsNone(response.data['opening_date'])
+        self.assertIsNone(response.data['estimated_annual_throughput'])
+        self.assertIsNone(response.data['number_of_workers'])
+
+    @override_switch('claim_a_facility', active=True)
+    def test_null_is_rejected_for_non_clearable_fields(self):
+        self.login()
+        response = self.client.patch(
+            self.pending_url, {'your_name': None}, format='json'
+        )
+        self.assertEqual(400, response.status_code)
+
+        self.claim.refresh_from_db()
+        self.assertEqual('Original Name', self.claim.contact_person)
 
     @override_switch('claim_a_facility', active=True)
     def test_stranger_gets_404_not_403(self):
@@ -507,9 +554,12 @@ class PendingClaimNotificationAndListTest(APITestCase):
         self.login()
         self.assertIsNone(self.claim.claimant_updated_at)
 
-        response = self.client.patch(
-            self.pending_url, {'your_name': 'Someone Else'}, format='json'
-        )
+        # The notification is deferred with transaction.on_commit;
+        # TestCase never commits, so capture and execute the callbacks.
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.patch(
+                self.pending_url, {'your_name': 'Someone Else'}, format='json'
+            )
         self.assertEqual(200, response.status_code)
 
         self.claim.refresh_from_db()
@@ -530,9 +580,10 @@ class PendingClaimNotificationAndListTest(APITestCase):
         from django.core import mail as django_mail
 
         self.login()
-        response = self.client.patch(
-            self.pending_url, {'your_name': 'Someone'}, format='json'
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.patch(
+                self.pending_url, {'your_name': 'Someone'}, format='json'
+            )
         self.assertEqual(200, response.status_code)
         self.claim.refresh_from_db()
         self.assertIsNone(self.claim.claimant_updated_at)
@@ -543,11 +594,12 @@ class PendingClaimNotificationAndListTest(APITestCase):
         from django.core import mail as django_mail
 
         self.login()
-        response = self.client.post(
-            self.attachments_url,
-            {'files': [make_png('proof.png')]},
-            format='multipart',
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                self.attachments_url,
+                {'files': [make_png('proof.png')]},
+                format='multipart',
+            )
         self.assertEqual(200, response.status_code)
         self.claim.refresh_from_db()
         self.assertIsNotNone(self.claim.claimant_updated_at)

--- a/src/django/api/tests/test_pending_claim_edit.py
+++ b/src/django/api/tests/test_pending_claim_edit.py
@@ -435,3 +435,146 @@ class PendingClaimEditTest(APITestCase):
                 pk=attachment.id
             ).exists()
         )
+
+
+class PendingClaimNotificationAndListTest(APITestCase):
+    def setUp(self):
+        self.email = 'claimant2@example.com'
+        self.password = 'example123'
+        self.user = User.objects.create(email=self.email)
+        self.user.set_password(self.password)
+        self.user.save()
+        self.contributor = Contributor.objects.create(
+            name='Claimant Two', admin=self.user
+        )
+
+        self.facility_list = FacilityList.objects.create(
+            header='header', file_name='two', name='list-two'
+        )
+        self.source = Source.objects.create(
+            facility_list=self.facility_list,
+            source_type=Source.LIST,
+            is_active=True,
+            is_public=True,
+            contributor=self.contributor,
+        )
+        self.list_item = FacilityListItem.objects.create(
+            name='name two',
+            address='address two',
+            country_code='US',
+            sector=['Apparel'],
+            source=self.source,
+            row_index=1,
+            status=FacilityListItem.CONFIRMED_MATCH,
+        )
+        self.facility = Facility.objects.create(
+            name='name two',
+            address='address two',
+            country_code='US',
+            location=Point(0, 0),
+            created_from=self.list_item,
+        )
+        FacilityMatch.objects.create(
+            status=FacilityMatch.CONFIRMED,
+            facility=self.facility,
+            results='',
+            facility_list_item=self.list_item,
+        )
+        self.claim = FacilityClaim.objects.create(
+            facility=self.facility,
+            contributor=self.contributor,
+            contact_person='Someone',
+            job_title='Something',
+            status=FacilityClaimStatuses.PENDING,
+        )
+        self.pending_url = f'/api/facility-claims/{self.claim.id}/pending/'
+        self.attachments_url = (
+            f'/api/facility-claims/{self.claim.id}/attachments/'
+        )
+        self.claimed_url = '/api/facilities/claimed/'
+
+    def login(self):
+        self.client.post(
+            '/user-login/',
+            {'email': self.email, 'password': self.password},
+            format='json',
+        )
+
+    @override_switch('claim_a_facility', active=True)
+    def test_patch_stamps_claimant_updated_at_and_sends_email(self):
+        from django.core import mail as django_mail
+
+        self.login()
+        self.assertIsNone(self.claim.claimant_updated_at)
+
+        response = self.client.patch(
+            self.pending_url, {'your_name': 'Someone Else'}, format='json'
+        )
+        self.assertEqual(200, response.status_code)
+
+        self.claim.refresh_from_db()
+        self.assertIsNotNone(self.claim.claimant_updated_at)
+
+        self.assertEqual(1, len(django_mail.outbox))
+        message = django_mail.outbox[0]
+        self.assertIn(str(self.claim.id), message.subject)
+        self.assertIn('contact_person', message.body)
+        self.assertIn(
+            f'/dashboard/claims/{self.claim.id}', message.body
+        )
+        # The notification carries names and a link, never documents.
+        self.assertEqual([], message.attachments)
+
+    @override_switch('claim_a_facility', active=True)
+    def test_noop_patch_sends_no_email_and_no_stamp(self):
+        from django.core import mail as django_mail
+
+        self.login()
+        response = self.client.patch(
+            self.pending_url, {'your_name': 'Someone'}, format='json'
+        )
+        self.assertEqual(200, response.status_code)
+        self.claim.refresh_from_db()
+        self.assertIsNone(self.claim.claimant_updated_at)
+        self.assertEqual(0, len(django_mail.outbox))
+
+    @override_switch('claim_a_facility', active=True)
+    def test_attachment_add_stamps_and_notifies(self):
+        from django.core import mail as django_mail
+
+        self.login()
+        response = self.client.post(
+            self.attachments_url,
+            {'files': [make_png('proof.png')]},
+            format='multipart',
+        )
+        self.assertEqual(200, response.status_code)
+        self.claim.refresh_from_db()
+        self.assertIsNotNone(self.claim.claimant_updated_at)
+        self.assertEqual(1, len(django_mail.outbox))
+        self.assertIn('proof.png', django_mail.outbox[0].body)
+
+    @override_switch('claim_a_facility', active=True)
+    def test_claimed_list_defaults_to_approved_only(self):
+        self.login()
+        response = self.client.get(self.claimed_url)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(0, len(json.loads(response.content)))
+
+    @override_switch('claim_a_facility', active=True)
+    def test_claimed_list_statuses_param_includes_pending(self):
+        self.login()
+        response = self.client.get(
+            f'{self.claimed_url}?statuses=PENDING,APPROVED'
+        )
+        self.assertEqual(200, response.status_code)
+        data = json.loads(response.content)
+        self.assertEqual(1, len(data))
+        self.assertEqual(FacilityClaimStatuses.PENDING, data[0]['status'])
+        self.assertIn('claimant_updated_at', data[0])
+
+    @override_switch('claim_a_facility', active=True)
+    def test_claimed_list_rejects_invalid_status(self):
+        self.login()
+        response = self.client.get(f'{self.claimed_url}?statuses=BOGUS')
+        self.assertEqual(400, response.status_code)

--- a/src/django/api/views/facility/facilities_view_set.py
+++ b/src/django/api/views/facility/facilities_view_set.py
@@ -2489,10 +2489,37 @@ class FacilitiesViewSet(ListModelMixin,
 
         if not switch_is_active('claim_a_facility'):
             raise NotFound()
+
+        # Default stays approved-only so existing consumers are
+        # unaffected; My Facilities passes ?statuses=PENDING,APPROVED to
+        # also show claims awaiting review (OSDEV-3371).
+        valid_statuses = {
+            FacilityClaimStatuses.PENDING,
+            FacilityClaimStatuses.APPROVED,
+            FacilityClaimStatuses.DENIED,
+            FacilityClaimStatuses.REVOKED,
+        }
+        statuses_param = request.query_params.get('statuses')
+        if statuses_param:
+            statuses = [
+                status.strip().upper()
+                for status in statuses_param.split(',')
+                if status.strip()
+            ]
+            invalid = set(statuses) - valid_statuses
+            if invalid:
+                raise BadRequestException(
+                    'Invalid claim statuses: {}.'.format(
+                        ', '.join(sorted(invalid))
+                    )
+                )
+        else:
+            statuses = [FacilityClaimStatuses.APPROVED]
+
         try:
             claims = FacilityClaim.objects.filter(
                 contributor=request.user.contributor,
-                status=FacilityClaimStatuses.APPROVED)
+                status__in=statuses)
         except Contributor.DoesNotExist as exc:
             raise NotFound(
                 'The current User does not have an associated Contributor'

--- a/src/django/api/views/facility/facility_claim_view_set.py
+++ b/src/django/api/views/facility/facility_claim_view_set.py
@@ -670,12 +670,20 @@ class FacilityClaimViewSet(ModelViewSet):
     def __notify_claims_team_of_update(request, claim, changes):
         """
         AC #5: the Claims team is notified on every claimant save. Sent
-        best-effort — a mail failure must not roll back the edit.
+        best-effort — a mail failure must not roll back the edit — and
+        deferred with transaction.on_commit, so a save that ends up
+        rolled back sends nothing, and the claim row lock is not held
+        open across the SMTP round-trip.
         """
-        try:
-            send_claim_updated_by_claimant_notice(request, claim, changes)
-        except Exception:
-            _report_facility_claim_email_error_to_rollbar(claim)
+        def send():
+            try:
+                send_claim_updated_by_claimant_notice(
+                    request, claim, changes
+                )
+            except Exception:
+                _report_facility_claim_email_error_to_rollbar(claim)
+
+        transaction.on_commit(send)
 
     def __get_owned_pending_claim(self, request, pk, for_update=False):
         """

--- a/src/django/api/views/facility/facility_claim_view_set.py
+++ b/src/django/api/views/facility/facility_claim_view_set.py
@@ -31,6 +31,7 @@ from ...mail import (
     send_claim_facility_denial_email,
     send_claim_facility_revocation_email,
     send_claim_update_notice_to_list_contributors,
+    send_claim_updated_by_claimant_notice,
     send_message_to_claimant_email,
 )
 from ...helpers.attachment_download import generate_attachment_download_url
@@ -654,6 +655,28 @@ class FacilityClaimViewSet(ModelViewSet):
         geocode_result = geocode_address(address, country_code)
         return Response(geocode_result)
 
+    @staticmethod
+    def __stamp_claimant_update(claim):
+        """
+        Record that the claimant changed something on this claim.
+        claimant_updated_at is deliberately separate from updated_at,
+        which moderator actions also bump — the claims queue sorts on
+        this field to surface claims edited since review started.
+        """
+        claim.claimant_updated_at = timezone.now()
+        claim.save(update_fields=['claimant_updated_at', 'updated_at'])
+
+    @staticmethod
+    def __notify_claims_team_of_update(request, claim, changes):
+        """
+        AC #5: the Claims team is notified on every claimant save. Sent
+        best-effort — a mail failure must not roll back the edit.
+        """
+        try:
+            send_claim_updated_by_claimant_notice(request, claim, changes)
+        except Exception:
+            _report_facility_claim_email_error_to_rollbar(claim)
+
     def __get_owned_pending_claim(self, request, pk, for_update=False):
         """
         Fetch a claim the requesting user may edit: they are its
@@ -714,10 +737,17 @@ class FacilityClaimViewSet(ModelViewSet):
 
         changed_fields = serializer.apply_to_claim(claim)
         if changed_fields:
+            claim.claimant_updated_at = timezone.now()
             # simple-history records this save with history_user set to
             # the claimant via HistoryRequestMiddleware, which is what
             # lets moderators see exactly what the claimant changed.
             claim.save()
+            self.__notify_claims_team_of_update(
+                request,
+                claim,
+                ['Updated {}'.format(field)
+                 for field in sorted(changed_fields)],
+            )
 
         return Response(PendingClaimSerializer(claim).data)
 
@@ -746,8 +776,15 @@ class FacilityClaimViewSet(ModelViewSet):
         ).count()
         validate_attachment_files(files, existing_count=existing_count)
 
-        for file in files:
-            create_claim_attachment(file, claim)
+        created = [create_claim_attachment(file, claim) for file in files]
+
+        self.__stamp_claimant_update(claim)
+        self.__notify_claims_team_of_update(
+            request,
+            claim,
+            ['Added document: {}'.format(attachment.file_name)
+             for attachment in created],
+        )
 
         return Response(PendingClaimSerializer(claim).data)
 
@@ -775,7 +812,15 @@ class FacilityClaimViewSet(ModelViewSet):
         except FacilityClaimAttachments.DoesNotExist as exc:
             raise NotFound() from exc
 
+        deleted_file_name = attachment.file_name
         delete_claim_attachment(attachment)
+
+        self.__stamp_claimant_update(claim)
+        self.__notify_claims_team_of_update(
+            request,
+            claim,
+            ['Removed document: {}'.format(deleted_file_name)],
+        )
 
         return Response(PendingClaimSerializer(claim).data)
 

--- a/src/django/sqls/0232_facility_processing_value_index.sql
+++ b/src/django/sqls/0232_facility_processing_value_index.sql
@@ -18,8 +18,7 @@ the recompute_facility_processing_value_index management command after them
 instead, and disable the triggers below for the duration if the run is large
 enough for the counter updates to matter.
 */
-DROP TABLE IF EXISTS api_facility_processing_value;
-DROP TABLE IF EXISTS api_facility_processing_value_variant;
+DROP MATERIALIZED VIEW IF EXISTS api_facility_processing_value;
 
 CREATE TABLE api_facility_processing_value (
 	kind TEXT NOT NULL,

--- a/src/django/sqls/0232_facility_processing_value_index.sql
+++ b/src/django/sqls/0232_facility_processing_value_index.sql
@@ -18,7 +18,8 @@ the recompute_facility_processing_value_index management command after them
 instead, and disable the triggers below for the duration if the run is large
 enough for the counter updates to matter.
 */
-DROP MATERIALIZED VIEW IF EXISTS api_facility_processing_value;
+DROP TABLE IF EXISTS api_facility_processing_value;
+DROP TABLE IF EXISTS api_facility_processing_value_variant;
 
 CREATE TABLE api_facility_processing_value (
 	kind TEXT NOT NULL,

--- a/src/react/src/actions/claimedFacilities.jsx
+++ b/src/react/src/actions/claimedFacilities.jsx
@@ -18,12 +18,12 @@ export const completeFetchClaimedFacilities = createAction(
 );
 export const clearClaimedFacilities = createAction('CLEAR_CLAIMED_FACILITIES');
 
-export function fetchClaimedFacilities() {
+export function fetchClaimedFacilities(statuses) {
     return dispatch => {
         dispatch(startFetchClaimedFacilities());
 
         return apiRequest
-            .get(makeGetClaimedFacilitiesURL())
+            .get(makeGetClaimedFacilitiesURL(statuses))
             .then(({ data }) => dispatch(completeFetchClaimedFacilities(data)))
             .catch(err =>
                 dispatch(

--- a/src/react/src/actions/pendingClaimEdit.js
+++ b/src/react/src/actions/pendingClaimEdit.js
@@ -69,11 +69,20 @@ export function fetchPendingClaim(claimID) {
 }
 
 /*
- * Saving a pending claim edit is up to two requests: newly picked
- * document files are uploaded first (multipart POST to the attachments
- * sub-resource), then the field edits go out as a JSON PATCH. The PATCH
+ * Saving a pending claim edit is up to two requests: the field edits go
+ * out as a JSON PATCH first, then newly picked document files are
+ * uploaded (multipart POST to the attachments sub-resource). The last
  * response is the fresh pending-claim payload, which becomes the new
  * source of truth for the form.
+ *
+ * The PATCH deliberately runs FIRST: if it fails validation, nothing
+ * has been uploaded yet, so the still-populated pickers can safely
+ * retry without duplicating attachments. On the reverse ordering a
+ * failed PATCH left the files already stored while the pickers kept
+ * them, and the retry uploaded them a second time. If the upload step
+ * fails instead, the retried PATCH is a no-op server-side (no changes,
+ * no email, no claimant_updated_at stamp), so retrying is safe there
+ * too.
  */
 export function savePendingClaim(claimID) {
     return (dispatch, getState) => {
@@ -88,9 +97,9 @@ export function savePendingClaim(claimID) {
             ...(formData.companyAddressVerificationDocuments || []),
         ];
 
-        const uploadNewFiles = () => {
+        const uploadNewFiles = patchResponseData => {
             if (newFiles.length === 0) {
-                return Promise.resolve();
+                return Promise.resolve({ data: patchResponseData });
             }
 
             const postData = new FormData();
@@ -102,13 +111,12 @@ export function savePendingClaim(claimID) {
             );
         };
 
-        return uploadNewFiles()
-            .then(() =>
-                apiRequest.patch(
-                    makePendingClaimURL(claimID),
-                    buildPendingClaimPatchPayload(formData),
-                ),
+        return apiRequest
+            .patch(
+                makePendingClaimURL(claimID),
+                buildPendingClaimPatchPayload(formData),
             )
+            .then(({ data }) => uploadNewFiles(data))
             .then(({ data }) =>
                 dispatch(
                     completeSavePendingClaim({

--- a/src/react/src/actions/pendingClaimEdit.js
+++ b/src/react/src/actions/pendingClaimEdit.js
@@ -1,0 +1,151 @@
+import { createAction } from 'redux-act';
+
+import apiRequest from '../util/apiRequest';
+
+import {
+    makePendingClaimURL,
+    makePendingClaimAttachmentsURL,
+    makePendingClaimAttachmentURL,
+    logErrorAndDispatchFailure,
+} from '../util/util';
+
+import {
+    pendingClaimApiToFormData,
+    buildPendingClaimPatchPayload,
+} from '../components/PendingClaimEdit/utils';
+
+export const startFetchPendingClaim = createAction('START_FETCH_PENDING_CLAIM');
+export const failFetchPendingClaim = createAction('FAIL_FETCH_PENDING_CLAIM');
+export const completeFetchPendingClaim = createAction(
+    'COMPLETE_FETCH_PENDING_CLAIM',
+);
+
+export const updatePendingClaimFormField = createAction(
+    'UPDATE_PENDING_CLAIM_FORM_FIELD',
+);
+
+export const startSavePendingClaim = createAction('START_SAVE_PENDING_CLAIM');
+export const failSavePendingClaim = createAction('FAIL_SAVE_PENDING_CLAIM');
+export const completeSavePendingClaim = createAction(
+    'COMPLETE_SAVE_PENDING_CLAIM',
+);
+
+export const startDeletePendingClaimAttachment = createAction(
+    'START_DELETE_PENDING_CLAIM_ATTACHMENT',
+);
+export const failDeletePendingClaimAttachment = createAction(
+    'FAIL_DELETE_PENDING_CLAIM_ATTACHMENT',
+);
+export const completeDeletePendingClaimAttachment = createAction(
+    'COMPLETE_DELETE_PENDING_CLAIM_ATTACHMENT',
+);
+
+export const resetPendingClaimEdit = createAction('RESET_PENDING_CLAIM_EDIT');
+
+export function fetchPendingClaim(claimID) {
+    return dispatch => {
+        dispatch(startFetchPendingClaim());
+
+        return apiRequest
+            .get(makePendingClaimURL(claimID))
+            .then(({ data }) =>
+                dispatch(
+                    completeFetchPendingClaim({
+                        data,
+                        formData: pendingClaimApiToFormData(data),
+                    }),
+                ),
+            )
+            .catch(err =>
+                dispatch(
+                    logErrorAndDispatchFailure(
+                        err,
+                        'An error prevented fetching this pending claim',
+                        failFetchPendingClaim,
+                    ),
+                ),
+            );
+    };
+}
+
+/*
+ * Saving a pending claim edit is up to two requests: newly picked
+ * document files are uploaded first (multipart POST to the attachments
+ * sub-resource), then the field edits go out as a JSON PATCH. The PATCH
+ * response is the fresh pending-claim payload, which becomes the new
+ * source of truth for the form.
+ */
+export function savePendingClaim(claimID) {
+    return (dispatch, getState) => {
+        const {
+            pendingClaimEdit: { formData },
+        } = getState();
+
+        dispatch(startSavePendingClaim());
+
+        const newFiles = [
+            ...(formData.employmentVerificationDocuments || []),
+            ...(formData.companyAddressVerificationDocuments || []),
+        ];
+
+        const uploadNewFiles = () => {
+            if (newFiles.length === 0) {
+                return Promise.resolve();
+            }
+
+            const postData = new FormData();
+            newFiles.forEach(file => postData.append('files', file));
+
+            return apiRequest.post(
+                makePendingClaimAttachmentsURL(claimID),
+                postData,
+            );
+        };
+
+        return uploadNewFiles()
+            .then(() =>
+                apiRequest.patch(
+                    makePendingClaimURL(claimID),
+                    buildPendingClaimPatchPayload(formData),
+                ),
+            )
+            .then(({ data }) =>
+                dispatch(
+                    completeSavePendingClaim({
+                        data,
+                        formData: pendingClaimApiToFormData(data),
+                    }),
+                ),
+            )
+            .catch(err =>
+                dispatch(
+                    logErrorAndDispatchFailure(
+                        err,
+                        'An error prevented saving your claim updates',
+                        failSavePendingClaim,
+                    ),
+                ),
+            );
+    };
+}
+
+export function deletePendingClaimAttachment(claimID, attachmentID) {
+    return dispatch => {
+        dispatch(startDeletePendingClaimAttachment());
+
+        return apiRequest
+            .delete(makePendingClaimAttachmentURL(claimID, attachmentID))
+            .then(({ data }) =>
+                dispatch(completeDeletePendingClaimAttachment({ data })),
+            )
+            .catch(err =>
+                dispatch(
+                    logErrorAndDispatchFailure(
+                        err,
+                        'An error prevented removing this document',
+                        failDeletePendingClaimAttachment,
+                    ),
+                ),
+            );
+    };
+}

--- a/src/react/src/components/ClaimFacilityStepper.jsx
+++ b/src/react/src/components/ClaimFacilityStepper.jsx
@@ -7,15 +7,11 @@ import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import clamp from 'lodash/clamp';
-import constant from 'lodash/constant';
-
-import Dialog from '@material-ui/core/Dialog';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogActions from '@material-ui/core/DialogActions';
 
 import ClaimFacilityIntroStep from './ClaimFacilityIntroStep';
 import ClaimFacilitySupportDocs from './ClaimFacilitySupportDocs';
 import ClaimFacilityAdditionalData from './ClaimFacilityAdditionalData';
+import ClaimOutcomeDialog from './ClaimOutcomeDialog';
 
 import { submitClaimAFacilityData } from '../actions/claimFacility';
 
@@ -51,30 +47,6 @@ const stepperStyles = theme =>
             },
         }),
     });
-
-const popupDialogStyles = Object.freeze({
-    containerStyles: Object.freeze({
-        padding: '35px',
-    }),
-    titleStyles: Object.freeze({
-        margin: 'auto',
-        textAlign: 'center',
-        color: COLOURS.NEAR_BLACK,
-        paddingBottom: '10px',
-        fontSize: '2.125rem',
-        fontWeight: '400',
-        lineHeight: '1.20588em',
-    }),
-    contentStyles: Object.freeze({
-        fontSize: '20px',
-        margin: 'auto',
-        textAlign: 'center',
-        paddingTop: '10px',
-    }),
-    actionStyles: Object.freeze({
-        justifyContent: 'center',
-    }),
-});
 
 const claimFacilityStepperStyles = Object.freeze({
     containerStyles: Object.freeze({
@@ -147,8 +119,6 @@ const steps = Object.freeze([
         stepInputIsValid: claimAFacilityFormIsValid,
     }),
 ]);
-
-const InvisibleDiv = constant(<div style={{ display: 'none ' }} />);
 
 const ClaimFacilityStepper = ({
     fetching,
@@ -298,51 +268,22 @@ const ClaimFacilityStepper = ({
 
     return (
         <div style={claimFacilityStepperStyles.containerStyles}>
-            <Dialog open={dialogIsOpen}>
-                {dialogIsOpen ? (
-                    <div style={popupDialogStyles.containerStyles}>
-                        <DialogContent>
-                            <Typography
-                                variant="title"
-                                style={popupDialogStyles.titleStyles}
-                            >
-                                Thank you for submitting your claim request!
-                            </Typography>
-                            <Typography style={popupDialogStyles.contentStyles}>
-                                You will receive a notification once it has been
-                                reviewed.
-                            </Typography>
-                            <hr
-                                style={{
-                                    color: COLOURS.GREY,
-                                    backgroundColor: COLOURS.GREY,
-                                    height: 1,
-                                }}
-                            />
-                        </DialogContent>
-                        <DialogActions style={popupDialogStyles.actionStyles}>
-                            <Button
-                                variant="contained"
-                                color="primary"
-                                href="/claimed"
-                                className={classes.popupButtonStyles}
-                            >
-                                View My Approved Claims
-                            </Button>
-                            <Button
-                                variant="contained"
-                                color="primary"
-                                href={mapRoute}
-                                className={classes.popupButtonStyles}
-                            >
-                                Search OS Hub
-                            </Button>
-                        </DialogActions>
-                    </div>
-                ) : (
-                    <InvisibleDiv />
-                )}
-            </Dialog>
+            <ClaimOutcomeDialog
+                open={dialogIsOpen}
+                title="Thank you for submitting your claim request!"
+                body="You will receive a notification once it has been reviewed."
+                actions={[
+                    {
+                        label: 'View My Approved Claims',
+                        href: '/claimed',
+                        secondary: true,
+                    },
+                    {
+                        label: 'Search OS Hub',
+                        href: mapRoute,
+                    },
+                ]}
+            />
             <div style={claimFacilityStepperStyles.formContainerStyles}>
                 {activeStepName ===
                 facilityClaimStepsNames.CLAIM_PROD_LOCATION ? (

--- a/src/react/src/components/ClaimOutcomeDialog.jsx
+++ b/src/react/src/components/ClaimOutcomeDialog.jsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { arrayOf, bool, func, object, shape, string } from 'prop-types';
+import Dialog from '@material-ui/core/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogActions from '@material-ui/core/DialogActions';
+import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography';
+import { withStyles } from '@material-ui/core/styles';
+
+import { primaryButtonStyles } from './InitialClaimFlow/ClaimForm/styles';
+
+/*
+ * Generic outcome dialog for the claim flows (OSDEV-3371): shown after
+ * submitting a claim (ClaimForm, ClaimFacilityStepper) and after saving
+ * a pending claim edit (PendingClaimEdit). Texts and actions come in as
+ * props; the structure and styling follow the v1 claim flow's success
+ * dialog.
+ */
+const claimOutcomeDialogStyles = theme =>
+    Object.freeze({
+        dialogTitle: Object.freeze({
+            fontSize: '36px',
+            fontWeight: theme.typography.fontWeightSemiBoldPlus,
+            display: 'flex',
+            alignItems: 'center',
+            textAlign: 'center',
+            justifyContent: 'center',
+        }),
+        dialogBodyText: Object.freeze({
+            textAlign: 'center',
+            fontSize: '18px',
+        }),
+        dialogActions: Object.freeze({
+            justifyContent: 'center',
+            padding: theme.spacing.unit * 2,
+            gap: '24px',
+            [theme.breakpoints.down('sm')]: {
+                flexDirection: 'column',
+                gap: '12px',
+            },
+        }),
+        secondaryButton: Object.freeze({
+            width: '200px',
+            height: '49px',
+            borderRadius: 0,
+            textTransform: 'none',
+            fontSize: '18px',
+            fontWeight: theme.typography.fontWeightExtraBold,
+            border: '1px solid #0D1128',
+            [theme.breakpoints.down('sm')]: {
+                width: '100%',
+            },
+        }),
+        primaryButton: primaryButtonStyles(theme),
+    });
+
+function ClaimOutcomeDialog({ classes, open, title, body, actions }) {
+    return (
+        <Dialog open={open}>
+            <DialogTitle className={classes.dialogTitle}>
+                <Typography className={classes.dialogTitle}>{title}</Typography>
+            </DialogTitle>
+            <DialogContent>
+                <Typography variant="body1" className={classes.dialogBodyText}>
+                    {body}
+                </Typography>
+            </DialogContent>
+            <DialogActions className={classes.dialogActions}>
+                {actions.map(action => (
+                    <Button
+                        key={action.label}
+                        variant="contained"
+                        color="primary"
+                        onClick={action.onClick}
+                        href={action.href}
+                        className={
+                            action.secondary
+                                ? classes.secondaryButton
+                                : classes.primaryButton
+                        }
+                    >
+                        {action.label}
+                    </Button>
+                ))}
+            </DialogActions>
+        </Dialog>
+    );
+}
+
+ClaimOutcomeDialog.defaultProps = {
+    open: false,
+};
+
+ClaimOutcomeDialog.propTypes = {
+    classes: object.isRequired,
+    open: bool,
+    title: string.isRequired,
+    body: string.isRequired,
+    actions: arrayOf(
+        shape({
+            label: string.isRequired,
+            onClick: func,
+            href: string,
+            secondary: bool,
+        }),
+    ).isRequired,
+};
+
+export default withStyles(claimOutcomeDialogStyles)(ClaimOutcomeDialog);

--- a/src/react/src/components/ClaimedFacilities.jsx
+++ b/src/react/src/components/ClaimedFacilities.jsx
@@ -3,16 +3,27 @@ import { Switch, Route } from 'react-router-dom';
 
 import ClaimedFacilitiesList from './ClaimedFacilitiesList';
 import ClaimedFacilitiesDetails from './ClaimedFacilitiesDetails/ClaimedFacilitiesDetails';
+import PendingClaimEdit from './PendingClaimEdit/PendingClaimEdit';
 import RouteNotFound from './RouteNotFound';
 
 import {
     claimedFacilitiesRoute,
     claimedFacilitiesDetailRoute,
+    pendingClaimEditRoute,
 } from '../util/constants';
 
 export default function ClaimedFacilities() {
     return (
         <Switch>
+            {/*
+                Registered before the :claimID detail route so 'pending'
+                is never captured as a claim id.
+            */}
+            <Route
+                exact
+                path={pendingClaimEditRoute}
+                component={PendingClaimEdit}
+            />
             <Route
                 exact
                 path={claimedFacilitiesDetailRoute}

--- a/src/react/src/components/ClaimedFacilitiesList.jsx
+++ b/src/react/src/components/ClaimedFacilitiesList.jsx
@@ -31,9 +31,11 @@ function ClaimedFacilitiesList({
     clearClaimed,
     userHasSignedIn,
 }) {
-    const TITLE = 'My Claimed Facilities';
+    const TITLE = 'My Facility Claims';
     useEffect(() => {
-        getClaimed();
+        // Pending claims are shown alongside approved ones so claimants
+        // can view and edit claims awaiting review (OSDEV-2278).
+        getClaimed(['PENDING', 'APPROVED']);
 
         return () => clearClaimed();
     }, [getClaimed, clearClaimed]);
@@ -63,10 +65,10 @@ function ClaimedFacilitiesList({
                             variant="body1"
                             style={claimFacilitiesListStyle.bodyStyle}
                         >
-                            You do not have any approved facility claims. Search
-                            for your facility and make a request to claim it.
-                            Claiming your facility will enable you to add
-                            business information, including production details,
+                            You do not have any facility claims. Search for your
+                            facility and make a request to claim it. Claiming
+                            your facility will enable you to add business
+                            information, including production details,
                             certifications, minimum order quantities and lead
                             times.
                         </Typography>
@@ -124,7 +126,7 @@ function mapStateToProps({
 
 function mapDispatchToProps(dispatch) {
     return {
-        getClaimed: () => dispatch(fetchClaimedFacilities()),
+        getClaimed: statuses => dispatch(fetchClaimedFacilities(statuses)),
         clearClaimed: () => dispatch(clearClaimedFacilities()),
     };
 }

--- a/src/react/src/components/ClaimedFacilitiesListTable.jsx
+++ b/src/react/src/components/ClaimedFacilitiesListTable.jsx
@@ -7,10 +7,16 @@ import TableHead from '@material-ui/core/TableHead';
 import TableBody from '@material-ui/core/TableBody';
 import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
+import Chip from '@material-ui/core/Chip';
 
 import { facilityClaimsListPropType } from '../util/propTypes';
+import { facilityClaimStatusChoicesEnum } from '../util/constants';
+import COLOURS from '../util/COLOURS';
 
-import { makeClaimedFacilityDetailsLink } from '../util/util';
+import {
+    makeClaimedFacilityDetailsLink,
+    makePendingClaimEditLink,
+} from '../util/util';
 
 const dashboardClaimsListTableStyles = Object.freeze({
     containerStyles: Object.freeze({
@@ -23,11 +29,28 @@ const dashboardClaimsListTableStyles = Object.freeze({
     osIdColumnStyles: Object.freeze({
         width: '20%',
     }),
+    pendingChipStyles: Object.freeze({
+        backgroundColor: COLOURS.PALE_LIGHT_YELLOW,
+    }),
+    approvedChipStyles: Object.freeze({
+        backgroundColor: COLOURS.MINT_GREEN,
+    }),
 });
 
+const statusChipStyle = status =>
+    status === facilityClaimStatusChoicesEnum.PENDING
+        ? dashboardClaimsListTableStyles.pendingChipStyles
+        : dashboardClaimsListTableStyles.approvedChipStyles;
+
 function ClaimedFacilitiesListTable({ data, history: { push } }) {
-    const makeRowClickHandler = claimID => () =>
-        push(makeClaimedFacilityDetailsLink(claimID));
+    // A pending claim opens the pending-claim edit view; an approved
+    // claim opens the claimed-facility profile editor, as before.
+    const makeRowClickHandler = claim => () =>
+        push(
+            claim.status === facilityClaimStatusChoicesEnum.PENDING
+                ? makePendingClaimEditLink(claim.id)
+                : makeClaimedFacilityDetailsLink(claim.id),
+        );
 
     return (
         <Paper style={dashboardClaimsListTableStyles.containerStyles}>
@@ -38,6 +61,7 @@ function ClaimedFacilitiesListTable({ data, history: { push } }) {
                         <TableCell>OS ID</TableCell>
                         <TableCell>Address</TableCell>
                         <TableCell>Country</TableCell>
+                        <TableCell>Status</TableCell>
                     </TableRow>
                 </TableHead>
                 <TableBody>
@@ -45,13 +69,19 @@ function ClaimedFacilitiesListTable({ data, history: { push } }) {
                         <TableRow
                             hover
                             key={claim.id}
-                            onClick={makeRowClickHandler(claim.id)}
+                            onClick={makeRowClickHandler(claim)}
                             style={dashboardClaimsListTableStyles.rowStyles}
                         >
                             <TableCell>{claim.facility_name}</TableCell>
                             <TableCell>{claim.os_id}</TableCell>
                             <TableCell>{claim.facility_address}</TableCell>
                             <TableCell>{claim.facility_country_name}</TableCell>
+                            <TableCell>
+                                <Chip
+                                    label={claim.status}
+                                    style={statusChipStyle(claim.status)}
+                                />
+                            </TableCell>
                         </TableRow>
                     ))}
                 </TableBody>

--- a/src/react/src/components/DashboardClaimsListTable.jsx
+++ b/src/react/src/components/DashboardClaimsListTable.jsx
@@ -163,7 +163,7 @@ function DashboardClaimsListTable({
             {loading || fetching ? (
                 <TableBody>
                     <TableRow>
-                        <TableCell colSpan={8}>
+                        <TableCell colSpan={9}>
                             <CircularProgress
                                 size={25}
                                 className={classes.loaderStyle}
@@ -219,6 +219,13 @@ function DashboardClaimsListTable({
                             </TableCell>
                             <TableCell padding="dense">
                                 {moment(claim.updated_at).format('LL')}
+                            </TableCell>
+                            <TableCell padding="dense">
+                                {claim.claimant_updated_at !== null
+                                    ? moment(claim.claimant_updated_at).format(
+                                          'LL',
+                                      )
+                                    : EMPTY_PLACEHOLDER}
                             </TableCell>
                         </TableRow>
                     ))}

--- a/src/react/src/components/DashboardClaimsListTableHeader.jsx
+++ b/src/react/src/components/DashboardClaimsListTableHeader.jsx
@@ -55,6 +55,12 @@ const claimsListHeadCells = [
         disablePadding: true,
         label: 'Last Updated',
     },
+    {
+        id: 'claimant_updated_at',
+        numeric: false,
+        disablePadding: true,
+        label: 'Updated by Claimant',
+    },
 ];
 
 function DashboardClaimsListTableHeader({

--- a/src/react/src/components/InitialClaimFlow/ClaimForm/ClaimEmissionsEstimate/ClaimEmissionsEstimate.jsx
+++ b/src/react/src/components/InitialClaimFlow/ClaimForm/ClaimEmissionsEstimate/ClaimEmissionsEstimate.jsx
@@ -5,8 +5,12 @@ import EmissionsEstimateForm from '../../../FreeEmissionsEstimate/EmissionsEstim
 import { updateClaimFormField } from '../../../../actions/claimForm';
 
 /**
- * Wrapper component for EmissionsEstimateForm connected to claimForm Redux state.
- * Used in the initial claim flow (ProfileStep).
+ * Wrapper component for EmissionsEstimateForm connected to claimForm Redux
+ * state. Used in the initial claim flow (ProfileStep).
+ *
+ * When formData / change handlers are passed in as props (the pending
+ * claim edit view, whose form state lives in its own slice — OSDEV-3371),
+ * they take precedence over the claimForm slice wiring.
  */
 const ClaimEmissionsEstimate = ({
     formData,
@@ -30,36 +34,40 @@ ClaimEmissionsEstimate.propTypes = {
     onValidationChange: func.isRequired,
 };
 
-const mapStateToProps = ({ claimForm: { formData } }) => ({
-    formData: {
-        openingDate: formData.openingDate,
-        estimatedAnnualThroughput: formData.estimatedAnnualThroughput,
-        energyCoal: formData.energyCoal,
-        energyNaturalGas: formData.energyNaturalGas,
-        energyDiesel: formData.energyDiesel,
-        energyKerosene: formData.energyKerosene,
-        energyBiomass: formData.energyBiomass,
-        energyCharcoal: formData.energyCharcoal,
-        energyAnimalWaste: formData.energyAnimalWaste,
-        energyElectricity: formData.energyElectricity,
-        energyOther: formData.energyOther,
-        energyCoalEnabled: formData.energyCoalEnabled,
-        energyNaturalGasEnabled: formData.energyNaturalGasEnabled,
-        energyDieselEnabled: formData.energyDieselEnabled,
-        energyKeroseneEnabled: formData.energyKeroseneEnabled,
-        energyBiomassEnabled: formData.energyBiomassEnabled,
-        energyCharcoalEnabled: formData.energyCharcoalEnabled,
-        energyAnimalWasteEnabled: formData.energyAnimalWasteEnabled,
-        energyElectricityEnabled: formData.energyElectricityEnabled,
-        energyOtherEnabled: formData.energyOtherEnabled,
-    },
+const pickEmissionsFields = formData => ({
+    openingDate: formData.openingDate,
+    estimatedAnnualThroughput: formData.estimatedAnnualThroughput,
+    energyCoal: formData.energyCoal,
+    energyNaturalGas: formData.energyNaturalGas,
+    energyDiesel: formData.energyDiesel,
+    energyKerosene: formData.energyKerosene,
+    energyBiomass: formData.energyBiomass,
+    energyCharcoal: formData.energyCharcoal,
+    energyAnimalWaste: formData.energyAnimalWaste,
+    energyElectricity: formData.energyElectricity,
+    energyOther: formData.energyOther,
+    energyCoalEnabled: formData.energyCoalEnabled,
+    energyNaturalGasEnabled: formData.energyNaturalGasEnabled,
+    energyDieselEnabled: formData.energyDieselEnabled,
+    energyKeroseneEnabled: formData.energyKeroseneEnabled,
+    energyBiomassEnabled: formData.energyBiomassEnabled,
+    energyCharcoalEnabled: formData.energyCharcoalEnabled,
+    energyAnimalWasteEnabled: formData.energyAnimalWasteEnabled,
+    energyElectricityEnabled: formData.energyElectricityEnabled,
+    energyOtherEnabled: formData.energyOtherEnabled,
 });
 
-const mapDispatchToProps = dispatch => ({
-    onEmissionsValueChange: (field, value) =>
-        dispatch(updateClaimFormField({ field, value })),
-    onEmissionsEnabledChange: (field, value) =>
-        dispatch(updateClaimFormField({ field, value })),
+const mapStateToProps = ({ claimForm: { formData } }, ownProps) => ({
+    formData: pickEmissionsFields(ownProps.formData || formData),
+});
+
+const mapDispatchToProps = (dispatch, ownProps) => ({
+    onEmissionsValueChange:
+        ownProps.onEmissionsValueChange ||
+        ((field, value) => dispatch(updateClaimFormField({ field, value }))),
+    onEmissionsEnabledChange:
+        ownProps.onEmissionsEnabledChange ||
+        ((field, value) => dispatch(updateClaimFormField({ field, value }))),
 });
 
 export default connect(

--- a/src/react/src/components/InitialClaimFlow/ClaimForm/ClaimForm.jsx
+++ b/src/react/src/components/InitialClaimFlow/ClaimForm/ClaimForm.jsx
@@ -7,10 +7,6 @@ import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
 import CircularProgress from '@material-ui/core/CircularProgress';
-import Dialog from '@material-ui/core/Dialog';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogActions from '@material-ui/core/DialogActions';
-import DialogTitle from '@material-ui/core/DialogTitle';
 import Security from '@material-ui/icons/Security';
 import People from '@material-ui/icons/People';
 import Language from '@material-ui/icons/Language';
@@ -22,6 +18,7 @@ import BusinessStep from './Steps/BusinessStep/BusinessStep';
 import ProfileStep from './Steps/ProfileStep/ProfileStep';
 import ErrorState from './ErrorState/ErrorState';
 import SubmissionErrorsBanner from './SubmissionErrorsBanner/SubmissionErrorsBanner';
+import ClaimOutcomeDialog from '../../ClaimOutcomeDialog';
 import RequireAuthNotice from '../../RequireAuthNotice';
 
 import {
@@ -357,40 +354,22 @@ const ClaimForm = ({
                     </Paper>
                 </form>
             </div>
-            <Dialog open={dialogIsOpen}>
-                <DialogTitle className={classes.dialogTitle}>
-                    <Typography className={classes.dialogTitle}>
-                        Thank you for submitting your claim request!
-                    </Typography>
-                </DialogTitle>
-                <DialogContent>
-                    <Typography
-                        variant="body1"
-                        className={classes.dialogBodyText}
-                    >
-                        You will receive a notification once it has been
-                        reviewed.
-                    </Typography>
-                </DialogContent>
-                <DialogActions className={classes.dialogActions}>
-                    <Button
-                        variant="contained"
-                        color="primary"
-                        onClick={() => history.push('/claimed')}
-                        className={classes.backButton}
-                    >
-                        To My Claims
-                    </Button>
-                    <Button
-                        variant="contained"
-                        color="primary"
-                        onClick={() => history.push(mapRoute)}
-                        className={classes.continueButton}
-                    >
-                        Search OS Hub
-                    </Button>
-                </DialogActions>
-            </Dialog>
+            <ClaimOutcomeDialog
+                open={dialogIsOpen}
+                title="Thank you for submitting your claim request!"
+                body="You will receive a notification once it has been reviewed."
+                actions={[
+                    {
+                        label: 'To My Claims',
+                        onClick: () => history.push('/claimed'),
+                        secondary: true,
+                    },
+                    {
+                        label: 'Search OS Hub',
+                        onClick: () => history.push(mapRoute),
+                    },
+                ]}
+            />
         </div>
     );
 };

--- a/src/react/src/components/InitialClaimFlow/ClaimForm/Steps/BusinessStep/BusinessStep.jsx
+++ b/src/react/src/components/InitialClaimFlow/ClaimForm/Steps/BusinessStep/BusinessStep.jsx
@@ -26,7 +26,10 @@ import {
 import useVerificationMethodChange from './hooks';
 import { getSelectStyles } from '../../../../../util/util';
 import findSelectedOption from '../utils';
-import { facilityDetailsRoute } from '../../../../../util/constants';
+import {
+    facilityDetailsRoute,
+    CLAIM_PII_WARNING_TEXT,
+} from '../../../../../util/constants';
 import { selectStyles } from '../../styles';
 
 const BusinessStep = ({
@@ -195,7 +198,7 @@ const BusinessStep = ({
             <div className={classes.documentUploadContainer}>
                 {showDocumentUpload && (
                     <Grid item xs={12}>
-                        <ImportantNote text="We do NOT require and you should NOT submit documents containing sensitive personal information such as salary information, personal phone numbers, home addresses, or personal ID numbers." />
+                        <ImportantNote text={CLAIM_PII_WARNING_TEXT} />
                         <ClaimAttachmentsUploader
                             inputId="company-address-verification-documents"
                             title="Upload your documents"

--- a/src/react/src/components/InitialClaimFlow/ClaimForm/Steps/ContactInfoStep/ContactInfoStep.jsx
+++ b/src/react/src/components/InitialClaimFlow/ClaimForm/Steps/ContactInfoStep/ContactInfoStep.jsx
@@ -32,6 +32,7 @@ import ImportantNote from '../../../Shared/ImportantNote/ImportantNote';
 import findSelectedOption from '../utils';
 import InputErrorText from '../../../../Contribute/InputErrorText';
 import { selectStyles } from '../../styles';
+import { CLAIM_PII_WARNING_TEXT } from '../../../../../util/constants';
 
 const ContactInfoStep = ({
     classes,
@@ -289,7 +290,7 @@ const ContactInfoStep = ({
                     {showDocumentUpload && (
                         <Grid item xs={12} className={classes.gridSpacing}>
                             <div className={classes.importantNoteWrapper}>
-                                <ImportantNote text="We do NOT require and you should NOT submit documents containing sensitive personal information such as salary information, personal phone numbers, home addresses, or personal ID numbers." />
+                                <ImportantNote text={CLAIM_PII_WARNING_TEXT} />
                             </div>
                             <ClaimAttachmentsUploader
                                 inputId="employment-verification-upload"

--- a/src/react/src/components/InitialClaimFlow/ClaimForm/Steps/ProfileStep/ProfileStep.jsx
+++ b/src/react/src/components/InitialClaimFlow/ClaimForm/Steps/ProfileStep/ProfileStep.jsx
@@ -60,6 +60,11 @@ const ProfileStep = ({
     countryOptions,
     processingTypeOptions,
     onEmissionsValidationChange,
+    // Optional overrides for the emissions section, used when the form
+    // state lives outside the claimForm slice (pending claim edit view).
+    emissionsFormData,
+    onEmissionsValueChange,
+    onEmissionsEnabledChange,
 }) => {
     const [
         claimEmissionsEstimateHasErrors,
@@ -411,6 +416,7 @@ const ProfileStep = ({
                         <TextField
                             fullWidth
                             variant="outlined"
+                            value={formData.parentCompanyName || ''}
                             onChange={e =>
                                 handleChange(
                                     'parentCompanyName',
@@ -543,6 +549,13 @@ const ProfileStep = ({
                             aria-label="Office country"
                             isMulti={false}
                             options={countryOptions || []}
+                            value={
+                                (countryOptions || []).find(
+                                    option =>
+                                        option.value ===
+                                        formData.officeCountryCode,
+                                ) || null
+                            }
                             onChange={option =>
                                 handleChange(
                                     'officeCountryCode',
@@ -1203,6 +1216,9 @@ const ProfileStep = ({
                 <div className={classes.emissionsEstimateContainer}>
                     <ClaimEmissionsEstimate
                         onValidationChange={setClaimEmissionsEstimateHasErrors}
+                        formData={emissionsFormData}
+                        onEmissionsValueChange={onEmissionsValueChange}
+                        onEmissionsEnabledChange={onEmissionsEnabledChange}
                     />
                 </div>
             )}
@@ -1220,6 +1236,9 @@ ProfileStep.propTypes = {
     countryOptions: array,
     processingTypeOptions: array,
     onEmissionsValidationChange: func,
+    emissionsFormData: object,
+    onEmissionsValueChange: func,
+    onEmissionsEnabledChange: func,
 };
 
 ProfileStep.defaultProps = {
@@ -1228,6 +1247,9 @@ ProfileStep.defaultProps = {
     countryOptions: null,
     processingTypeOptions: null,
     onEmissionsValidationChange: null,
+    emissionsFormData: null,
+    onEmissionsValueChange: null,
+    onEmissionsEnabledChange: null,
 };
 
 export default withStyles(profileStepStyles)(withScrollReset(ProfileStep));

--- a/src/react/src/components/InitialClaimFlow/ClaimForm/styles.js
+++ b/src/react/src/components/InitialClaimFlow/ClaimForm/styles.js
@@ -6,7 +6,7 @@ export const selectStyles = Object.freeze({
     fontWeight: '600',
 });
 
-const primaryButtonStyles = theme =>
+export const primaryButtonStyles = theme =>
     Object.freeze({
         height: '49px',
         borderRadius: 0,

--- a/src/react/src/components/PendingClaimEdit/PendingClaimAttachments.jsx
+++ b/src/react/src/components/PendingClaimEdit/PendingClaimAttachments.jsx
@@ -1,0 +1,143 @@
+import React, { useState } from 'react';
+import { bool, func, number, object } from 'prop-types';
+import moment from 'moment';
+import Paper from '@material-ui/core/Paper';
+import Typography from '@material-ui/core/Typography';
+import Button from '@material-ui/core/Button';
+import IconButton from '@material-ui/core/IconButton';
+import DeleteIcon from '@material-ui/icons/Delete';
+import Dialog from '@material-ui/core/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogActions from '@material-ui/core/DialogActions';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { withStyles } from '@material-ui/core/styles';
+
+import { facilityClaimAttachmentsPropType } from '../../util/propTypes';
+import { makeFacilityClaimAttachmentDownloadURL } from '../../util/util';
+
+const styles = Object.freeze({
+    container: Object.freeze({
+        padding: '25px',
+        marginTop: '20px',
+        marginBottom: '20px',
+    }),
+    list: Object.freeze({
+        listStyle: 'none',
+        padding: 0,
+        margin: '10px 0 0 0',
+    }),
+    listItem: Object.freeze({
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        borderBottom: '1px solid rgba(0, 0, 0, 0.08)',
+        padding: '6px 0',
+    }),
+    uploadedAt: Object.freeze({
+        color: 'rgba(0, 0, 0, 0.54)',
+        marginLeft: '12px',
+    }),
+});
+
+/*
+ * The documents already stored on the pending claim. Download links go
+ * through the authorization-checked download endpoint (the API answers
+ * with a short-lived redirect); no storage URLs exist in the payload.
+ */
+function PendingClaimAttachments({
+    classes,
+    claimId,
+    attachments,
+    deleting,
+    onDelete,
+}) {
+    const [attachmentToDelete, setAttachmentToDelete] = useState(null);
+
+    const closeDialog = () => setAttachmentToDelete(null);
+
+    const confirmDelete = () => {
+        onDelete(attachmentToDelete.id);
+        closeDialog();
+    };
+
+    return (
+        <Paper className={classes.container}>
+            <Typography variant="title">Uploaded documents</Typography>
+            {attachments.length === 0 ? (
+                <Typography variant="body1">
+                    No documents uploaded yet.
+                </Typography>
+            ) : (
+                <ul className={classes.list}>
+                    {attachments.map(attachment => (
+                        <li key={attachment.id} className={classes.listItem}>
+                            <span>
+                                <a
+                                    href={makeFacilityClaimAttachmentDownloadURL(
+                                        claimId,
+                                        attachment.id,
+                                    )}
+                                    rel="noreferrer"
+                                    target="_blank"
+                                >
+                                    {attachment.file_name}
+                                </a>
+                                <span className={classes.uploadedAt}>
+                                    {moment(attachment.uploaded_at).format(
+                                        'LL',
+                                    )}
+                                </span>
+                            </span>
+                            {deleting ? (
+                                <CircularProgress size={20} />
+                            ) : (
+                                <IconButton
+                                    aria-label={`Remove ${attachment.file_name}`}
+                                    onClick={() =>
+                                        setAttachmentToDelete(attachment)
+                                    }
+                                >
+                                    <DeleteIcon />
+                                </IconButton>
+                            )}
+                        </li>
+                    ))}
+                </ul>
+            )}
+            <Dialog open={attachmentToDelete !== null} onClose={closeDialog}>
+                <DialogTitle>Remove this document?</DialogTitle>
+                <DialogContent>
+                    <DialogContentText>
+                        {attachmentToDelete !== null
+                            ? `${attachmentToDelete.file_name} will be removed
+                               from your claim. This cannot be undone.`
+                            : ''}
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={closeDialog}>Cancel</Button>
+                    <Button color="secondary" onClick={confirmDelete}>
+                        Remove
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </Paper>
+    );
+}
+
+PendingClaimAttachments.defaultProps = {
+    attachments: [],
+    deleting: false,
+};
+
+PendingClaimAttachments.propTypes = {
+    classes: object.isRequired,
+    claimId: number.isRequired,
+    attachments: facilityClaimAttachmentsPropType,
+    deleting: bool,
+    onDelete: func.isRequired,
+};
+
+export default withStyles(styles)(PendingClaimAttachments);

--- a/src/react/src/components/PendingClaimEdit/PendingClaimEdit.jsx
+++ b/src/react/src/components/PendingClaimEdit/PendingClaimEdit.jsx
@@ -1,0 +1,350 @@
+import React, { useEffect, useState } from 'react';
+import { arrayOf, bool, func, object, shape, string } from 'prop-types';
+import { connect } from 'react-redux';
+import { useFormik } from 'formik';
+import * as Yup from 'yup';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import Typography from '@material-ui/core/Typography';
+import Paper from '@material-ui/core/Paper';
+import Button from '@material-ui/core/Button';
+import { withStyles } from '@material-ui/core/styles';
+import { Link } from 'react-router-dom';
+
+import ContactInfoStep from '../InitialClaimFlow/ClaimForm/Steps/ContactInfoStep/ContactInfoStep';
+import BusinessStep from '../InitialClaimFlow/ClaimForm/Steps/BusinessStep/BusinessStep';
+import ProfileStep from '../InitialClaimFlow/ClaimForm/Steps/ProfileStep/ProfileStep';
+import PendingClaimAttachments from './PendingClaimAttachments';
+import SubmissionErrorsBanner from '../InitialClaimFlow/ClaimForm/SubmissionErrorsBanner/SubmissionErrorsBanner';
+
+import {
+    contactStepSchema,
+    businessStepSchema,
+    profileStepSchema,
+} from '../InitialClaimFlow/ClaimForm/validationSchemas';
+import { getTouchedFieldsFromErrors } from '../InitialClaimFlow/ClaimForm/utils';
+
+import {
+    fetchPendingClaim,
+    savePendingClaim,
+    deletePendingClaimAttachment,
+    updatePendingClaimFormField,
+    resetPendingClaimEdit,
+} from '../../actions/pendingClaimEdit';
+import {
+    fetchCountryOptions,
+    fetchFacilityProcessingTypeOptions,
+} from '../../actions/filterOptions';
+import {
+    fetchProductionLocationByOsId,
+    resetSingleProductionLocation,
+} from '../../actions/contributeProductionLocation';
+
+import { claimedFacilitiesRoute } from '../../util/constants';
+
+const pendingClaimEditStyles = Object.freeze({
+    container: Object.freeze({
+        maxWidth: '960px',
+        margin: '0 auto',
+        padding: '20px',
+    }),
+    header: Object.freeze({
+        margin: '10px 0',
+    }),
+    subtitle: Object.freeze({
+        marginBottom: '20px',
+    }),
+    section: Object.freeze({
+        padding: '25px',
+        marginBottom: '20px',
+    }),
+    buttons: Object.freeze({
+        display: 'flex',
+        justifyContent: 'flex-end',
+        gap: '10px',
+        marginTop: '20px',
+    }),
+    loader: Object.freeze({
+        display: 'block',
+        margin: '40px auto',
+    }),
+});
+
+// The full edit page validates every section at once; the two document
+// picker fields are relaxed because already-uploaded attachments (shown
+// in the attachments section) satisfy the documentation requirement.
+const editValidationSchema = contactStepSchema
+    .concat(businessStepSchema)
+    .concat(profileStepSchema)
+    .shape({
+        employmentVerificationDocuments: Yup.array().notRequired(),
+        companyAddressVerificationDocuments: Yup.array().notRequired(),
+    });
+
+function PendingClaimEdit({
+    classes,
+    match: {
+        params: { claimID },
+    },
+    history: { push },
+    data,
+    fetching,
+    error,
+    formData,
+    saving,
+    savingError,
+    deletingAttachment,
+    getPendingClaim,
+    saveClaim,
+    deleteAttachment,
+    updateFormField,
+    resetState,
+    prefetchCountries,
+    prefetchProcessingTypes,
+    prefetchProductionLocation,
+    resetProductionLocation,
+    countriesOptions,
+    facilityProcessingTypeOptions,
+}) {
+    const [emissionsHasErrors, setEmissionsHasErrors] = useState(false);
+
+    useEffect(() => {
+        getPendingClaim(claimID);
+        return () => {
+            resetState();
+            resetProductionLocation();
+        };
+    }, [claimID, getPendingClaim, resetState, resetProductionLocation]);
+
+    useEffect(() => {
+        if (!countriesOptions) {
+            prefetchCountries();
+        }
+        if (!facilityProcessingTypeOptions) {
+            prefetchProcessingTypes();
+        }
+    }, [
+        countriesOptions,
+        facilityProcessingTypeOptions,
+        prefetchCountries,
+        prefetchProcessingTypes,
+    ]);
+
+    useEffect(() => {
+        if (data?.os_id) {
+            prefetchProductionLocation(data.os_id);
+        }
+    }, [data?.os_id, prefetchProductionLocation]);
+
+    const formik = useFormik({
+        initialValues: formData || {},
+        validationSchema: editValidationSchema,
+        enableReinitialize: true,
+        validateOnChange: true,
+        validateOnBlur: true,
+        onSubmit: () => saveClaim(claimID),
+    });
+
+    const handleFieldChange = (field, value) => {
+        formik.setFieldValue(field, value, true);
+        formik.setFieldTouched(field, true, false);
+        updateFormField({ field, value });
+    };
+
+    const updateFieldWithoutTouch = (field, value) => {
+        formik.setFieldValue(field, value, true);
+        updateFormField({ field, value });
+    };
+
+    const handleBlur = field => formik.setFieldTouched(field, true, true);
+
+    const handleSave = async () => {
+        const errors = await formik.validateForm();
+        if (Object.keys(errors).length > 0) {
+            formik.setTouched(getTouchedFieldsFromErrors(errors));
+            return;
+        }
+        formik.handleSubmit();
+    };
+
+    if (fetching) {
+        return <CircularProgress className={classes.loader} />;
+    }
+
+    if (error || !data || !formData) {
+        return (
+            <div className={classes.container}>
+                <Typography variant="title" className={classes.header}>
+                    This claim is not available for editing
+                </Typography>
+                <Typography variant="body1">
+                    It may have already been reviewed, or it may not belong to
+                    your account. Only pending claims can be edited.
+                </Typography>
+                <Link to={claimedFacilitiesRoute} href={claimedFacilitiesRoute}>
+                    Back to My Facilities
+                </Link>
+            </div>
+        );
+    }
+
+    const stepProps = {
+        formData: formik.values,
+        handleChange: handleFieldChange,
+        handleBlur,
+        updateFieldWithoutTouch,
+        errors: formik.errors,
+        touched: formik.touched,
+    };
+
+    return (
+        <div className={`${classes.container} notranslate`} translate="no">
+            <Typography variant="title" className={classes.header}>
+                Edit your pending claim
+            </Typography>
+            <Typography variant="body1" className={classes.subtitle}>
+                {data.facility_name} ({data.os_id}) — submitted{' '}
+                {new Date(data.created_at).toLocaleDateString()}. Your claim is
+                awaiting review; any updates you save here are visible to the
+                Open Supply Hub Claims Team.
+            </Typography>
+
+            <PendingClaimAttachments
+                claimId={data.id}
+                attachments={data.attachments}
+                deleting={deletingAttachment}
+                onDelete={attachmentID =>
+                    deleteAttachment(claimID, attachmentID)
+                }
+            />
+
+            <form>
+                <Paper className={classes.section}>
+                    <Typography variant="title">Contact information</Typography>
+                    <ContactInfoStep {...stepProps} />
+                </Paper>
+                <Paper className={classes.section}>
+                    <Typography variant="title">
+                        Business information
+                    </Typography>
+                    <BusinessStep {...stepProps} />
+                </Paper>
+                <Paper className={classes.section}>
+                    <Typography variant="title">
+                        Production location profile
+                    </Typography>
+                    <ProfileStep
+                        {...stepProps}
+                        countryOptions={countriesOptions}
+                        processingTypeOptions={facilityProcessingTypeOptions}
+                        onEmissionsValidationChange={setEmissionsHasErrors}
+                    />
+                </Paper>
+
+                <SubmissionErrorsBanner errors={savingError} />
+
+                <div className={classes.buttons}>
+                    <Button
+                        variant="outlined"
+                        onClick={() => push(claimedFacilitiesRoute)}
+                        disabled={saving}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        variant="contained"
+                        color="primary"
+                        onClick={handleSave}
+                        disabled={saving || emissionsHasErrors}
+                    >
+                        {saving ? (
+                            <CircularProgress size={20} />
+                        ) : (
+                            'Save changes'
+                        )}
+                    </Button>
+                </div>
+            </form>
+        </div>
+    );
+}
+
+PendingClaimEdit.defaultProps = {
+    data: null,
+    error: null,
+    formData: null,
+    savingError: null,
+    countriesOptions: null,
+    facilityProcessingTypeOptions: null,
+};
+
+PendingClaimEdit.propTypes = {
+    classes: object.isRequired,
+    match: shape({
+        params: shape({ claimID: string.isRequired }).isRequired,
+    }).isRequired,
+    history: shape({ push: func.isRequired }).isRequired,
+    data: object,
+    fetching: bool.isRequired,
+    error: arrayOf(string),
+    formData: object,
+    saving: bool.isRequired,
+    savingError: arrayOf(string),
+    deletingAttachment: bool.isRequired,
+    getPendingClaim: func.isRequired,
+    saveClaim: func.isRequired,
+    deleteAttachment: func.isRequired,
+    updateFormField: func.isRequired,
+    resetState: func.isRequired,
+    prefetchCountries: func.isRequired,
+    prefetchProcessingTypes: func.isRequired,
+    prefetchProductionLocation: func.isRequired,
+    resetProductionLocation: func.isRequired,
+    countriesOptions: arrayOf(object),
+    facilityProcessingTypeOptions: arrayOf(object),
+};
+
+const mapStateToProps = ({
+    pendingClaimEdit: {
+        data,
+        fetching,
+        error,
+        formData,
+        saving,
+        savingError,
+        deletingAttachment,
+    },
+    filterOptions: {
+        countries: { data: countriesOptions },
+        facilityProcessingType: { data: facilityProcessingTypeOptions },
+    },
+}) => ({
+    data,
+    fetching,
+    error,
+    formData,
+    saving,
+    savingError,
+    deletingAttachment,
+    countriesOptions,
+    facilityProcessingTypeOptions,
+});
+
+const mapDispatchToProps = dispatch => ({
+    getPendingClaim: claimID => dispatch(fetchPendingClaim(claimID)),
+    saveClaim: claimID => dispatch(savePendingClaim(claimID)),
+    deleteAttachment: (claimID, attachmentID) =>
+        dispatch(deletePendingClaimAttachment(claimID, attachmentID)),
+    updateFormField: payload => dispatch(updatePendingClaimFormField(payload)),
+    resetState: () => dispatch(resetPendingClaimEdit()),
+    prefetchCountries: () => dispatch(fetchCountryOptions()),
+    prefetchProcessingTypes: () =>
+        dispatch(fetchFacilityProcessingTypeOptions()),
+    prefetchProductionLocation: osID =>
+        dispatch(fetchProductionLocationByOsId(osID)),
+    resetProductionLocation: () => dispatch(resetSingleProductionLocation()),
+});
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(withStyles(pendingClaimEditStyles)(PendingClaimEdit));

--- a/src/react/src/components/PendingClaimEdit/PendingClaimEdit.jsx
+++ b/src/react/src/components/PendingClaimEdit/PendingClaimEdit.jsx
@@ -14,6 +14,7 @@ import ContactInfoStep from '../InitialClaimFlow/ClaimForm/Steps/ContactInfoStep
 import BusinessStep from '../InitialClaimFlow/ClaimForm/Steps/BusinessStep/BusinessStep';
 import ProfileStep from '../InitialClaimFlow/ClaimForm/Steps/ProfileStep/ProfileStep';
 import PendingClaimAttachments from './PendingClaimAttachments';
+import ClaimOutcomeDialog from '../ClaimOutcomeDialog';
 import SubmissionErrorsBanner from '../InitialClaimFlow/ClaimForm/SubmissionErrorsBanner/SubmissionErrorsBanner';
 
 import {
@@ -39,7 +40,7 @@ import {
     resetSingleProductionLocation,
 } from '../../actions/contributeProductionLocation';
 
-import { claimedFacilitiesRoute } from '../../util/constants';
+import { claimedFacilitiesRoute, mapRoute } from '../../util/constants';
 
 const pendingClaimEditStyles = Object.freeze({
     container: Object.freeze({
@@ -91,6 +92,7 @@ function PendingClaimEdit({
     error,
     formData,
     saving,
+    saved,
     savingError,
     deletingAttachment,
     getPendingClaim,
@@ -106,6 +108,16 @@ function PendingClaimEdit({
     facilityProcessingTypeOptions,
 }) {
     const [emissionsHasErrors, setEmissionsHasErrors] = useState(false);
+    // Latched locally so a stray Redux state change can never close the
+    // dialog once a save has succeeded; it closes only by navigating
+    // away (both dialog actions navigate, and unmount resets the slice).
+    const [outcomeDialogOpen, setOutcomeDialogOpen] = useState(false);
+
+    useEffect(() => {
+        if (saved) {
+            setOutcomeDialogOpen(true);
+        }
+    }, [saved]);
 
     useEffect(() => {
         getPendingClaim(claimID);
@@ -166,7 +178,18 @@ function PendingClaimEdit({
         formik.handleSubmit();
     };
 
-    if (fetching) {
+    // The steps must not mount until the outer formik has actually
+    // hydrated: enableReinitialize applies one render after formData
+    // arrives, and EmissionsEstimateForm seeds its own internal Formik
+    // from whatever it receives at mount (no reinitialize) — mounting
+    // it against the pre-hydration empty values leaves the emissions
+    // section blank and syncs '' back over the fetched data.
+    const formHydrated = Object.keys(formik.values).length > 0;
+
+    // On the very first render data is null and fetching has not been
+    // set yet (the fetch dispatch runs in an effect), so treat that as
+    // loading too rather than flashing the not-available message.
+    if (fetching || (!data && !error) || (data && !formHydrated)) {
         return <CircularProgress className={classes.loader} />;
     }
 
@@ -197,74 +220,99 @@ function PendingClaimEdit({
     };
 
     return (
-        <div className={`${classes.container} notranslate`} translate="no">
-            <Typography variant="title" className={classes.header}>
-                Edit your pending claim
-            </Typography>
-            <Typography variant="body1" className={classes.subtitle}>
-                {data.facility_name} ({data.os_id}) — submitted{' '}
-                {new Date(data.created_at).toLocaleDateString()}. Your claim is
-                awaiting review; any updates you save here are visible to the
-                Open Supply Hub Claims Team.
-            </Typography>
+        <>
+            <div className={`${classes.container} notranslate`} translate="no">
+                <Typography variant="title" className={classes.header}>
+                    Edit your pending claim
+                </Typography>
+                <Typography variant="body1" className={classes.subtitle}>
+                    {data.facility_name} ({data.os_id}) — submitted{' '}
+                    {new Date(data.created_at).toLocaleDateString()}. Your claim
+                    is awaiting review; any updates you save here are visible to
+                    the Open Supply Hub Claims Team.
+                </Typography>
 
-            <PendingClaimAttachments
-                claimId={data.id}
-                attachments={data.attachments}
-                deleting={deletingAttachment}
-                onDelete={attachmentID =>
-                    deleteAttachment(claimID, attachmentID)
-                }
+                <PendingClaimAttachments
+                    claimId={data.id}
+                    attachments={data.attachments}
+                    deleting={deletingAttachment}
+                    onDelete={attachmentID =>
+                        deleteAttachment(claimID, attachmentID)
+                    }
+                />
+
+                <form>
+                    <Paper className={classes.section}>
+                        <Typography variant="title">
+                            Contact information
+                        </Typography>
+                        <ContactInfoStep {...stepProps} />
+                    </Paper>
+                    <Paper className={classes.section}>
+                        <Typography variant="title">
+                            Business information
+                        </Typography>
+                        <BusinessStep {...stepProps} />
+                    </Paper>
+                    <Paper className={classes.section}>
+                        <Typography variant="title">
+                            Production location profile
+                        </Typography>
+                        <ProfileStep
+                            {...stepProps}
+                            countryOptions={countriesOptions}
+                            processingTypeOptions={
+                                facilityProcessingTypeOptions
+                            }
+                            onEmissionsValidationChange={setEmissionsHasErrors}
+                            emissionsFormData={formik.values}
+                            onEmissionsValueChange={handleFieldChange}
+                            onEmissionsEnabledChange={updateFieldWithoutTouch}
+                        />
+                    </Paper>
+
+                    <SubmissionErrorsBanner errors={savingError} />
+
+                    <div className={classes.buttons}>
+                        <Button
+                            variant="outlined"
+                            onClick={() => push(claimedFacilitiesRoute)}
+                            disabled={saving}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            variant="contained"
+                            color="primary"
+                            onClick={handleSave}
+                            disabled={saving || emissionsHasErrors}
+                        >
+                            {saving ? (
+                                <CircularProgress size={20} />
+                            ) : (
+                                'Save changes'
+                            )}
+                        </Button>
+                    </div>
+                </form>
+            </div>
+            <ClaimOutcomeDialog
+                open={outcomeDialogOpen}
+                title="Thank you for editing your claim request!"
+                body="We have received your edited claim request, we will review it shortly."
+                actions={[
+                    {
+                        label: 'To My Claims',
+                        onClick: () => push(claimedFacilitiesRoute),
+                        secondary: true,
+                    },
+                    {
+                        label: 'Search OS Hub',
+                        onClick: () => push(mapRoute),
+                    },
+                ]}
             />
-
-            <form>
-                <Paper className={classes.section}>
-                    <Typography variant="title">Contact information</Typography>
-                    <ContactInfoStep {...stepProps} />
-                </Paper>
-                <Paper className={classes.section}>
-                    <Typography variant="title">
-                        Business information
-                    </Typography>
-                    <BusinessStep {...stepProps} />
-                </Paper>
-                <Paper className={classes.section}>
-                    <Typography variant="title">
-                        Production location profile
-                    </Typography>
-                    <ProfileStep
-                        {...stepProps}
-                        countryOptions={countriesOptions}
-                        processingTypeOptions={facilityProcessingTypeOptions}
-                        onEmissionsValidationChange={setEmissionsHasErrors}
-                    />
-                </Paper>
-
-                <SubmissionErrorsBanner errors={savingError} />
-
-                <div className={classes.buttons}>
-                    <Button
-                        variant="outlined"
-                        onClick={() => push(claimedFacilitiesRoute)}
-                        disabled={saving}
-                    >
-                        Cancel
-                    </Button>
-                    <Button
-                        variant="contained"
-                        color="primary"
-                        onClick={handleSave}
-                        disabled={saving || emissionsHasErrors}
-                    >
-                        {saving ? (
-                            <CircularProgress size={20} />
-                        ) : (
-                            'Save changes'
-                        )}
-                    </Button>
-                </div>
-            </form>
-        </div>
+        </>
     );
 }
 
@@ -288,6 +336,7 @@ PendingClaimEdit.propTypes = {
     error: arrayOf(string),
     formData: object,
     saving: bool.isRequired,
+    saved: bool.isRequired,
     savingError: arrayOf(string),
     deletingAttachment: bool.isRequired,
     getPendingClaim: func.isRequired,
@@ -310,6 +359,7 @@ const mapStateToProps = ({
         error,
         formData,
         saving,
+        saved,
         savingError,
         deletingAttachment,
     },
@@ -323,6 +373,7 @@ const mapStateToProps = ({
     error,
     formData,
     saving,
+    saved,
     savingError,
     deletingAttachment,
     countriesOptions,

--- a/src/react/src/components/PendingClaimEdit/utils.js
+++ b/src/react/src/components/PendingClaimEdit/utils.js
@@ -1,0 +1,160 @@
+import camelCase from 'lodash/camelCase';
+import snakeCase from 'lodash/snakeCase';
+
+import { filterFreeEmissionsEstimateFields } from '../../util/util';
+
+/*
+ * The single place the API <-> form field mapping lives for the
+ * pending-claim edit view (OSDEV-3371).
+ *
+ * The pending-claim API payload uses the claim form's snake_case field
+ * names (the same names FacilityCreateClaimSerializer accepts), and the
+ * claim form's Redux/Formik state uses their camelCase equivalents —
+ * the identical convention the create flow relies on when it
+ * snake-cases keys at submit time (actions/claimForm.js).
+ */
+
+// Fields that hold File objects picked in the UI; they are uploaded to
+// the attachments sub-resource, never sent in the PATCH payload.
+export const DOCUMENT_FIELDS = [
+    'employmentVerificationDocuments',
+    'companyAddressVerificationDocuments',
+];
+
+// Client-only fields that must never reach the API.
+const CLIENT_ONLY_FIELDS = new Set([
+    ...DOCUMENT_FIELDS,
+    'attachments',
+    'id',
+    'status',
+    'createdAt',
+    'updatedAt',
+    'claimantUpdatedAt',
+    'osId',
+    'facilityName',
+]);
+
+// Numeric/date fields where an empty string means "not provided" and
+// must be omitted rather than sent (the API rejects '' for them).
+const OMIT_WHEN_EMPTY_FIELDS = new Set([
+    'openingDate',
+    'estimatedAnnualThroughput',
+    'facilityFemaleWorkersPercentage',
+    'numberOfWorkers',
+    'energyCoal',
+    'energyNaturalGas',
+    'energyDiesel',
+    'energyKerosene',
+    'energyBiomass',
+    'energyCharcoal',
+    'energyAnimalWaste',
+    'energyElectricity',
+    'energyOther',
+]);
+
+const ENERGY_VALUE_TO_ENABLED = Object.freeze({
+    energyCoal: 'energyCoalEnabled',
+    energyNaturalGas: 'energyNaturalGasEnabled',
+    energyDiesel: 'energyDieselEnabled',
+    energyKerosene: 'energyKeroseneEnabled',
+    energyBiomass: 'energyBiomassEnabled',
+    energyCharcoal: 'energyCharcoalEnabled',
+    energyAnimalWaste: 'energyAnimalWasteEnabled',
+    energyElectricity: 'energyElectricityEnabled',
+    energyOther: 'energyOtherEnabled',
+});
+
+/*
+ * Map a GET /pending/ payload onto the claim form's camelCase formData
+ * shape, so the create flow's step components render it unchanged.
+ */
+export const pendingClaimApiToFormData = apiData => {
+    const formData = {};
+
+    Object.entries(apiData || {}).forEach(([key, value]) => {
+        const formKey = camelCase(key);
+        if (formKey === 'attachments') {
+            return;
+        }
+        formData[formKey] = value === null ? '' : value;
+    });
+
+    // facility_type is stored pipe-joined; the form works with an array.
+    if (typeof formData.facilityType === 'string') {
+        formData.facilityType = formData.facilityType
+            ? formData.facilityType.split('|')
+            : [];
+    }
+
+    // List fields arrive as null when unset.
+    [
+        'sectors',
+        'facilityProductionTypes',
+        'facilityProductTypes',
+        'facilityAffiliations',
+        'facilityCertifications',
+    ].forEach(field => {
+        if (!Array.isArray(formData[field])) {
+            formData[field] = [];
+        }
+    });
+
+    // Derive the emissions-section checkbox state from stored values.
+    Object.entries(ENERGY_VALUE_TO_ENABLED).forEach(
+        ([valueField, enabledField]) => {
+            formData[enabledField] =
+                formData[valueField] !== '' &&
+                formData[valueField] !== undefined;
+        },
+    );
+
+    // Document pickers always start empty; existing uploads are shown
+    // in the attachments section instead.
+    DOCUMENT_FIELDS.forEach(field => {
+        formData[field] = [];
+    });
+
+    return formData;
+};
+
+/*
+ * Build the JSON PATCH payload from formData: strip client-only fields,
+ * drop disabled emissions fields (same behavior as the create flow's
+ * filterFreeEmissionsEstimateFields), omit empty numeric/date fields,
+ * pipe-join facilityType, and snake_case every key.
+ */
+export const buildPendingClaimPatchPayload = formData => {
+    const filtered = filterFreeEmissionsEstimateFields(formData);
+    const payload = {};
+
+    Object.entries(filtered).forEach(([key, value]) => {
+        if (CLIENT_ONLY_FIELDS.has(key) || key.endsWith('Enabled')) {
+            return;
+        }
+        if (
+            OMIT_WHEN_EMPTY_FIELDS.has(key) &&
+            (value === '' || value === null || value === undefined)
+        ) {
+            return;
+        }
+        if (value === undefined) {
+            return;
+        }
+
+        let outValue = value;
+        if (key === 'facilityType') {
+            if (!Array.isArray(value) || value.length === 0) {
+                return;
+            }
+            outValue = value
+                .map(item =>
+                    typeof item === 'object' ? item.label || item.value : item,
+                )
+                .join('|');
+        }
+
+        payload[snakeCase(key)] = outValue;
+    });
+
+    return payload;
+};

--- a/src/react/src/components/PendingClaimEdit/utils.js
+++ b/src/react/src/components/PendingClaimEdit/utils.js
@@ -1,7 +1,10 @@
 import camelCase from 'lodash/camelCase';
 import snakeCase from 'lodash/snakeCase';
 
-import { filterFreeEmissionsEstimateFields } from '../../util/util';
+import {
+    extractSelectValue,
+    filterFreeEmissionsEstimateFields,
+} from '../../util/util';
 
 /*
  * The single place the API <-> form field mapping lives for the
@@ -52,6 +55,19 @@ const OMIT_WHEN_EMPTY_FIELDS = new Set([
     'energyOther',
 ]);
 
+// Multi-select fields: the API stores/accepts plain string arrays, but
+// the form's StyledSelect components work with {value, label} option
+// objects — the same shape the create flow keeps in Redux and unwraps
+// via extractSelectValue at submit time (appendArrayField).
+const SELECT_OPTION_ARRAY_FIELDS = [
+    'sectors',
+    'facilityType',
+    'facilityProductTypes',
+    'facilityProductionTypes',
+    'facilityAffiliations',
+    'facilityCertifications',
+];
+
 const ENERGY_VALUE_TO_ENABLED = Object.freeze({
     energyCoal: 'energyCoalEnabled',
     energyNaturalGas: 'energyNaturalGasEnabled',
@@ -63,6 +79,20 @@ const ENERGY_VALUE_TO_ENABLED = Object.freeze({
     energyElectricity: 'energyElectricityEnabled',
     energyOther: 'energyOtherEnabled',
 });
+
+// The claim form keeps numeric inputs as strings ('' when blank); the
+// API returns numbers. Coerce for display so controlled inputs behave.
+const NUMERIC_STRING_FIELDS = new Set([
+    'estimatedAnnualThroughput',
+    'facilityFemaleWorkersPercentage',
+    ...Object.keys(ENERGY_VALUE_TO_ENABLED),
+]);
+
+const toSelectOptions = values =>
+    (Array.isArray(values) ? values : []).map(value => ({
+        value,
+        label: value,
+    }));
 
 /*
  * Map a GET /pending/ payload onto the claim form's camelCase formData
@@ -86,16 +116,17 @@ export const pendingClaimApiToFormData = apiData => {
             : [];
     }
 
-    // List fields arrive as null when unset.
-    [
-        'sectors',
-        'facilityProductionTypes',
-        'facilityProductTypes',
-        'facilityAffiliations',
-        'facilityCertifications',
-    ].forEach(field => {
-        if (!Array.isArray(formData[field])) {
-            formData[field] = [];
+    // Wrap multi-select values as {value, label} options — the shape
+    // the form's select components render. Plain strings display as
+    // empty chips.
+    SELECT_OPTION_ARRAY_FIELDS.forEach(field => {
+        formData[field] = toSelectOptions(formData[field]);
+    });
+
+    // Numeric inputs are controlled text fields holding strings.
+    NUMERIC_STRING_FIELDS.forEach(field => {
+        if (formData[field] !== '' && formData[field] !== undefined) {
+            formData[field] = String(formData[field]);
         }
     });
 
@@ -121,7 +152,9 @@ export const pendingClaimApiToFormData = apiData => {
  * Build the JSON PATCH payload from formData: strip client-only fields,
  * drop disabled emissions fields (same behavior as the create flow's
  * filterFreeEmissionsEstimateFields), omit empty numeric/date fields,
- * pipe-join facilityType, and snake_case every key.
+ * unwrap select option objects to plain strings (extractSelectValue,
+ * exactly like the create flow's appendArrayField), pipe-join
+ * facilityType, and snake_case every key.
  */
 export const buildPendingClaimPatchPayload = formData => {
     const filtered = filterFreeEmissionsEstimateFields(formData);
@@ -146,11 +179,11 @@ export const buildPendingClaimPatchPayload = formData => {
             if (!Array.isArray(value) || value.length === 0) {
                 return;
             }
-            outValue = value
-                .map(item =>
-                    typeof item === 'object' ? item.label || item.value : item,
-                )
-                .join('|');
+            outValue = value.map(extractSelectValue).join('|');
+        } else if (SELECT_OPTION_ARRAY_FIELDS.includes(key)) {
+            outValue = (Array.isArray(value) ? value : []).map(
+                extractSelectValue,
+            );
         }
 
         payload[snakeCase(key)] = outValue;

--- a/src/react/src/components/PendingClaimEdit/utils.js
+++ b/src/react/src/components/PendingClaimEdit/utils.js
@@ -1,10 +1,7 @@
 import camelCase from 'lodash/camelCase';
 import snakeCase from 'lodash/snakeCase';
 
-import {
-    extractSelectValue,
-    filterFreeEmissionsEstimateFields,
-} from '../../util/util';
+import { extractSelectValue } from '../../util/util';
 
 /*
  * The single place the API <-> form field mapping lives for the
@@ -37,9 +34,11 @@ const CLIENT_ONLY_FIELDS = new Set([
     'facilityName',
 ]);
 
-// Numeric/date fields where an empty string means "not provided" and
-// must be omitted rather than sent (the API rejects '' for them).
-const OMIT_WHEN_EMPTY_FIELDS = new Set([
+// Numeric/date fields where an empty string means "cleared". In a
+// partial PATCH an omitted field means "unchanged", so these are sent
+// as null (the edit serializer allows null for exactly this set) —
+// otherwise clearing a value in the UI would silently keep the old one.
+const NULL_WHEN_EMPTY_FIELDS = new Set([
     'openingDate',
     'estimatedAnnualThroughput',
     'facilityFemaleWorkersPercentage',
@@ -150,38 +149,48 @@ export const pendingClaimApiToFormData = apiData => {
 
 /*
  * Build the JSON PATCH payload from formData: strip client-only fields,
- * drop disabled emissions fields (same behavior as the create flow's
- * filterFreeEmissionsEstimateFields), omit empty numeric/date fields,
+ * send null for cleared numeric/date fields and for the value fields of
+ * unchecked emissions sections (in a partial PATCH, omitted means
+ * "unchanged" — null is how a claimant actually clears a stored value),
  * unwrap select option objects to plain strings (extractSelectValue,
  * exactly like the create flow's appendArrayField), pipe-join
  * facilityType, and snake_case every key.
  */
 export const buildPendingClaimPatchPayload = formData => {
-    const filtered = filterFreeEmissionsEstimateFields(formData);
     const payload = {};
 
-    Object.entries(filtered).forEach(([key, value]) => {
+    Object.entries(formData).forEach(([key, value]) => {
         if (CLIENT_ONLY_FIELDS.has(key) || key.endsWith('Enabled')) {
-            return;
-        }
-        if (
-            OMIT_WHEN_EMPTY_FIELDS.has(key) &&
-            (value === '' || value === null || value === undefined)
-        ) {
-            return;
-        }
-        if (value === undefined) {
             return;
         }
 
         let outValue = value;
+
+        // Unchecking an emissions section clears its stored value; the
+        // create flow just omits these, but on edit that would leave
+        // the old value in place (and the checkbox would re-derive as
+        // checked on the next load).
+        const enabledField = ENERGY_VALUE_TO_ENABLED[key];
+        if (enabledField && !formData[enabledField]) {
+            outValue = null;
+        }
+
+        if (
+            NULL_WHEN_EMPTY_FIELDS.has(key) &&
+            (outValue === '' || outValue === undefined)
+        ) {
+            outValue = null;
+        }
+        if (outValue === undefined) {
+            return;
+        }
+
         if (key === 'facilityType') {
-            if (!Array.isArray(value) || value.length === 0) {
-                return;
-            }
-            outValue = value.map(extractSelectValue).join('|');
+            outValue = Array.isArray(outValue)
+                ? outValue.map(extractSelectValue).join('|')
+                : '';
         } else if (SELECT_OPTION_ARRAY_FIELDS.includes(key)) {
-            outValue = (Array.isArray(value) ? value : []).map(
+            outValue = (Array.isArray(outValue) ? outValue : []).map(
                 extractSelectValue,
             );
         }

--- a/src/react/src/reducers/PendingClaimEditReducer.js
+++ b/src/react/src/reducers/PendingClaimEditReducer.js
@@ -1,0 +1,90 @@
+/* eslint-disable camelcase */
+import { createReducer } from 'redux-act';
+import update from 'immutability-helper';
+
+import {
+    startFetchPendingClaim,
+    failFetchPendingClaim,
+    completeFetchPendingClaim,
+    updatePendingClaimFormField,
+    startSavePendingClaim,
+    failSavePendingClaim,
+    completeSavePendingClaim,
+    startDeletePendingClaimAttachment,
+    failDeletePendingClaimAttachment,
+    completeDeletePendingClaimAttachment,
+    resetPendingClaimEdit,
+} from '../actions/pendingClaimEdit';
+
+const initialState = Object.freeze({
+    // The GET /pending/ payload — attachments live here.
+    data: null,
+    fetching: false,
+    error: null,
+    // camelCase form values driving the reused claim-form steps.
+    formData: null,
+    saving: false,
+    savingError: null,
+    deletingAttachment: false,
+});
+
+export default createReducer(
+    {
+        [startFetchPendingClaim]: state =>
+            update(state, {
+                fetching: { $set: true },
+                error: { $set: null },
+            }),
+        [failFetchPendingClaim]: (state, error) =>
+            update(state, {
+                fetching: { $set: false },
+                error: { $set: error },
+            }),
+        [completeFetchPendingClaim]: (state, { data, formData }) =>
+            update(state, {
+                fetching: { $set: false },
+                error: { $set: null },
+                data: { $set: data },
+                formData: { $set: formData },
+            }),
+        [updatePendingClaimFormField]: (state, { field, value }) =>
+            update(state, {
+                formData: { [field]: { $set: value } },
+                savingError: { $set: null },
+            }),
+        [startSavePendingClaim]: state =>
+            update(state, {
+                saving: { $set: true },
+                savingError: { $set: null },
+            }),
+        [failSavePendingClaim]: (state, error) =>
+            update(state, {
+                saving: { $set: false },
+                savingError: { $set: error },
+            }),
+        [completeSavePendingClaim]: (state, { data, formData }) =>
+            update(state, {
+                saving: { $set: false },
+                savingError: { $set: null },
+                data: { $set: data },
+                formData: { $set: formData },
+            }),
+        [startDeletePendingClaimAttachment]: state =>
+            update(state, {
+                deletingAttachment: { $set: true },
+                savingError: { $set: null },
+            }),
+        [failDeletePendingClaimAttachment]: (state, error) =>
+            update(state, {
+                deletingAttachment: { $set: false },
+                savingError: { $set: error },
+            }),
+        [completeDeletePendingClaimAttachment]: (state, { data }) =>
+            update(state, {
+                deletingAttachment: { $set: false },
+                data: { $set: data },
+            }),
+        [resetPendingClaimEdit]: () => initialState,
+    },
+    initialState,
+);

--- a/src/react/src/reducers/PendingClaimEditReducer.js
+++ b/src/react/src/reducers/PendingClaimEditReducer.js
@@ -25,6 +25,8 @@ const initialState = Object.freeze({
     formData: null,
     saving: false,
     savingError: null,
+    // True right after a successful save; drives the outcome dialog.
+    saved: false,
     deletingAttachment: false,
 });
 
@@ -47,6 +49,11 @@ export default createReducer(
                 data: { $set: data },
                 formData: { $set: formData },
             }),
+        // Deliberately does NOT clear `saved`: the reused claim-form
+        // steps dispatch programmatic field updates from effects (e.g.
+        // right after the post-save formik reinitialization), which
+        // would close the outcome dialog in the same frame it opened.
+        // `saved` is cleared when the next save starts, and on reset.
         [updatePendingClaimFormField]: (state, { field, value }) =>
             update(state, {
                 formData: { [field]: { $set: value } },
@@ -56,6 +63,7 @@ export default createReducer(
             update(state, {
                 saving: { $set: true },
                 savingError: { $set: null },
+                saved: { $set: false },
             }),
         [failSavePendingClaim]: (state, error) =>
             update(state, {
@@ -66,6 +74,7 @@ export default createReducer(
             update(state, {
                 saving: { $set: false },
                 savingError: { $set: null },
+                saved: { $set: true },
                 data: { $set: data },
                 formData: { $set: formData },
             }),

--- a/src/react/src/reducers/index.js
+++ b/src/react/src/reducers/index.js
@@ -21,6 +21,7 @@ import ClaimFacilityReducer from './ClaimFacilityReducer';
 import ClaimFacilityDashboardReducer from './ClaimFacilityDashboardReducer';
 import ClaimedFacilityDetailsReducer from './ClaimedFacilityDetailsReducer';
 import ClaimedFacilitesReducer from './ClaimedFacilitesReducer';
+import PendingClaimEditReducer from './PendingClaimEditReducer';
 import DashboardListsReducer from './DashboardListsReducer';
 import DashboardApiBlocksReducer from './DashboardApiBlocksReducer';
 import DashboardActivityReportsReducer from './DashboardActivityReportsReducer';
@@ -58,6 +59,7 @@ export default combineReducers({
     claimFacilityDashboard: ClaimFacilityDashboardReducer,
     claimedFacilityDetails: ClaimedFacilityDetailsReducer,
     claimedFacilities: ClaimedFacilitesReducer,
+    pendingClaimEdit: PendingClaimEditReducer,
     dashboardLists: DashboardListsReducer,
     dashboardApiBlocks: DashboardApiBlocksReducer,
     dashboardActivityReports: DashboardActivityReportsReducer,

--- a/src/react/src/util/constants.jsx
+++ b/src/react/src/util/constants.jsx
@@ -330,6 +330,12 @@ export const profileFormFields = Object.freeze([
     accountConfirmNewPasswordField,
 ]);
 
+// OSDEV-2280 PII warning shown above every claim document upload.
+export const CLAIM_PII_WARNING_TEXT =
+    'We do NOT require and you should NOT submit documents containing ' +
+    'sensitive personal information such as salary information, personal ' +
+    'phone numbers, home addresses, or personal ID numbers.';
+
 export const mainRoute = '/';
 export const mapRoute = '/map';
 export const settingsRoute = '/settings';
@@ -372,6 +378,9 @@ export const dashboardActivityReportsRoute = '/dashboard/activityreports';
 export const dashboardLinkOsIdRoute = '/dashboard/linkid';
 export const dashboardGeocoderRoute = '/dashboard/geocoder';
 export const claimedFacilitiesRoute = '/claimed';
+// Registered before claimedFacilitiesDetailRoute so 'pending' is never
+// captured as a :claimID.
+export const pendingClaimEditRoute = '/claimed/pending/:claimID';
 export const claimedFacilitiesDetailRoute = '/claimed/:claimID';
 export const dashboardClaimsDetailsRoute = '/dashboard/claims/:claimID';
 export const aboutClaimedFacilitiesRoute = `${InfoLink}/${InfoPaths.claimedFacilities}`;

--- a/src/react/src/util/util.facilityClaimsXLSX.js
+++ b/src/react/src/util/util.facilityClaimsXLSX.js
@@ -10,6 +10,7 @@ const xlsxHeaders = Object.freeze([
     'Claim Decision',
     'Status',
     'Last Updated',
+    'Updated by Claimant',
 ]);
 
 const formatFacilityClaimsDataForXLSX = facilityClaims =>
@@ -25,6 +26,12 @@ const formatFacilityClaimsDataForXLSX = facilityClaims =>
                 : EMPTY_PLACEHOLDER,
             facilityClaim.status,
             formatDate(facilityClaim.updated_at, DATE_FORMATS.LONG),
+            facilityClaim.claimant_updated_at !== null
+                ? formatDate(
+                      facilityClaim.claimant_updated_at,
+                      DATE_FORMATS.LONG,
+                  )
+                : EMPTY_PLACEHOLDER,
         ]),
     );
 

--- a/src/react/src/util/util.js
+++ b/src/react/src/util/util.js
@@ -301,6 +301,12 @@ export const makeGetFacilityClaimByClaimIDURL = claimID =>
 // URLs (OSDEV-3370).
 export const makeFacilityClaimAttachmentDownloadURL = (claimID, attachmentID) =>
     `/api/facility-claims/${claimID}/attachments/${attachmentID}/download/`;
+export const makePendingClaimURL = claimID =>
+    `/api/facility-claims/${claimID}/pending/`;
+export const makePendingClaimAttachmentsURL = claimID =>
+    `/api/facility-claims/${claimID}/attachments/`;
+export const makePendingClaimAttachmentURL = (claimID, attachmentID) =>
+    `/api/facility-claims/${claimID}/attachments/${attachmentID}/`;
 export const makeMessageFacilityClaimantByClaimIDURL = claimID =>
     `/api/facility-claims/${claimID}/message-claimant/`;
 export const makeApproveFacilityClaimByClaimIDURL = claimID =>
@@ -314,8 +320,13 @@ export const makeAddNewFacilityClaimReviewNoteURL = claimID =>
 
 export const makeGetOrUpdateApprovedFacilityClaimURL = claimID =>
     `/api/facility-claims/${claimID}/claimed/`;
-export const makeGetClaimedFacilitiesURL = () => '/api/facilities/claimed/';
+export const makeGetClaimedFacilitiesURL = statuses =>
+    statuses && statuses.length > 0
+        ? `/api/facilities/claimed/?statuses=${statuses.join(',')}`
+        : '/api/facilities/claimed/';
 export const makeClaimedFacilityDetailsLink = claimID => `/claimed/${claimID}/`;
+export const makePendingClaimEditLink = claimID =>
+    `/claimed/pending/${claimID}`;
 
 export const makeLogDownloadUrl = (path, recordCount) =>
     `/api/log-download/?path=${encodeURIComponent(


### PR DESCRIPTION
## Jira Ticket

[OSDEV-2278](https://opensupplyhub.atlassian.net/browse/OSDEV-2278) — subtasks [OSDEV-3370](https://opensupplyhub.atlassian.net/browse/OSDEV-3370) (Platform API) and [OSDEV-3371](https://opensupplyhub.atlassian.net/browse/OSDEV-3371) (UX + notification)

---

## Summary of Changes

Lets claimants view and edit their own PENDING claims from My Account → My Facilities — replacing the email-based document exchange that raised the PII/SOC 2 concern behind OSDEV-2278. Two commits, one per subtask.

**API (OSDEV-3370).** Claim attachments were exposed as raw presigned S3 URLs: 1-hour, shareable bearer tokens signed by the app role that can read the whole bucket — tolerable for superusers only, unsafe once every claimant gets URLs. The access model therefore changes with the feature:

- `GET/PATCH /api/facility-claims/{id}/pending/` — claimant view/edit of their own PENDING claim. Guard: owning contributor + PENDING; everything else 404s (no claim-id existence leak). `EditPendingClaimSerializer` derives from `FacilityCreateClaimSerializer` so create and edit share one set of validation rules.
- `POST/DELETE .../attachments/` — attachment management on pending claims. The 20-file cap now applies across the claim's lifetime (was per-request); validation adds magic-byte content checks on both create and edit paths (a "pdf" that is actually HTML is rejected).
- `GET .../attachments/{id}/download/` — authorization-checked download (owning claimant or superuser): 302 to a 60-second, single-object presigned URL minted by a new dedicated IAM signing role. Raw `claim_attachment` URLs removed from every API payload; the moderator dashboard uses this endpoint too.
- New uploads get opaque UUID object keys under `claim_attachments/` (the old key format embedded the contributor name, leaking PII into access logs); the display filename stays in the DB.
- **Root cause fix:** `FacilityClaimAttachments.claim` was `on_delete=PROTECT` while facility deletion calls `claim.delete()` — any claim with attachments raised `ProtectedError` and aborted the whole deletion. Migration 0234 moves it to CASCADE with a `post_delete` signal removing the stored file.
- Terraform: signing role + assume-role wiring, `s3:signatureAge` ≤ 15 min deny on the files bucket (caps any presigned URL's usable life at the policy layer), `AWS_QUERYSTRING_EXPIRE=300` for remaining django-storages URLs.

**UX + notification (OSDEV-3371).**

- My Facilities (`/claimed`) now requests `?statuses=PENDING,APPROVED` (endpoint default stays approved-only for other consumers), shows a status chip per row, and forks the row click: pending → new `/claimed/pending/{id}` edit view; approved → existing profile editor, unchanged.
- `PendingClaimEdit` reuses the v1 claim flow's step components (`ContactInfoStep`, `BusinessStep`, `ProfileStep`) on a single page — fields, Yup validation, and the OSDEV-2280 PII warning are the create flow's own components, not copies. Own Redux slice + Formik; the API↔form field mapping lives in one file (`PendingClaimEdit/utils.js`). Uploaded documents render in a manager section (download via the new endpoint, delete with confirmation); newly picked files upload on Save, then field edits go as a JSON PATCH.
- The OSDEV-2280 warning copy is lifted into `CLAIM_PII_WARNING_TEXT` and shared by both claim-flow steps and the edit view (it was duplicated inline).
- `claim_updated_by_claimant` email to `NOTIFICATION_EMAIL_TO` on every claimant save: changed field names, document add/remove by filename, and a dashboard link — never a document or a URL to one.
- New `FacilityClaim.claimant_updated_at` (migration 0235), stamped **only** by claimant edits — moderator actions bump `updated_at` but not this — feeding a sortable "Updated by Claimant" column in the claims queue and its XLSX export, so claims edited after review starts don't hide in the "already reviewed" pile.

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Backend change (API, database, business logic)
- [x] UI / frontend change
- [ ] Architectural change (affects structure, contracts, or shared modules)
- [ ] Refactor (no functional change)
- [x] Breaking change (existing functionality may not work as before)
- [ ] Documentation / tooling only

**Breaking change detail:** claim API payloads no longer carry `claim_attachment` (raw storage URL). The `automated-claims` Lambda consumes exactly that field via `requests.get(presigned_url)`, so it must move to direct S3 reads via IAM **before or together with** this deploy, or attachment processing breaks. Additionally, any presigned URL older than 15 minutes now dies at the bucket policy — stale dashboard-tab links need a page refresh.

---

## Testing

- `api/tests/test_pending_claim_edit.py` — 28 tests, all passing:
  - Guard matrix: owner/stranger/anonymous/superuser × pending/approved/denied/revoked, asserting 404 (not 403) for non-owners; PATCH cannot change `status`.
  - Partial-update semantics; URL validation; lifetime 20-file cap (19+2 rejected, 19+1 accepted); magic-byte rejection (HTML-as-pdf); extension allowlist; opaque storage keys (original filename never in the key).
  - Download endpoint: 302 for owner and superuser, 404 stranger, 401 anonymous; moderator claim-details payload contains no storage URLs.
  - Claim deletion with attachments succeeds (previously `ProtectedError`).
  - OSDEV-3371: PATCH stamps `claimant_updated_at` + sends the notification (subject/body/dashboard link asserted, zero attachments); no-op saves send nothing and stamp nothing; attachment add stamps + notifies; `?statuses=` default/param/invalid-400 behavior; `claimant_updated_at` present in the list payload.
- Regression: `test_facility_claim`, `test_facility_claim_serializer`, `test_facility_claim_changes`, `test_facility_create_claim_serializer`, `test_facility_delete` — 43 tests passing.
- `makemigrations --check`: migrations 0234/0235 fully cover the model changes.
- flake8 clean on all touched Python; prettier 2.0.2 (repo-pinned) clean on all touched frontend files.
- Not verified in the build environment: the STS signing path against real AWS (falls back to default storage URLs when `CLAIM_ATTACHMENTS_SIGNING_ROLE_ARN` is unset, so MinIO local dev is unaffected) — verify on Development after Terraform applies. Frontend `yarn test`/ESLint and a manual pass of the edit view run locally/CI — screenshots to be attached.

---

## Known TODO Items

- **`automated-claims` (blocking dependency, in OSDEV-2278 backlog):** read attachments directly via IAM instead of API presigned URLs; treat `updated_at > processed_at` as "reprocess" in the DynamoDB idempotency check (an edited claim is currently skipped — or was already auto-processed on stale evidence); clean up its S3/GCS copies when the platform disposes of documents.
- A save touching both fields and files sends two notification emails (one per backend action); revisit cadence if the Claims team finds it noisy.
- Legacy attachments remain at the bucket root; after migrating them under `claim_attachments/`, tighten the signer role's `s3:GetObject` to the prefix (noted in `iam.tf`).
- Retention/disposal of attachments after claim decision — next subtask under OSDEV-2278.
- The first render of the v1 claim-flow step components outside the stepper; visual QA notes welcome.

---

## Checklist

### Implementation

- [x] My code follows the project's style guidelines and naming conventions.
- [x] I have removed debug logs, commented-out code, and unused imports.
- [ ] Any AI-assisted code (e.g., Claude) has been reviewed, understood, and adapted to fit our codebase.
- [x] I have considered backward compatibility and migrations where applicable.
- [x] The diff contains no secrets, internal document/spreadsheet/folder IDs, internal board or channel identifiers, internal policy thresholds, or staff contact details — internal values are externalized to runtime configuration (see "Public repository hygiene" in AGENTS.md).

### Testing & Validation

- [ ] I have manually tested the change in a local/dev environment.
- [x] I have added or updated unit tests for the new/changed behavior.
- [ ] All existing tests pass locally.
- [ ] For UI changes: I have included screenshots or a recording, and verified responsive/cross-browser behavior.
- [x] For backend changes: I have validated API contracts, error handling, and edge cases.
- [ ] For architectural changes: I have documented the design decision and notified affected teams.

### Documentation & Communication

- [ ] I have updated relevant documentation (README, ADRs, inline comments, API docs).
- [x] I have updated the Jira ticket status and added any relevant notes.

### Final Review

- [ ] I have performed a self-review on my PR and I am presenting my best work for my peers to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UmS2eMwSzmN4wjFFGFGVp

[OSDEV-2278]: https://opensupplyhub.atlassian.net/browse/OSDEV-2278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OSDEV-3370]: https://opensupplyhub.atlassian.net/browse/OSDEV-3370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OSDEV-3371]: https://opensupplyhub.atlassian.net/browse/OSDEV-3371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ